### PR TITLE
Make DisconnectMessage reason optional

### DIFF
--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/protocol/IbftProtocolManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/protocol/IbftProtocolManager.java
@@ -24,6 +24,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,7 +91,7 @@ public class IbftProtocolManager implements ProtocolManager {
   @Override
   public void handleDisconnect(
       final PeerConnection peerConnection,
-      final DisconnectReason disconnectReason,
+      final Optional<DisconnectReason> disconnectReason,
       final boolean initiatedByPeer) {
     peers.peerRemoved(peerConnection);
   }

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthProtocolManager.java
@@ -200,19 +200,20 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
   @Override
   public void handleDisconnect(
       final PeerConnection connection,
-      final DisconnectReason reason,
+      final Optional<DisconnectReason> reason,
       final boolean initiatedByPeer) {
     ethPeers.registerDisconnect(connection);
+    String reasonDescription = reason.map(DisconnectReason::toString).orElse("none");
     if (initiatedByPeer) {
       LOG.debug(
-          "Peer requested to be disconnected ({}), {} peers left: {}",
-          reason,
+          "Peer requested to be disconnected (reason: {}), {} peers left: {}",
+          reasonDescription,
           ethPeers.peerCount(),
           ethPeers);
     } else {
       LOG.debug(
-          "Disconnecting from peer ({}), {} peers left: {}",
-          reason,
+          "Disconnecting from peer (reason: {}), {} peers left: {}",
+          reasonDescription,
           ethPeers.peerCount(),
           ethPeers);
     }

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
@@ -82,6 +82,11 @@ class MockPeerConnection implements PeerConnection {
   }
 
   @Override
+  public void disconnect() {
+    disconnected = true;
+  }
+
+  @Override
   public SocketAddress getLocalAddress() {
     throw new UnsupportedOperationException();
   }

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
@@ -21,6 +21,7 @@ import tech.pegasys.pantheon.util.bytes.Bytes32;
 
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -70,8 +71,9 @@ class MockPeerConnection implements PeerConnection {
   }
 
   @Override
-  public void terminateConnection(final DisconnectReason reason, final boolean peerInitiated) {
-    disconnect(reason);
+  public void terminateConnection(
+      final Optional<DisconnectReason> reason, final boolean peerInitiated) {
+    disconnect(reason.orElse(null));
   }
 
   @Override

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/DownloaderTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/DownloaderTest.java
@@ -530,7 +530,7 @@ public class DownloaderTest {
 
     // Disconnect peer
     ethProtocolManager.handleDisconnect(
-        bestPeer.getPeerConnection(), DisconnectReason.TOO_MANY_PEERS, true);
+        bestPeer.getPeerConnection(), Optional.of(DisconnectReason.TOO_MANY_PEERS), true);
 
     // Downloader should recover and sync to next best peer
     await()

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNode.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 
@@ -67,7 +68,7 @@ public class TestNode implements Closeable {
   protected final SECP256K1.KeyPair kp;
   protected final P2PNetwork network;
   protected final Peer selfPeer;
-  protected final Map<PeerConnection, DisconnectReason> disconnections = new HashMap<>();
+  protected final Map<PeerConnection, Optional<DisconnectReason>> disconnections = new HashMap<>();
   private final TransactionPool transactionPool;
 
   public TestNode(

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNodeList.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNodeList.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -218,7 +219,7 @@ public class TestNodeList implements Closeable {
     int errCnt = 0;
     final StringBuilder sb = new StringBuilder();
     for (final TestNode node : nodes) {
-      for (final Map.Entry<PeerConnection, DisconnectReason> entry :
+      for (final Map.Entry<PeerConnection, Optional<DisconnectReason>> entry :
           node.disconnections.entrySet()) {
         final PeerConnection peer = entry.getKey();
         final String peerString = peer.getPeer().getNodeId() + "@" + peer.getRemoteAddress();

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNodeList.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNodeList.java
@@ -228,8 +228,8 @@ public class TestNodeList implements Closeable {
                 + node.shortId()
                 + " has received a disconnection from "
                 + peerString
-                + " for "
-                + entry.getValue()
+                + " for reason "
+                + entry.getValue().map(DisconnectReason::toString).orElse("none")
                 + "\n";
         sb.append(unsentTxMsg);
         errCnt++;

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/MockPeerConnection.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/MockPeerConnection.java
@@ -20,6 +20,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Optional;
 import java.util.Set;
 
 public class MockPeerConnection implements PeerConnection {
@@ -57,7 +58,8 @@ public class MockPeerConnection implements PeerConnection {
   }
 
   @Override
-  public void terminateConnection(final DisconnectReason reason, final boolean peerInitiated) {
+  public void terminateConnection(
+      final Optional<DisconnectReason> reason, final boolean peerInitiated) {
     throw new UnsupportedOperationException();
   }
 

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/MockPeerConnection.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/MockPeerConnection.java
@@ -69,6 +69,11 @@ public class MockPeerConnection implements PeerConnection {
   }
 
   @Override
+  public void disconnect() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public SocketAddress getLocalAddress() {
     return localAddress;
   }

--- a/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
@@ -258,6 +258,11 @@ public final class MockNetwork {
     }
 
     @Override
+    public void disconnect() {
+      network.disconnect(this, Optional.empty());
+    }
+
+    @Override
     public SocketAddress getLocalAddress() {
       throw new UnsupportedOperationException();
     }

--- a/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,7 +84,7 @@ public final class MockNetwork {
   }
 
   private void disconnect(
-      final MockNetwork.MockPeerConnection connection, final DisconnectReason reason) {
+      final MockNetwork.MockPeerConnection connection, final Optional<DisconnectReason> reason) {
     synchronized (this) {
       final MockP2PNetwork sourceNode = nodes.get(connection.from);
       final MockP2PNetwork targetNode = nodes.get(connection.to);
@@ -94,7 +95,7 @@ public final class MockNetwork {
       }
       targetNode.disconnectCallbacks.forEach(c -> c.onDisconnect(connection, reason, true));
       sourceNode.disconnectCallbacks.forEach(
-          c -> c.onDisconnect(connection, DisconnectReason.REQUESTED, false));
+          c -> c.onDisconnect(connection, Optional.of(DisconnectReason.REQUESTED), false));
     }
   }
 
@@ -246,13 +247,14 @@ public final class MockNetwork {
     }
 
     @Override
-    public void terminateConnection(final DisconnectReason reason, final boolean peerInitiated) {
+    public void terminateConnection(
+        final Optional<DisconnectReason> reason, final boolean peerInitiated) {
       network.disconnect(this, reason);
     }
 
     @Override
     public void disconnect(final DisconnectReason reason) {
-      network.disconnect(this, reason);
+      network.disconnect(this, Optional.ofNullable(reason));
     }
 
     @Override

--- a/ethereum/mock-p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetworkTest.java
+++ b/ethereum/mock-p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetworkTest.java
@@ -84,15 +84,18 @@ public final class MockNetworkTest {
       Assertions.assertThat(receivedMessageData.getCode()).isEqualTo(code);
 
       // Validate Disconnect Behaviour
-      final CompletableFuture<DisconnectReason> peer1DisconnectFuture = new CompletableFuture<>();
-      final CompletableFuture<DisconnectReason> peer2DisconnectFuture = new CompletableFuture<>();
+      final CompletableFuture<Optional<DisconnectReason>> peer1DisconnectFuture =
+          new CompletableFuture<>();
+      final CompletableFuture<Optional<DisconnectReason>> peer2DisconnectFuture =
+          new CompletableFuture<>();
       network2.subscribeDisconnect(
           (peer, reason, initiatedByPeer) -> peer1DisconnectFuture.complete(reason));
       network1.subscribeDisconnect(
           (peer, reason, initiatedByPeer) -> peer2DisconnectFuture.complete(reason));
       connection.disconnect(DisconnectReason.CLIENT_QUITTING);
-      Assertions.assertThat(peer1DisconnectFuture.get()).isEqualTo(DisconnectReason.REQUESTED);
-      Assertions.assertThat(peer2DisconnectFuture.get())
+      Assertions.assertThat(peer1DisconnectFuture.get().get())
+          .isEqualTo(DisconnectReason.REQUESTED);
+      Assertions.assertThat(peer2DisconnectFuture.get().get())
           .isEqualTo(DisconnectReason.CLIENT_QUITTING);
       Assertions.assertThat(network1.getPeers().stream().filter(isPeerTwo).findFirst())
           .isNotPresent();

--- a/ethereum/mock-p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetworkTest.java
+++ b/ethereum/mock-p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetworkTest.java
@@ -93,10 +93,8 @@ public final class MockNetworkTest {
       network1.subscribeDisconnect(
           (peer, reason, initiatedByPeer) -> peer2DisconnectFuture.complete(reason));
       connection.disconnect(DisconnectReason.CLIENT_QUITTING);
-      Assertions.assertThat(peer1DisconnectFuture.get().get())
-          .isEqualTo(DisconnectReason.REQUESTED);
-      Assertions.assertThat(peer2DisconnectFuture.get().get())
-          .isEqualTo(DisconnectReason.CLIENT_QUITTING);
+      Assertions.assertThat(peer1DisconnectFuture.get()).contains(DisconnectReason.REQUESTED);
+      Assertions.assertThat(peer2DisconnectFuture.get()).contains(DisconnectReason.CLIENT_QUITTING);
       Assertions.assertThat(network1.getPeers().stream().filter(isPeerTwo).findFirst())
           .isNotPresent();
       Assertions.assertThat(network2.getPeers().stream().filter(isPeerOne).findFirst())

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/DisconnectCallback.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/DisconnectCallback.java
@@ -14,7 +14,10 @@ package tech.pegasys.pantheon.ethereum.p2p.api;
 
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
 
+import java.util.Optional;
+
 @FunctionalInterface
 public interface DisconnectCallback {
-  void onDisconnect(PeerConnection connection, DisconnectReason reason, boolean initiatedByPeer);
+  void onDisconnect(
+      PeerConnection connection, Optional<DisconnectReason> reason, boolean initiatedByPeer);
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
@@ -90,9 +90,8 @@ public interface PeerConnection {
    */
   void disconnect(DisconnectReason reason);
 
-  default void disconnect() {
-    disconnect(null);
-  }
+  /** Disconnect from this Peer. */
+  void disconnect();
 
   SocketAddress getLocalAddress();
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
@@ -18,6 +18,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Optional;
 import java.util.Set;
 
 /** A P2P connection to another node. */
@@ -76,7 +77,11 @@ public interface PeerConnection {
    * @param reason the reason for disconnection
    * @param peerInitiated <code>true</code> if and only if the remote peer requested disconnection
    */
-  void terminateConnection(DisconnectReason reason, boolean peerInitiated);
+  void terminateConnection(Optional<DisconnectReason> reason, boolean peerInitiated);
+
+  default void terminateConnection(final DisconnectReason reason, final boolean peerInitiated) {
+    terminateConnection(Optional.ofNullable(reason), peerInitiated);
+  }
 
   /**
    * Disconnect from this Peer.
@@ -84,6 +89,10 @@ public interface PeerConnection {
    * @param reason Reason for disconnecting
    */
   void disconnect(DisconnectReason reason);
+
+  default void disconnect() {
+    disconnect(null);
+  }
 
   SocketAddress getLocalAddress();
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/ProtocolManager.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/ProtocolManager.java
@@ -17,6 +17,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.Capability;
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
 
 import java.util.List;
+import java.util.Optional;
 
 /** Represents an object responsible for managing a wire subprotocol. */
 public interface ProtocolManager extends AutoCloseable, PeerRequirement {
@@ -61,10 +62,11 @@ public interface ProtocolManager extends AutoCloseable, PeerRequirement {
    * @param peerConnection the connection that is being closed
    * @param disconnectReason the reason given for closing the connection
    * @param initiatedByPeer true if the peer requested to disconnect, false if this node requested
-   *     the disconnect
    */
   void handleDisconnect(
-      PeerConnection peerConnection, DisconnectReason disconnectReason, boolean initiatedByPeer);
+      PeerConnection peerConnection,
+      Optional<DisconnectReason> disconnectReason,
+      boolean initiatedByPeer);
 
   @Override
   default void close() {

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -33,7 +33,7 @@ import tech.pegasys.pantheon.ethereum.p2p.discovery.internal.PeerTable;
 import tech.pegasys.pantheon.ethereum.p2p.discovery.internal.PingPacketData;
 import tech.pegasys.pantheon.ethereum.p2p.peers.DefaultPeerId;
 import tech.pegasys.pantheon.ethereum.p2p.peers.PeerBlacklist;
-import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage;
+import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
 import tech.pegasys.pantheon.util.NetworkUtility;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
@@ -44,6 +44,7 @@ import java.net.SocketException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -401,7 +402,7 @@ public class PeerDiscoveryAgent implements DisconnectCallback {
   @Override
   public void onDisconnect(
       final PeerConnection connection,
-      final DisconnectMessage.DisconnectReason reason,
+      final Optional<DisconnectReason> reason,
       final boolean initiatedByPeer) {
     final BytesValue nodeId = connection.getPeer().getNodeId();
     peerTable.evict(new DefaultPeerId(nodeId));

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/ApiHandler.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/ApiHandler.java
@@ -19,8 +19,8 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage;
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.PongMessage;
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.WireMessageCodes;
-import tech.pegasys.pantheon.ethereum.rlp.RLPException;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -74,23 +74,11 @@ final class ApiHandler extends SimpleChannelInboundHandler<MessageData> {
           break;
         case WireMessageCodes.DISCONNECT:
           final DisconnectMessage disconnect = DisconnectMessage.readFrom(message);
-          DisconnectReason reason = null;
-          try {
-            reason = disconnect.getReason();
-            LOG.debug(
-                "Received Wire DISCONNECT ({}) from peer: {}",
-                reason.name(),
-                connection.getPeer().getClientId());
-          } catch (final RLPException e) {
-            LOG.debug(
-                "Received Wire DISCONNECT with invalid RLP. Peer: {}",
-                connection.getPeer().getClientId());
-          } catch (final Exception e) {
-            LOG.error(
-                "Received Wire DISCONNECT, but unable to parse reason. Peer: {}",
-                connection.getPeer().getClientId(),
-                e);
-          }
+          Optional<DisconnectReason> reason = disconnect.getReason();
+          LOG.debug(
+              "Received Wire DISCONNECT (reason: {}) from peer: {}",
+              reason.map(DisconnectReason::toString).orElse("none"),
+              connection.getPeer().getClientId());
           connection.terminateConnection(reason, true);
       }
       return;

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/Callbacks.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/Callbacks.java
@@ -22,6 +22,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 import tech.pegasys.pantheon.util.Subscribers;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
@@ -44,10 +45,18 @@ public class Callbacks {
 
   public void invokeDisconnect(
       final PeerConnection connection,
-      final DisconnectReason reason,
+      final Optional<DisconnectReason> reason,
       final boolean initatedByPeer) {
     disconnectCallbacks.forEach(
         consumer -> consumer.onDisconnect(connection, reason, initatedByPeer));
+  }
+
+  public void invokeDisconnect(
+      final PeerConnection connection,
+      final DisconnectReason reason,
+      final boolean initatedByPeer) {
+    disconnectCallbacks.forEach(
+        consumer -> consumer.onDisconnect(connection, Optional.ofNullable(reason), initatedByPeer));
   }
 
   public void invokeSubProtocol(

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
@@ -241,7 +241,7 @@ public final class NettyP2PNetwork implements P2PNetwork {
               }
               // Reject incoming connections that are blacklisted
               if (peerBlacklist.contains(connection)) {
-                connection.disconnect(DisconnectReason.USELESS_PEER);
+                connection.disconnect();
                 return;
               }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
@@ -26,6 +26,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -104,7 +105,8 @@ final class NettyPeerConnection implements PeerConnection {
   }
 
   @Override
-  public void terminateConnection(final DisconnectReason reason, final boolean peerInitiated) {
+  public void terminateConnection(
+      final Optional<DisconnectReason> reason, final boolean peerInitiated) {
     if (disconnectDispatched.compareAndSet(false, true)) {
       LOG.debug("Disconnected ({}) from {}", reason, peerInfo);
       callbacks.invokeDisconnect(this, reason, peerInitiated);

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
@@ -118,9 +118,19 @@ final class NettyPeerConnection implements PeerConnection {
   }
 
   @Override
-  public void disconnect(final DisconnectReason reason) {
+  public void disconnect(DisconnectReason reason) {
+    disconnect(Optional.ofNullable(reason));
+  }
+
+  @Override
+  public void disconnect() {
+    disconnect(Optional.empty());
+  }
+
+  private void disconnect(final Optional<DisconnectReason> reason) {
     if (disconnectDispatched.compareAndSet(false, true)) {
-      LOG.debug("Disconnecting ({}) from {}", reason, peerInfo);
+      String reasonDescription = reason.map(DisconnectReason::toString).orElse("none");
+      LOG.debug("Disconnecting (reason: {}) from {}", reasonDescription, peerInfo);
       callbacks.invokeDisconnect(this, reason, false);
       try {
         send(null, DisconnectMessage.create(reason));

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistry.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistry.java
@@ -75,7 +75,8 @@ public class PeerConnectionRegistry implements DisconnectCallback {
       final PeerConnection connection,
       final Optional<DisconnectReason> reason,
       final boolean initiatedByPeer) {
+    String reasonDescription = reason.map(DisconnectReason::name).orElse("NONE");
     connections.remove(connection.getPeer().getNodeId());
-    disconnectCounter.labels(initiatedByPeer ? "remote" : "local", reason.name()).inc();
+    disconnectCounter.labels(initiatedByPeer ? "remote" : "local", reasonDescription).inc();
   }
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistry.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistry.java
@@ -24,6 +24,7 @@ import tech.pegasys.pantheon.metrics.MetricsSystem;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -72,7 +73,7 @@ public class PeerConnectionRegistry implements DisconnectCallback {
   @Override
   public void onDisconnect(
       final PeerConnection connection,
-      final DisconnectReason reason,
+      final Optional<DisconnectReason> reason,
       final boolean initiatedByPeer) {
     connections.remove(connection.getPeer().getNodeId());
     disconnectCounter.labels(initiatedByPeer ? "remote" : "local", reason.name()).inc();

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklist.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklist.java
@@ -14,13 +14,13 @@ package tech.pegasys.pantheon.ethereum.p2p.peers;
 
 import tech.pegasys.pantheon.ethereum.p2p.api.DisconnectCallback;
 import tech.pegasys.pantheon.ethereum.p2p.api.PeerConnection;
-import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage;
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -102,7 +102,7 @@ public class PeerBlacklist implements DisconnectCallback {
   @Override
   public void onDisconnect(
       final PeerConnection connection,
-      final DisconnectReason reason,
+      final Optional<DisconnectReason> reason,
       final boolean initiatedByPeer) {
     if (shouldBlacklistForDisconnect(reason, initiatedByPeer)) {
       add(connection.getPeer().getNodeId());
@@ -110,7 +110,11 @@ public class PeerBlacklist implements DisconnectCallback {
   }
 
   private boolean shouldBlacklistForDisconnect(
-      final DisconnectMessage.DisconnectReason reason, final boolean initiatedByPeer) {
+      final Optional<DisconnectReason> maybeReason, final boolean initiatedByPeer) {
+    if (!maybeReason.isPresent()) {
+      return false;
+    }
+    DisconnectReason reason = maybeReason.get();
     return (!initiatedByPeer && locallyTriggeredBlacklistReasons.contains(reason))
         || (initiatedByPeer && remotelyTriggeredBlacklistReasons.contains(reason));
   }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessage.java
@@ -41,6 +41,14 @@ public final class DisconnectMessage extends AbstractMessageData {
     return new DisconnectMessage(out.encoded());
   }
 
+  public static DisconnectMessage create() {
+    final Data data = new Data();
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    data.writeTo(out);
+
+    return new DisconnectMessage(out.encoded());
+  }
+
   public static DisconnectMessage readFrom(final MessageData message) {
     if (message instanceof DisconnectMessage) {
       return (DisconnectMessage) message;
@@ -72,6 +80,10 @@ public final class DisconnectMessage extends AbstractMessageData {
 
     public Data(final DisconnectReason reason) {
       this.reason = Optional.ofNullable(reason);
+    }
+
+    public Data() {
+      this.reason = Optional.empty();
     }
 
     public void writeTo(final RLPOutput out) {

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessage.java
@@ -165,7 +165,7 @@ public final class DisconnectMessage extends AbstractMessageData {
 
     @Override
     public String toString() {
-      return name() + " ( " + code + ")";
+      return name() + " (" + code + ")";
     }
   }
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessage.java
@@ -34,15 +34,15 @@ public final class DisconnectMessage extends AbstractMessageData {
   }
 
   public static DisconnectMessage create(final DisconnectReason reason) {
-    final Data data = new Data(reason);
-    final BytesValueRLPOutput out = new BytesValueRLPOutput();
-    data.writeTo(out);
-
-    return new DisconnectMessage(out.encoded());
+    return create(Optional.ofNullable(reason));
   }
 
   public static DisconnectMessage create() {
-    final Data data = new Data();
+    return create(Optional.empty());
+  }
+
+  public static DisconnectMessage create(final Optional<DisconnectReason> reason) {
+    final Data data = new Data(reason);
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     data.writeTo(out);
 
@@ -78,12 +78,12 @@ public final class DisconnectMessage extends AbstractMessageData {
   public static class Data {
     private final Optional<DisconnectReason> reason;
 
-    public Data(final DisconnectReason reason) {
-      this.reason = Optional.ofNullable(reason);
+    Data(final DisconnectReason reason) {
+      this(Optional.ofNullable(reason));
     }
 
-    public Data() {
-      this.reason = Optional.empty();
+    Data(Optional<DisconnectReason> reason) {
+      this.reason = reason;
     }
 
     public void writeTo(final RLPOutput out) {

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
@@ -41,6 +41,7 @@ import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -237,7 +238,7 @@ public final class NettyP2PNetworkTest {
 
       // Setup second connection and check that connection is not accepted
       final CompletableFuture<PeerConnection> peerFuture = new CompletableFuture<>();
-      final CompletableFuture<DisconnectReason> reasonFuture = new CompletableFuture<>();
+      final CompletableFuture<Optional<DisconnectReason>> reasonFuture = new CompletableFuture<>();
       connector2.subscribeDisconnect(
           (peerConnection, reason, initiatedByPeer) -> {
             peerFuture.complete(peerConnection);
@@ -247,7 +248,7 @@ public final class NettyP2PNetworkTest {
       assertThat(connector2.connect(listeningPeer).get(30L, TimeUnit.SECONDS).getPeer().getNodeId())
           .isEqualTo(listenId);
       assertThat(peerFuture.get(30L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(listenId);
-      assertThat(reasonFuture.get(30L, TimeUnit.SECONDS))
+      assertThat(reasonFuture.get(30L, TimeUnit.SECONDS).get())
           .isEqualByComparingTo(DisconnectReason.TOO_MANY_PEERS);
     }
   }
@@ -364,7 +365,7 @@ public final class NettyP2PNetworkTest {
 
       // Setup disconnect listener
       final CompletableFuture<PeerConnection> peerFuture = new CompletableFuture<>();
-      final CompletableFuture<DisconnectReason> reasonFuture = new CompletableFuture<>();
+      final CompletableFuture<Optional<DisconnectReason>> reasonFuture = new CompletableFuture<>();
       remoteNetwork.subscribeDisconnect(
           (peerConnection, reason, initiatedByPeer) -> {
             peerFuture.complete(peerConnection);
@@ -377,7 +378,7 @@ public final class NettyP2PNetworkTest {
       // Check connection is made, and then a disconnect is registered at remote
       assertThat(connectFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
       assertThat(peerFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
-      assertThat(reasonFuture.get(5L, TimeUnit.SECONDS))
+      assertThat(reasonFuture.get(5L, TimeUnit.SECONDS).get())
           .isEqualByComparingTo(DisconnectReason.USELESS_PEER);
     }
   }

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
@@ -248,8 +248,7 @@ public final class NettyP2PNetworkTest {
       assertThat(connector2.connect(listeningPeer).get(30L, TimeUnit.SECONDS).getPeer().getNodeId())
           .isEqualTo(listenId);
       assertThat(peerFuture.get(30L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(listenId);
-      assertThat(reasonFuture.get(30L, TimeUnit.SECONDS).get())
-          .isEqualByComparingTo(DisconnectReason.TOO_MANY_PEERS);
+      assertThat(reasonFuture.get(30L, TimeUnit.SECONDS)).contains(DisconnectReason.TOO_MANY_PEERS);
     }
   }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
@@ -378,8 +378,7 @@ public final class NettyP2PNetworkTest {
       // Check connection is made, and then a disconnect is registered at remote
       assertThat(connectFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
       assertThat(peerFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
-      assertThat(reasonFuture.get(5L, TimeUnit.SECONDS).get())
-          .isEqualByComparingTo(DisconnectReason.USELESS_PEER);
+      assertThat(reasonFuture.get(5L, TimeUnit.SECONDS)).isNotPresent();
     }
   }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -35,6 +35,7 @@ import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -157,7 +158,7 @@ public class PeerDiscoveryAgentTest extends AbstractPeerDiscoveryTest {
     assertThat(peerDiscoveryAgent2.getPeers().size()).isEqualTo(1);
 
     final PeerConnection peerConnection = createAnonymousPeerConnection(peer.getId());
-    peerDiscoveryAgent2.onDisconnect(peerConnection, DisconnectReason.REQUESTED, true);
+    peerDiscoveryAgent2.onDisconnect(peerConnection, Optional.of(DisconnectReason.REQUESTED), true);
 
     assertThat(peerDiscoveryAgent2.getPeers().size()).isEqualTo(0);
   }
@@ -176,8 +177,8 @@ public class PeerDiscoveryAgentTest extends AbstractPeerDiscoveryTest {
     assertThat(agent.getPeers()).hasSize(1);
 
     // Disconnect with innocuous reason
-    blacklist.onDisconnect(wirePeer, DisconnectReason.TOO_MANY_PEERS, false);
-    agent.onDisconnect(wirePeer, DisconnectReason.TOO_MANY_PEERS, false);
+    blacklist.onDisconnect(wirePeer, Optional.of(DisconnectReason.TOO_MANY_PEERS), false);
+    agent.onDisconnect(wirePeer, Optional.of(DisconnectReason.TOO_MANY_PEERS), false);
     // Confirm peer was removed
     assertThat(agent.getPeers()).hasSize(0);
 
@@ -202,8 +203,8 @@ public class PeerDiscoveryAgentTest extends AbstractPeerDiscoveryTest {
     assertThat(agent.getPeers()).hasSize(1);
 
     // Disconnect with problematic reason
-    blacklist.onDisconnect(wirePeer, DisconnectReason.BREACH_OF_PROTOCOL, false);
-    agent.onDisconnect(wirePeer, DisconnectReason.BREACH_OF_PROTOCOL, false);
+    blacklist.onDisconnect(wirePeer, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
+    agent.onDisconnect(wirePeer, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
     // Confirm peer was removed
     assertThat(agent.getPeers()).hasSize(0);
 
@@ -228,8 +229,8 @@ public class PeerDiscoveryAgentTest extends AbstractPeerDiscoveryTest {
     assertThat(agent.getPeers()).hasSize(1);
 
     // Disconnect with problematic reason
-    blacklist.onDisconnect(wirePeer, DisconnectReason.BREACH_OF_PROTOCOL, true);
-    agent.onDisconnect(wirePeer, DisconnectReason.BREACH_OF_PROTOCOL, true);
+    blacklist.onDisconnect(wirePeer, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), true);
+    agent.onDisconnect(wirePeer, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), true);
     // Confirm peer was removed
     assertThat(agent.getPeers()).hasSize(0);
 
@@ -254,8 +255,10 @@ public class PeerDiscoveryAgentTest extends AbstractPeerDiscoveryTest {
     assertThat(agent.getPeers()).hasSize(1);
 
     // Disconnect
-    blacklist.onDisconnect(wirePeer, DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION, false);
-    agent.onDisconnect(wirePeer, DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION, false);
+    blacklist.onDisconnect(
+        wirePeer, Optional.of(DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION), false);
+    agent.onDisconnect(
+        wirePeer, Optional.of(DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION), false);
     // Confirm peer was removed
     assertThat(agent.getPeers()).hasSize(0);
 
@@ -280,8 +283,10 @@ public class PeerDiscoveryAgentTest extends AbstractPeerDiscoveryTest {
     assertThat(agent.getPeers()).hasSize(1);
 
     // Disconnect
-    blacklist.onDisconnect(wirePeer, DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION, true);
-    agent.onDisconnect(wirePeer, DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION, true);
+    blacklist.onDisconnect(
+        wirePeer, Optional.of(DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION), true);
+    agent.onDisconnect(
+        wirePeer, Optional.of(DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION), true);
     // Confirm peer was removed
     assertThat(agent.getPeers()).hasSize(0);
 
@@ -329,7 +334,8 @@ public class PeerDiscoveryAgentTest extends AbstractPeerDiscoveryTest {
       }
 
       @Override
-      public void terminateConnection(final DisconnectReason reason, final boolean peerInitiated) {}
+      public void terminateConnection(
+          final Optional<DisconnectReason> reason, final boolean peerInitiated) {}
 
       @Override
       public void disconnect(final DisconnectReason reason) {}

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistryTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistryTest.java
@@ -23,6 +23,8 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 import tech.pegasys.pantheon.metrics.noop.NoOpMetricsSystem;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
+import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,7 +59,7 @@ public class PeerConnectionRegistryTest {
   public void shouldUnregisterConnections() {
     registry.registerConnection(connection1);
     registry.registerConnection(connection2);
-    registry.onDisconnect(connection1, DisconnectReason.TCP_SUBSYSTEM_ERROR, false);
+    registry.onDisconnect(connection1, Optional.of(DisconnectReason.TCP_SUBSYSTEM_ERROR), false);
     assertThat(registry.getPeerConnections()).containsOnly(connection2);
     assertThat(registry.size()).isEqualTo(1);
   }

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklistTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklistTest.java
@@ -22,6 +22,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import org.junit.Test;
 
@@ -100,7 +101,7 @@ public class PeerBlacklistTest {
 
     assertThat(blacklist.contains(peer)).isFalse();
 
-    blacklist.onDisconnect(peer, DisconnectReason.TOO_MANY_PEERS, false);
+    blacklist.onDisconnect(peer, Optional.of(DisconnectReason.TOO_MANY_PEERS), false);
 
     assertThat(blacklist.contains(peer)).isFalse();
   }
@@ -113,7 +114,7 @@ public class PeerBlacklistTest {
 
     assertThat(blacklist.contains(peer)).isFalse();
 
-    blacklist.onDisconnect(peer, DisconnectReason.BREACH_OF_PROTOCOL, false);
+    blacklist.onDisconnect(peer, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
 
     assertThat(blacklist.contains(peer)).isTrue();
   }
@@ -125,7 +126,7 @@ public class PeerBlacklistTest {
 
     assertThat(blacklist.contains(peer)).isFalse();
 
-    blacklist.onDisconnect(peer, DisconnectReason.BREACH_OF_PROTOCOL, true);
+    blacklist.onDisconnect(peer, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), true);
 
     assertThat(blacklist.contains(peer)).isFalse();
   }
@@ -137,7 +138,8 @@ public class PeerBlacklistTest {
 
     assertThat(blacklist.contains(peer)).isFalse();
 
-    blacklist.onDisconnect(peer, DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION, false);
+    blacklist.onDisconnect(
+        peer, Optional.of(DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION), false);
 
     assertThat(blacklist.contains(peer)).isTrue();
   }
@@ -149,7 +151,8 @@ public class PeerBlacklistTest {
 
     assertThat(blacklist.contains(peer)).isFalse();
 
-    blacklist.onDisconnect(peer, DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION, true);
+    blacklist.onDisconnect(
+        peer, Optional.of(DisconnectReason.INCOMPATIBLE_P2P_PROTOCOL_VERSION), true);
 
     assertThat(blacklist.contains(peer)).isTrue();
   }
@@ -163,31 +166,31 @@ public class PeerBlacklistTest {
     final PeerConnection peer3 = generatePeerConnection();
 
     // Add first peer
-    blacklist.onDisconnect(peer1, DisconnectReason.BREACH_OF_PROTOCOL, false);
+    blacklist.onDisconnect(peer1, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
     assertThat(blacklist.contains(peer1)).isTrue();
     assertThat(blacklist.contains(peer2)).isFalse();
     assertThat(blacklist.contains(peer3)).isFalse();
 
     // Add second peer
-    blacklist.onDisconnect(peer2, DisconnectReason.BREACH_OF_PROTOCOL, false);
+    blacklist.onDisconnect(peer2, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
     assertThat(blacklist.contains(peer1)).isTrue();
     assertThat(blacklist.contains(peer2)).isTrue();
     assertThat(blacklist.contains(peer3)).isFalse();
 
     // Adding third peer should kick out least recently accessed peer
-    blacklist.onDisconnect(peer3, DisconnectReason.BREACH_OF_PROTOCOL, false);
+    blacklist.onDisconnect(peer3, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
     assertThat(blacklist.contains(peer1)).isFalse();
     assertThat(blacklist.contains(peer2)).isTrue();
     assertThat(blacklist.contains(peer3)).isTrue();
 
     // Adding peer1 back in should kick out peer2
-    blacklist.onDisconnect(peer1, DisconnectReason.BREACH_OF_PROTOCOL, false);
+    blacklist.onDisconnect(peer1, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
     assertThat(blacklist.contains(peer1)).isTrue();
     assertThat(blacklist.contains(peer2)).isFalse();
     assertThat(blacklist.contains(peer3)).isTrue();
 
     // Adding peer2 back in should kick out peer3
-    blacklist.onDisconnect(peer2, DisconnectReason.BREACH_OF_PROTOCOL, false);
+    blacklist.onDisconnect(peer2, Optional.of(DisconnectReason.BREACH_OF_PROTOCOL), false);
     assertThat(blacklist.contains(peer1)).isTrue();
     assertThat(blacklist.contains(peer2)).isTrue();
     assertThat(blacklist.contains(peer3)).isFalse();

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/wire/DisconnectMessageTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/wire/DisconnectMessageTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.wire;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
+import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage;
+import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
+import tech.pegasys.pantheon.ethereum.p2p.wire.messages.WireMessageCodes;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class DisconnectMessageTest {
+
+  @Test
+  public void readFromWithReason() {
+    MessageData messageData =
+        new RawMessage(WireMessageCodes.DISCONNECT, BytesValue.fromHexString("0xC103"));
+    DisconnectMessage disconnectMessage = DisconnectMessage.readFrom(messageData);
+
+    Optional<DisconnectReason> reason = disconnectMessage.getReason();
+    assertThat(reason).contains(DisconnectReason.USELESS_PEER);
+  }
+
+  @Test
+  public void readFromWithNoReason() {
+    MessageData messageData =
+        new RawMessage(WireMessageCodes.DISCONNECT, BytesValue.fromHexString("0xC180"));
+    DisconnectMessage disconnectMessage = DisconnectMessage.readFrom(messageData);
+
+    Optional<DisconnectReason> reason = disconnectMessage.getReason();
+    assertThat(reason).isNotPresent();
+  }
+
+  @Test
+  public void readFromWithWrongMessageType() {
+    MessageData messageData =
+        new RawMessage(WireMessageCodes.PING, BytesValue.fromHexString("0xC103"));
+    assertThatThrownBy(() -> DisconnectMessage.readFrom(messageData))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Message has code 2 and thus is not a DisconnectMessage");
+  }
+
+  @Test
+  public void createWithReason() {
+    DisconnectMessage disconnectMessage = DisconnectMessage.create(DisconnectReason.USELESS_PEER);
+
+    assertThat(disconnectMessage.getReason()).contains(DisconnectReason.USELESS_PEER);
+    assertThat(disconnectMessage.getData().toString()).isEqualToIgnoringCase("0xC103");
+  }
+
+  @Test
+  public void createWithNoReason() {
+    DisconnectMessage disconnectMessage = DisconnectMessage.create();
+
+    assertThat(disconnectMessage.getReason()).isNotPresent();
+    assertThat(disconnectMessage.getData().toString()).isEqualToIgnoringCase("0xC180");
+  }
+
+  @Test
+  public void createWithNullReason() {
+    DisconnectMessage disconnectMessage = DisconnectMessage.create(null);
+
+    assertThat(disconnectMessage.getReason()).isNotPresent();
+    assertThat(disconnectMessage.getData().toString()).isEqualToIgnoringCase("0xC180");
+  }
+}

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/wire/HelloMessageTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/wire/HelloMessageTest.java
@@ -21,7 +21,7 @@ import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import org.junit.Test;
 
-public class WireMessagesSedesTest {
+public class HelloMessageTest {
 
   @Test
   public void deserializeHello() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
* Update `DisconnectMessage` to hold an optional reason
* Add tests for `DisconnectMessage` construction and parsing
* Send an empty reason when we disconnect from blacklisted peers