### PR TITLE
Add an UNKNOWN DisconnectReason

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/ApiHandler.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/ApiHandler.java
@@ -74,7 +74,7 @@ final class ApiHandler extends SimpleChannelInboundHandler<MessageData> {
           break;
         case WireMessageCodes.DISCONNECT:
           final DisconnectMessage disconnect = DisconnectMessage.readFrom(message);
-          DisconnectReason reason = null;
+          DisconnectReason reason = DisconnectReason.UNKNOWN;
           try {
             reason = disconnect.getReason();
             LOG.debug(

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
@@ -241,7 +241,7 @@ public final class NettyP2PNetwork implements P2PNetwork {
               }
               // Reject incoming connections that are blacklisted
               if (peerBlacklist.contains(connection)) {
-                connection.disconnect(DisconnectReason.USELESS_PEER);
+                connection.disconnect(DisconnectReason.UNKNOWN);
                 return;
               }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NettyP2PNetworkTest.java
@@ -378,7 +378,7 @@ public final class NettyP2PNetworkTest {
       assertThat(connectFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
       assertThat(peerFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
       assertThat(reasonFuture.get(5L, TimeUnit.SECONDS))
-          .isEqualByComparingTo(DisconnectReason.USELESS_PEER);
+          .isEqualByComparingTo(DisconnectReason.UNKNOWN);
     }
   }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessageTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/wire/messages/DisconnectMessageTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.wire.messages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
+import tech.pegasys.pantheon.ethereum.p2p.wire.RawMessage;
+import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import org.junit.Test;
+
+public class DisconnectMessageTest {
+
+  @Test
+  public void readFromWithReason() {
+    MessageData messageData =
+        new RawMessage(WireMessageCodes.DISCONNECT, BytesValue.fromHexString("0xC103"));
+    DisconnectMessage disconnectMessage = DisconnectMessage.readFrom(messageData);
+
+    DisconnectReason reason = disconnectMessage.getReason();
+    assertThat(reason).isEqualTo(DisconnectReason.USELESS_PEER);
+  }
+
+  @Test
+  public void readFromWithNoReason() {
+    MessageData messageData =
+        new RawMessage(WireMessageCodes.DISCONNECT, BytesValue.fromHexString("0xC180"));
+    DisconnectMessage disconnectMessage = DisconnectMessage.readFrom(messageData);
+
+    DisconnectReason reason = disconnectMessage.getReason();
+    assertThat(reason).isEqualTo(DisconnectReason.UNKNOWN);
+  }
+
+  @Test
+  public void readFromWithInvalidReason() {
+    String[] invalidReasons = {
+      "0xC10C",
+      "0xC155",
+      // List containing a byte > 128 (negative valued)
+      "0xC281FF",
+      // List containing a multi-byte reason
+      "0xC3820101"
+    };
+
+    for (String invalidReason : invalidReasons) {
+      MessageData messageData =
+          new RawMessage(WireMessageCodes.DISCONNECT, BytesValue.fromHexString(invalidReason));
+      DisconnectMessage disconnectMessage = DisconnectMessage.readFrom(messageData);
+      DisconnectReason reason = disconnectMessage.getReason();
+      assertThat(reason).isEqualTo(DisconnectReason.UNKNOWN);
+    }
+  }
+
+  @Test
+  public void readFromWithWrongMessageType() {
+    MessageData messageData =
+        new RawMessage(WireMessageCodes.PING, BytesValue.fromHexString("0xC103"));
+    assertThatThrownBy(() -> DisconnectMessage.readFrom(messageData))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Message has code 2 and thus is not a DisconnectMessage");
+  }
+
+  @Test
+  public void createWithReason() {
+    DisconnectMessage disconnectMessage = DisconnectMessage.create(DisconnectReason.USELESS_PEER);
+
+    assertThat(disconnectMessage.getReason()).isEqualTo(DisconnectReason.USELESS_PEER);
+    assertThat(disconnectMessage.getData().toString()).isEqualToIgnoringCase("0xC103");
+  }
+
+  @Test
+  public void createWithUnknownReason() {
+    DisconnectMessage disconnectMessage = DisconnectMessage.create(DisconnectReason.UNKNOWN);
+
+    assertThat(disconnectMessage.getReason()).isEqualTo(DisconnectReason.UNKNOWN);
+    assertThat(disconnectMessage.getData().toString()).isEqualToIgnoringCase("0xC180");
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
As an alternative to https://github.com/PegaSysEng/pantheon/pull/354, this PR handles wire disconnect messages with no explicit reason by adding a new UNKNOWN `DisconnectReason` value.  It also includes the following changes:
* Add tests for parsing and constructing `DisconnectMessage`'s
* Send an empty reason when we disconnect from blacklisted peers
