### PR TITLE
Don't advertise eth63 for regular sync

### DIFF
--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthPeer.java
@@ -25,6 +25,7 @@ import tech.pegasys.pantheon.ethereum.eth.messages.GetReceiptsMessage;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.ethereum.p2p.api.PeerConnection;
 import tech.pegasys.pantheon.ethereum.p2p.api.PeerConnection.PeerNotConnected;
+import tech.pegasys.pantheon.ethereum.p2p.wire.Capability;
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
 import tech.pegasys.pantheon.util.Subscribers;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
@@ -124,6 +125,10 @@ public class EthPeer {
         connection.sendForProtocol(protocolName, messageData);
         return null;
     }
+  }
+
+  public Capability getCapability() {
+    return connection.capability(protocolName);
   }
 
   public ResponseStream getHeadersByHash(

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthProtocolManager.java
@@ -47,8 +47,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
   private static final Logger LOG = LogManager.getLogger();
   private static final List<Capability> FAST_SYNC_CAPS =
       Collections.singletonList(EthProtocol.ETH63);
-  private static final List<Capability> FULL_SYNC_CAPS =
-      Arrays.asList(EthProtocol.ETH62, EthProtocol.ETH63);
+  private static final List<Capability> FULL_SYNC_CAPS = Arrays.asList(EthProtocol.ETH62);
 
   private final EthScheduler scheduler;
   private final CountDownLatch shutdown;

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/EthProtocolManagerTestUtil.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/EthProtocolManagerTestUtil.java
@@ -18,7 +18,6 @@ import tech.pegasys.pantheon.config.GenesisConfigFile;
 import tech.pegasys.pantheon.ethereum.chain.Blockchain;
 import tech.pegasys.pantheon.ethereum.chain.ChainHead;
 import tech.pegasys.pantheon.ethereum.chain.GenesisState;
-import tech.pegasys.pantheon.ethereum.eth.EthProtocol;
 import tech.pegasys.pantheon.ethereum.eth.manager.DeterministicEthScheduler.TimeoutPolicy;
 import tech.pegasys.pantheon.ethereum.mainnet.MainnetProtocolSchedule;
 import tech.pegasys.pantheon.ethereum.mainnet.ProtocolSchedule;
@@ -53,7 +52,7 @@ public class EthProtocolManagerTestUtil {
       final RespondingEthPeer peer,
       final MessageData message) {
     ethProtocolManager.processMessage(
-        EthProtocol.ETH63, new DefaultMessage(peer.getPeerConnection(), message));
+        peer.getCapability(), new DefaultMessage(peer.getPeerConnection(), message));
   }
 
   public static RespondingEthPeer createPeer(

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/RespondingEthPeer.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/RespondingEthPeer.java
@@ -109,7 +109,7 @@ public class RespondingEthPeer {
       final long estimatedHeight) {
     final EthPeers ethPeers = ethProtocolManager.ethContext().getEthPeers();
 
-    final Set<Capability> caps = new HashSet<>(Collections.singletonList(EthProtocol.ETH63));
+    final Set<Capability> caps = new HashSet<>(Collections.singletonList(EthProtocol.ETH62));
     final Queue<OutgoingMessage> outgoingMessages = new ArrayDeque<>();
     final MockPeerConnection peerConnection =
         new MockPeerConnection(
@@ -125,6 +125,10 @@ public class RespondingEthPeer {
 
   public EthPeer getEthPeer() {
     return ethPeer;
+  }
+
+  public Capability getCapability() {
+    return ethPeer.getCapability();
   }
 
   public void respondWhile(final Responder responder, final RespondWhileCondition condition) {

--- a/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
@@ -78,16 +78,11 @@ public final class RunnerTest {
     syncFromGenesis(SyncMode.FULL);
   }
 
-  @Test
-  public void fastSyncFromGenesis() throws Exception {
-    syncFromGenesis(SyncMode.FAST);
-  }
-
   private void syncFromGenesis(final SyncMode mode) throws Exception {
     final Path dbAhead = temp.newFolder().toPath();
     final int blockCount = 500;
     final KeyPair aheadDbNodeKeys = loadKeyPair(dbAhead);
-    final SynchronizerConfiguration fastSyncConfig =
+    final SynchronizerConfiguration syncConfig =
         SynchronizerConfiguration.builder()
             .syncMode(mode)
             // TODO: Disable switch from fast to full sync via configuration for now, set pivot to
@@ -103,7 +98,7 @@ public final class RunnerTest {
             createKeyValueStorageProvider(dbAhead),
             GenesisConfigFile.mainnet(),
             MainnetProtocolSchedule.create(),
-            fastSyncConfig,
+            syncConfig,
             new MiningParametersTestBuilder().enabled(false).build(),
             aheadDbNodeKeys,
             noOpMetricsSystem)) {
@@ -116,7 +111,7 @@ public final class RunnerTest {
             createKeyValueStorageProvider(dbAhead),
             GenesisConfigFile.mainnet(),
             MainnetProtocolSchedule.create(),
-            fastSyncConfig,
+            syncConfig,
             new MiningParametersTestBuilder().enabled(false).build(),
             aheadDbNodeKeys,
             noOpMetricsSystem);
@@ -156,7 +151,7 @@ public final class RunnerTest {
               new InMemoryStorageProvider(),
               GenesisConfigFile.mainnet(),
               MainnetProtocolSchedule.create(),
-              fastSyncConfig,
+              syncConfig,
               new MiningParametersTestBuilder().enabled(false).build(),
               KeyPair.generate(),
               noOpMetricsSystem);


### PR DESCRIPTION
## PR description
We don't fully support eth63 as node data requests are always served with an empty response.  So, just don't advertise eth63 for now.

