### PR TITLE
[NC-2105] Updated --bootnodes CLI option to take zero arguments, to c…

### DIFF
--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -179,7 +179,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
         "Comma separated enode URLs for P2P discovery bootstrap. "
             + "Default is a predefined list.",
     split = ",",
-    arity = "1..*",
+    arity = "0..*",
     converter = EnodeToURIPropertyConverter.class
   )
   private final Collection<URI> bootstrapNodes = null;

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
@@ -489,6 +489,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
     assertThat(commandErrorOutput.toString()).isEmpty();
   }
 
+  @Ignore("NC-2015 - Temporarily enabling zero-arg --bootnodes to permit 'bootnode' configuration")
   @Test
   public void callingWithBootnodesOptionButNoValueMustDisplayErrorAndUsage() {
     parseCommand("--bootnodes");
@@ -499,11 +500,34 @@ public class PantheonCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void callingWithBootnodesOptionButNoValueMustPassEmptyBootnodeList() {
+    parseCommand("--bootnodes");
+
+    verify(mockRunnerBuilder).bootstrapPeers(uriListArgumentCaptor.capture());
+    verify(mockRunnerBuilder).build();
+
+    assertThat(uriListArgumentCaptor.getValue()).isEmpty();
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Ignore(
+      "NC-2015 - Temporarily enabling zero-arg --bootnodes to permit 'bootnode' configuration, which changes the error.")
+  @Test
   public void callingWithInvalidBootnodesMustDisplayErrorAndUsage() {
     parseCommand("--bootnodes", "invalid_enode_url");
     assertThat(commandOutput.toString()).isEmpty();
     final String expectedErrorOutputStart =
         "Invalid value for option '--bootnodes' at index 0 (<enode://id@host:port>)";
+    assertThat(commandErrorOutput.toString()).startsWith(expectedErrorOutputStart);
+  }
+
+  @Test
+  public void callingWithInvalidBootnodesAndZeroArityMustDisplayAlternateErrorAndUsage() {
+    parseCommand("--bootnodes", "invalid_enode_url");
+    assertThat(commandOutput.toString()).isEmpty();
+    final String expectedErrorOutputStart = "Unmatched argument: invalid_enode_url";
     assertThat(commandErrorOutput.toString()).startsWith(expectedErrorOutputStart);
   }
 


### PR DESCRIPTION
…onfigure Pantheon to run in 'bootnode' mode.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Prior to a recent CLI validation improvement, Pantheon was able to be started in 'bootnode' mode by specifying `--bootnodes=""`.  The validator no longer accepts empty string as a value.

To retain the ability to run Pantheon as a bootnode, the `--bootnodes` option has been updated to accept no argument.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
NC-2105