### PR TITLE
Ibft Validator RPCs to return list of strings

### DIFF
--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHash.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHash.java
@@ -23,6 +23,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class IbftGetValidatorsByBlockHash implements JsonRpcMethod {
 
@@ -52,6 +53,14 @@ public class IbftGetValidatorsByBlockHash implements JsonRpcMethod {
   private Object blockResult(final JsonRpcRequest request) {
     final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
     final Optional<BlockHeader> blockHeader = blockchain.getBlockHeader(hash);
-    return blockHeader.map(header -> ibftBlockInterface.validatorsInBlock(header)).orElse(null);
+    return blockHeader
+        .map(
+            header ->
+                ibftBlockInterface
+                    .validatorsInBlock(header)
+                    .stream()
+                    .map(validator -> validator.toString())
+                    .collect(Collectors.toList()))
+        .orElse(null);
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumber.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumber.java
@@ -22,6 +22,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.parameters.JsonRpcParamet
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockchainQueries;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class IbftGetValidatorsByBlockNumber extends AbstractBlockParameterMethod
     implements JsonRpcMethod {
@@ -45,7 +46,15 @@ public class IbftGetValidatorsByBlockNumber extends AbstractBlockParameterMethod
   protected Object resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
     final Optional<BlockHeader> blockHeader =
         blockchainQueries().getBlockHeaderByNumber(blockNumber);
-    return blockHeader.map(header -> ibftBlockInterface.validatorsInBlock(header)).orElse(null);
+    return blockHeader
+        .map(
+            header ->
+                ibftBlockInterface
+                    .validatorsInBlock(header)
+                    .stream()
+                    .map(validator -> validator.toString())
+                    .collect(Collectors.toList()))
+        .orElse(null);
   }
 
   @Override

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHashTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHashTest.java
@@ -63,10 +63,11 @@ public class IbftGetValidatorsByBlockHashTest {
   public void shouldReturnListOfValidatorsFromBlock() {
     when(blockchain.getBlockHeader(Hash.ZERO)).thenReturn(Optional.of(blockHeader));
     final List<Address> addresses = Collections.singletonList(Address.ID);
+    final List<String> expectedOutput = Collections.singletonList(Address.ID.toString());
     when(ibftBlockInterface.validatorsInBlock(blockHeader)).thenReturn(addresses);
     request = requestWithParams(ZERO_HASH);
     JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
-    Assertions.assertThat(response.getResult()).isEqualTo(addresses);
+    Assertions.assertThat(response.getResult()).isEqualTo(expectedOutput);
   }
 
   private JsonRpcRequest requestWithParams(final Object... params) {

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumberTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumberTest.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
@@ -26,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,20 +53,21 @@ public class IbftGetValidatorsByBlockNumberTest {
   public void blockParameterIsParameter0() {
     request = new JsonRpcRequest("?", "ignore", new String[] {"0x1245"});
     BlockParameter blockParameter = method.blockParameter(request);
-    Assertions.assertThat(blockParameter.getNumber().getAsLong()).isEqualTo(0x1245);
+    assertThat(blockParameter.getNumber().getAsLong()).isEqualTo(0x1245);
   }
 
   @Test
   public void nameShouldBeCorrect() {
-    Assertions.assertThat(method.getName()).isEqualTo("ibft_getValidatorsByBlockNumber");
+    assertThat(method.getName()).isEqualTo("ibft_getValidatorsByBlockNumber");
   }
 
   @Test
   public void shouldReturnListOfValidatorsFromBlock() {
     when(blockchainQueries.getBlockHeaderByNumber(12)).thenReturn(Optional.of(blockHeader));
     final List<Address> addresses = Collections.singletonList(Address.ID);
+    final List<String> expectedOutput = Collections.singletonList(Address.ID.toString());
     when(ibftBlockInterface.validatorsInBlock(blockHeader)).thenReturn(addresses);
     Object result = method.resultByBlockNumber(request, 12);
-    Assertions.assertThat(result).isEqualTo(addresses);
+    assertThat(result).isEqualTo(expectedOutput);
   }
 }


### PR DESCRIPTION
The ibftGetValidatorsByBlockNumber and ibftGetValidatorsByBlockHash
both returned a list of Addresses, whichi when translated back into
JSON RPC responses, results in an incorrect 'shape'.

These RPC calls should (and now do) return a list of strings.