### PR TITLE
IbftGetValidatorsByBlockHash added to json factory

### DIFF
--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/IbftJsonRpcMethodsFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/IbftJsonRpcMethodsFactory.java
@@ -15,6 +15,7 @@ package tech.pegasys.pantheon.consensus.ibft.jsonrpc;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
 import tech.pegasys.pantheon.consensus.ibft.IbftContext;
 import tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods.IbftDiscardValidatorVote;
+import tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods.IbftGetValidatorsByBlockHash;
 import tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods.IbftGetValidatorsByBlockNumber;
 import tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods.IbftProposeValidatorVote;
 import tech.pegasys.pantheon.ethereum.ProtocolContext;
@@ -46,7 +47,9 @@ public class IbftJsonRpcMethodsFactory {
           new IbftGetValidatorsByBlockNumber(
               blockchainQueries, new IbftBlockInterface(), jsonRpcParameter),
           new IbftDiscardValidatorVote(
-              context.getConsensusState().getVoteProposer(), jsonRpcParameter));
+              context.getConsensusState().getVoteProposer(), jsonRpcParameter),
+          new IbftGetValidatorsByBlockHash(
+              context.getBlockchain(), new IbftBlockInterface(), jsonRpcParameter));
     }
 
     return rpcMethods;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/IbftJsonRpcMethodsFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/IbftJsonRpcMethodsFactory.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.jsonrpc;
 
+import tech.pegasys.pantheon.consensus.common.BlockInterface;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
 import tech.pegasys.pantheon.consensus.ibft.IbftContext;
 import tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods.IbftDiscardValidatorVote;
@@ -38,18 +39,18 @@ public class IbftJsonRpcMethodsFactory {
     final Map<String, JsonRpcMethod> rpcMethods = new HashMap<>();
 
     if (jsonRpcApis.contains(IbftRpcApis.IBFT)) {
-      BlockchainQueries blockchainQueries =
+      final BlockchainQueries blockchainQueries =
           new BlockchainQueries(context.getBlockchain(), context.getWorldStateArchive());
+      final BlockInterface blockInterface = new IbftBlockInterface();
       addMethods(
           rpcMethods,
           new IbftProposeValidatorVote(
               context.getConsensusState().getVoteProposer(), jsonRpcParameter),
-          new IbftGetValidatorsByBlockNumber(
-              blockchainQueries, new IbftBlockInterface(), jsonRpcParameter),
+          new IbftGetValidatorsByBlockNumber(blockchainQueries, blockInterface, jsonRpcParameter),
           new IbftDiscardValidatorVote(
               context.getConsensusState().getVoteProposer(), jsonRpcParameter),
           new IbftGetValidatorsByBlockHash(
-              context.getBlockchain(), new IbftBlockInterface(), jsonRpcParameter));
+              context.getBlockchain(), blockInterface, jsonRpcParameter));
     }
 
     return rpcMethods;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHash.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHash.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods;
 
-import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
+import tech.pegasys.pantheon.consensus.common.BlockInterface;
 import tech.pegasys.pantheon.ethereum.chain.Blockchain;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 import tech.pegasys.pantheon.ethereum.core.Hash;
@@ -28,15 +28,15 @@ import java.util.stream.Collectors;
 public class IbftGetValidatorsByBlockHash implements JsonRpcMethod {
 
   private final Blockchain blockchain;
-  private final IbftBlockInterface ibftBlockInterface;
+  private final BlockInterface blockInterface;
   private final JsonRpcParameter parameters;
 
   public IbftGetValidatorsByBlockHash(
       final Blockchain blockchain,
-      final IbftBlockInterface ibftBlockInterface,
+      final BlockInterface blockInterface,
       final JsonRpcParameter parameters) {
     this.blockchain = blockchain;
-    this.ibftBlockInterface = ibftBlockInterface;
+    this.blockInterface = blockInterface;
     this.parameters = parameters;
   }
 
@@ -56,7 +56,7 @@ public class IbftGetValidatorsByBlockHash implements JsonRpcMethod {
     return blockHeader
         .map(
             header ->
-                ibftBlockInterface
+                blockInterface
                     .validatorsInBlock(header)
                     .stream()
                     .map(validator -> validator.toString())

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumber.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumber.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.jsonrpc.methods;
 
-import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
+import tech.pegasys.pantheon.consensus.common.BlockInterface;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.AbstractBlockParameterMethod;
@@ -27,14 +27,14 @@ import java.util.stream.Collectors;
 public class IbftGetValidatorsByBlockNumber extends AbstractBlockParameterMethod
     implements JsonRpcMethod {
 
-  private final IbftBlockInterface ibftBlockInterface;
+  private final BlockInterface blockInterface;
 
   public IbftGetValidatorsByBlockNumber(
       final BlockchainQueries blockchainQueries,
-      final IbftBlockInterface ibftBlockInterface,
+      final BlockInterface blockInterface,
       final JsonRpcParameter parameters) {
     super(blockchainQueries, parameters);
-    this.ibftBlockInterface = ibftBlockInterface;
+    this.blockInterface = blockInterface;
   }
 
   @Override
@@ -49,7 +49,7 @@ public class IbftGetValidatorsByBlockNumber extends AbstractBlockParameterMethod
     return blockHeader
         .map(
             header ->
-                ibftBlockInterface
+                blockInterface
                     .validatorsInBlock(header)
                     .stream()
                     .map(validator -> validator.toString())


### PR DESCRIPTION
The JSON RPC handler was pre-existing, but was not "wired" into the JSON RPC factory, and as such, was not being recognised as an available JSON RPC method.

This commit updates the Factory such that the RPC will be available externally.