### PR TITLE
NC-2104 Clique and iBFT should not be defined by default in RPC APIs

### DIFF
--- a/docs/Reference/Pantheon-CLI-Syntax.md
+++ b/docs/Reference/Pantheon-CLI-Syntax.md
@@ -622,7 +622,7 @@ rpc-http-api=["ETH","NET","WEB3"]
 Comma-separated APIs to enable on the HTTP JSON-RPC channel.
 When you use this option, the `--rpc-http-enabled` option must also be specified.
 The available API options are: `ADMIN`, `ETH`, `NET`, `WEB3`, `CLIQUE`, `IBFT`, `DEBUG`, and `MINER`.
-The default is: `ETH`, `NET`, `WEB3`, `CLIQUE`, `IBFT`.
+The default is: `ETH`, `NET`, `WEB3`.
 
 !!!note
     :construction: IBFT is not currently supported. Support for IBFT is in active development. 
@@ -701,7 +701,7 @@ rpc-ws-api=["ETH","NET","WEB3"]
 Comma-separated APIs to enable on Websockets channel.
 When you use this option, the `--rpc-ws-enabled` option must also be specified.
 The available API options are: `ETH`, `NET`, `WEB3`, `CLIQUE`, `IBFT`, `DEBUG`, and `MINER`.
-The default is: `ETH`, `NET`, `WEB3`, `CLIQUE`, `IBFT`.
+The default is: `ETH`, `NET`, `WEB3`.
 
 !!!note
     :construction: IBFT is not currently supported. Support for IBFT is in active development. 

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/RpcApi.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/RpcApi.java
@@ -45,6 +45,6 @@ public class RpcApi {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("cliValue", cliValue).toString();
+    return cliValue;
   }
 }

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/RpcApi.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/RpcApi.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.pantheon.ethereum.jsonrpc;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class RpcApi {

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -24,7 +24,6 @@ import static tech.pegasys.pantheon.ethereum.p2p.peers.DefaultPeer.DEFAULT_PORT;
 import static tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PORT;
 import static tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration.createDefault;
 
-import java.util.Collections;
 import tech.pegasys.pantheon.Runner;
 import tech.pegasys.pantheon.RunnerBuilder;
 import tech.pegasys.pantheon.cli.custom.CorsAllowedOriginsProperty;

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -17,12 +17,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static tech.pegasys.pantheon.cli.DefaultCommandValues.getDefaultPantheonDataPath;
 import static tech.pegasys.pantheon.cli.NetworkName.MAINNET;
 import static tech.pegasys.pantheon.ethereum.jsonrpc.JsonRpcConfiguration.DEFAULT_JSON_RPC_PORT;
+import static tech.pegasys.pantheon.ethereum.jsonrpc.RpcApis.DEFAULT_JSON_RPC_APIS;
 import static tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration.DEFAULT_WEBSOCKET_PORT;
 import static tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration.DEFAULT_WEBSOCKET_REFRESH_DELAY;
 import static tech.pegasys.pantheon.ethereum.p2p.peers.DefaultPeer.DEFAULT_PORT;
 import static tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PORT;
 import static tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration.createDefault;
 
+import java.util.Collections;
 import tech.pegasys.pantheon.Runner;
 import tech.pegasys.pantheon.RunnerBuilder;
 import tech.pegasys.pantheon.cli.custom.CorsAllowedOriginsProperty;
@@ -336,10 +338,9 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
     split = ",",
     arity = "1..*",
     converter = RpcApisConverter.class,
-    description = "Comma separated APIs to enable on JSON-RPC channel. default: ${DEFAULT-VALUE}",
-    defaultValue = "ETH,NET,WEB3,CLIQUE,IBFT"
+    description = "Comma separated APIs to enable on JSON-RPC channel. default: ${DEFAULT-VALUE}"
   )
-  private final Collection<RpcApi> rpcHttpApis = null;
+  private final Collection<RpcApi> rpcHttpApis = DEFAULT_JSON_RPC_APIS;
 
   @Option(
     names = {"--rpc-ws-enabled"},
@@ -371,10 +372,9 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
     split = ",",
     arity = "1..*",
     converter = RpcApisConverter.class,
-    description = "Comma separated APIs to enable on WebSocket channel. default: ${DEFAULT-VALUE}",
-    defaultValue = "ETH,NET,WEB3,CLIQUE,IBFT"
+    description = "Comma separated APIs to enable on WebSocket channel. default: ${DEFAULT-VALUE}"
   )
-  private final Collection<RpcApi> rpcWsApis = null;
+  private final Collection<RpcApi> rpcWsApis = DEFAULT_JSON_RPC_APIS;
 
   private Long rpcWsRefreshDelay;
 

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
@@ -24,8 +24,6 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static tech.pegasys.pantheon.ethereum.p2p.config.DiscoveryConfiguration.MAINNET_BOOTSTRAP_NODES;
 
 import tech.pegasys.pantheon.PantheonInfo;
-import tech.pegasys.pantheon.consensus.clique.jsonrpc.CliqueRpcApis;
-import tech.pegasys.pantheon.consensus.ibft.jsonrpc.IbftRpcApis;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.MiningParameters;
 import tech.pegasys.pantheon.ethereum.core.Wei;
@@ -84,13 +82,9 @@ public class PantheonCommandTest extends CommandTestAbstract {
 
   static {
     final JsonRpcConfiguration rpcConf = JsonRpcConfiguration.createDefault();
-    rpcConf.addRpcApi(CliqueRpcApis.CLIQUE);
-    rpcConf.addRpcApi(IbftRpcApis.IBFT);
     defaultJsonRpcConfiguration = rpcConf;
 
     final WebSocketConfiguration websocketConf = WebSocketConfiguration.createDefault();
-    websocketConf.addRpcApi(CliqueRpcApis.CLIQUE);
-    websocketConf.addRpcApi(IbftRpcApis.IBFT);
     defaultWebSocketConfiguration = websocketConf;
 
     defaultMetricsConfiguration = MetricsConfiguration.createDefault();
@@ -107,7 +101,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
   @Test
   public void callingHelpDisplaysDefaultRpcApisCorrectly() {
     parseCommand("--help");
-    assertThat(commandOutput.toString()).contains("default: ETH,NET,WEB3,CLIQUE,IBFT");
+    assertThat(commandOutput.toString()).contains("default: [ETH, NET, WEB3]");
     assertThat(commandErrorOutput.toString()).isEmpty();
   }
 
@@ -254,16 +248,12 @@ public class PantheonCommandTest extends CommandTestAbstract {
     jsonRpcConfiguration.setPort(5678);
     jsonRpcConfiguration.setCorsAllowedDomains(Collections.emptyList());
     jsonRpcConfiguration.setRpcApis(RpcApis.DEFAULT_JSON_RPC_APIS);
-    jsonRpcConfiguration.addRpcApi(CliqueRpcApis.CLIQUE);
-    jsonRpcConfiguration.addRpcApi(IbftRpcApis.IBFT);
 
     final WebSocketConfiguration webSocketConfiguration = WebSocketConfiguration.createDefault();
     webSocketConfiguration.setEnabled(false);
     webSocketConfiguration.setHost("9.10.11.12");
     webSocketConfiguration.setPort(9101);
     webSocketConfiguration.setRpcApis(WebSocketConfiguration.DEFAULT_WEBSOCKET_APIS);
-    webSocketConfiguration.addRpcApi(CliqueRpcApis.CLIQUE);
-    webSocketConfiguration.addRpcApi(IbftRpcApis.IBFT);
 
     final MetricsConfiguration metricsConfiguration = MetricsConfiguration.createDefault();
     metricsConfiguration.setEnabled(false);
@@ -356,12 +346,8 @@ public class PantheonCommandTest extends CommandTestAbstract {
 
     parseCommand("--config-file", configFile);
     final JsonRpcConfiguration jsonRpcConfiguration = JsonRpcConfiguration.createDefault();
-    jsonRpcConfiguration.addRpcApi(CliqueRpcApis.CLIQUE);
-    jsonRpcConfiguration.addRpcApi(IbftRpcApis.IBFT);
 
     final WebSocketConfiguration webSocketConfiguration = WebSocketConfiguration.createDefault();
-    webSocketConfiguration.addRpcApi(CliqueRpcApis.CLIQUE);
-    webSocketConfiguration.addRpcApi(IbftRpcApis.IBFT);
 
     final MetricsConfiguration metricsConfiguration = MetricsConfiguration.createDefault();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Clique and iBFT should not be defined by default in HTTP and Websocket RPC APIs options.
This PR removes the default values for both Clique and iBFT and removes the hard coded string used as default value for description and replaces it with a constant default that's can be changed in one place.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes NC-2104