### PR TITLE
rename revisedibft config section to ibft2 in docs

### DIFF
--- a/docs/Consensus-Protocols/IBFT.md
+++ b/docs/Consensus-Protocols/IBFT.md
@@ -23,7 +23,7 @@ To use IBFT 2.0 requires an IBFT 2.0 genesis file. The genesis file defines prop
       {
         "config": {
           ...
-          "revisedibft": {
+          "ibft2": {
             "blockperiodseconds": 2,
             "epochlength": 30000,
             "requesttimeoutseconds": 10

--- a/docs/Consensus-Protocols/Overview-Consensus.md
+++ b/docs/Consensus-Protocols/Overview-Consensus.md
@@ -44,7 +44,7 @@ The genesis file specifies the consensus protocol for a chain `config`:
 {
   "config": {
     ....
-    "revisedibft": {
+    "ibft2": {
       ...     
    }
   },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Update IBFT 2 documentation example to use ibft2 instead of revisedibft. This related to change in PR 722 to rename revisedibft config section to ibft2 for the ibft2 config.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
