### PR TITLE
Create wrapper types for Ibft Signed messages

### DIFF
--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
@@ -195,19 +195,23 @@ public class RoundSpecificPeers {
 
     switch (expectedPayload.getMessageType()) {
       case IbftV2.PROPOSAL:
-        actualSignedPayload = ProposalMessageData.fromMessageData(actual).decode();
+        actualSignedPayload =
+            ProposalMessageData.fromMessageData(actual).decode().getSignedPayload();
         break;
       case IbftV2.PREPARE:
-        actualSignedPayload = PrepareMessageData.fromMessageData(actual).decode();
+        actualSignedPayload =
+            PrepareMessageData.fromMessageData(actual).decode().getSignedPayload();
         break;
       case IbftV2.COMMIT:
-        actualSignedPayload = CommitMessageData.fromMessageData(actual).decode();
+        actualSignedPayload = CommitMessageData.fromMessageData(actual).decode().getSignedPayload();
         break;
       case IbftV2.NEW_ROUND:
-        actualSignedPayload = NewRoundMessageData.fromMessageData(actual).decode();
+        actualSignedPayload =
+            NewRoundMessageData.fromMessageData(actual).decode().getSignedPayload();
         break;
       case IbftV2.ROUND_CHANGE:
-        actualSignedPayload = RoundChangeMessageData.fromMessageData(actual).decode();
+        actualSignedPayload =
+            RoundChangeMessageData.fromMessageData(actual).decode().getSignedPayload();
         break;
       default:
         fail("Illegal IBFTV2 message type.");

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/ValidatorPeer.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/ValidatorPeer.java
@@ -20,6 +20,11 @@ import tech.pegasys.pantheon.consensus.ibft.messagedata.NewRoundMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.PrepareMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.ProposalMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.RoundChangeMessageData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
@@ -82,7 +87,7 @@ public class ValidatorPeer {
     final SignedData<ProposalPayload> payload =
         messageFactory.createSignedProposalPayload(rId, block);
 
-    injectMessage(ProposalMessageData.create(payload));
+    injectMessage(ProposalMessageData.create(new Proposal(payload)));
     return payload;
   }
 
@@ -90,7 +95,7 @@ public class ValidatorPeer {
       final ConsensusRoundIdentifier rId, final Hash digest) {
     final SignedData<PreparePayload> payload =
         messageFactory.createSignedPreparePayload(rId, digest);
-    injectMessage(PrepareMessageData.create(payload));
+    injectMessage(PrepareMessageData.create(new Prepare(payload)));
     return payload;
   }
 
@@ -109,7 +114,7 @@ public class ValidatorPeer {
       final ConsensusRoundIdentifier rId, final Hash digest, final Signature commitSeal) {
     final SignedData<CommitPayload> payload =
         messageFactory.createSignedCommitPayload(rId, digest, commitSeal);
-    injectMessage(CommitMessageData.create(payload));
+    injectMessage(CommitMessageData.create(new Commit(payload)));
     return payload;
   }
 
@@ -120,7 +125,7 @@ public class ValidatorPeer {
 
     final SignedData<NewRoundPayload> payload =
         messageFactory.createSignedNewRoundPayload(rId, roundChangeCertificate, proposalPayload);
-    injectMessage(NewRoundMessageData.create(payload));
+    injectMessage(NewRoundMessageData.create(new NewRound(payload)));
     return payload;
   }
 
@@ -128,7 +133,7 @@ public class ValidatorPeer {
       final ConsensusRoundIdentifier rId, final Optional<PreparedCertificate> preparedCertificate) {
     final SignedData<RoundChangePayload> payload =
         messageFactory.createSignedRoundChangePayload(rId, preparedCertificate);
-    injectMessage(RoundChangeMessageData.create(payload));
+    injectMessage(RoundChangeMessageData.create(new RoundChange(payload)));
     return payload;
   }
 

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
@@ -19,6 +19,7 @@ import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftHelpers;
 import tech.pegasys.pantheon.consensus.ibft.ibftevent.NewChainHead;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.ProposalMessageData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
@@ -124,7 +125,7 @@ public class GossipTest {
     final SignedData<ProposalPayload> unknownProposal =
         unknownMsgFactory.createSignedProposalPayload(roundId, block);
 
-    sender.injectMessage(ProposalMessageData.create(unknownProposal));
+    sender.injectMessage(ProposalMessageData.create(new Proposal(unknownProposal)));
     peers.verifyNoMessagesReceived();
   }
 
@@ -135,7 +136,7 @@ public class GossipTest {
     final SignedData<ProposalPayload> proposalFromPeer =
         peerMsgFactory.createSignedProposalPayload(roundId, block);
 
-    sender.injectMessage(ProposalMessageData.create(proposalFromPeer));
+    sender.injectMessage(ProposalMessageData.create(new Proposal(proposalFromPeer)));
 
     peers.verifyMessagesReceivedNonPropsingExcluding(msgCreator, proposalFromPeer);
     peers.verifyNoMessagesReceivedProposer();

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/CommitMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/CommitMessageData.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.ethereum.rlp.RLP;
@@ -31,13 +31,13 @@ public class CommitMessageData extends AbstractIbftMessageData {
         messageData, MESSAGE_CODE, CommitMessageData.class, CommitMessageData::new);
   }
 
-  public SignedData<CommitPayload> decode() {
-    return SignedData.readSignedCommitPayloadFrom(RLP.input(data));
+  public Commit decode() {
+    return new Commit(SignedData.readSignedCommitPayloadFrom(RLP.input(data)));
   }
 
-  public static CommitMessageData create(final SignedData<CommitPayload> signedPayload) {
+  public static CommitMessageData create(final Commit commit) {
 
-    return new CommitMessageData(signedPayload.encode());
+    return new CommitMessageData(commit.encode());
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageData.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.ethereum.rlp.RLP;
@@ -31,13 +31,12 @@ public class NewRoundMessageData extends AbstractIbftMessageData {
         messageData, MESSAGE_CODE, NewRoundMessageData.class, NewRoundMessageData::new);
   }
 
-  public SignedData<NewRoundPayload> decode() {
-    return SignedData.readSignedNewRoundPayloadFrom(RLP.input(data));
+  public NewRound decode() {
+    return new NewRound(SignedData.readSignedNewRoundPayloadFrom(RLP.input(data)));
   }
 
-  public static NewRoundMessageData create(final SignedData<NewRoundPayload> signedPayload) {
-
-    return new NewRoundMessageData(signedPayload.encode());
+  public static NewRoundMessageData create(final NewRound newRound) {
+    return new NewRoundMessageData(newRound.encode());
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/PrepareMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/PrepareMessageData.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.ethereum.rlp.RLP;
@@ -31,13 +31,12 @@ public class PrepareMessageData extends AbstractIbftMessageData {
         messageData, MESSAGE_CODE, PrepareMessageData.class, PrepareMessageData::new);
   }
 
-  public SignedData<PreparePayload> decode() {
-    return SignedData.readSignedPreparePayloadFrom(RLP.input(data));
+  public Prepare decode() {
+    return new Prepare(SignedData.readSignedPreparePayloadFrom(RLP.input(data)));
   }
 
-  public static PrepareMessageData create(final SignedData<PreparePayload> signedPayload) {
-
-    return new PrepareMessageData(signedPayload.encode());
+  public static PrepareMessageData create(final Prepare preapare) {
+    return new PrepareMessageData(preapare.encode());
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageData.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.ethereum.rlp.RLP;
@@ -31,13 +31,13 @@ public class ProposalMessageData extends AbstractIbftMessageData {
         messageData, MESSAGE_CODE, ProposalMessageData.class, ProposalMessageData::new);
   }
 
-  public SignedData<ProposalPayload> decode() {
-    return SignedData.readSignedProposalPayloadFrom(RLP.input(data));
+  public Proposal decode() {
+    return new Proposal(SignedData.readSignedProposalPayloadFrom(RLP.input(data)));
   }
 
-  public static ProposalMessageData create(final SignedData<ProposalPayload> signedPayload) {
+  public static ProposalMessageData create(final Proposal proposal) {
 
-    return new ProposalMessageData(signedPayload.encode());
+    return new ProposalMessageData(proposal.encode());
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageData.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.ethereum.rlp.RLP;
@@ -31,11 +31,11 @@ public class RoundChangeMessageData extends AbstractIbftMessageData {
         messageData, MESSAGE_CODE, RoundChangeMessageData.class, RoundChangeMessageData::new);
   }
 
-  public SignedData<RoundChangePayload> decode() {
-    return SignedData.readSignedRoundChangePayloadFrom(RLP.input(data));
+  public RoundChange decode() {
+    return new RoundChange(SignedData.readSignedRoundChangePayloadFrom(RLP.input(data)));
   }
 
-  public static RoundChangeMessageData create(final SignedData<RoundChangePayload> signedPayload) {
+  public static RoundChangeMessageData create(final RoundChange signedPayload) {
 
     return new RoundChangeMessageData(signedPayload.encode());
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Commit.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Commit.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
+
+import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+
+public class Commit extends IbftMessage<CommitPayload> {
+
+  public Commit(final SignedData<CommitPayload> payload) {
+    super(payload);
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/IbftMessage.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/IbftMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
+
+import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
+import tech.pegasys.pantheon.consensus.ibft.payload.Authored;
+import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
+import tech.pegasys.pantheon.consensus.ibft.payload.RoundSpecific;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.ethereum.core.Address;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+public class IbftMessage<P extends Payload> implements Authored, RoundSpecific {
+
+  private final SignedData<P> payload;
+
+  public IbftMessage(final SignedData<P> payload) {
+    this.payload = payload;
+  }
+
+  @Override
+  public Address getAuthor() {
+    return payload.getAuthor();
+  }
+
+  @Override
+  public ConsensusRoundIdentifier getRoundIdentifier() {
+    return payload.getPayload().getRoundIdentifier();
+  }
+
+  public BytesValue encode() {
+    return payload.encode();
+  }
+
+  public SignedData<P> getSignedPayload() {
+    return payload;
+  }
+
+  public int getMessageType() {
+    return payload.getPayload().getMessageType();
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/NewRound.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/NewRound.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
+
+import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+
+public class NewRound extends IbftMessage<NewRoundPayload> {
+
+  public NewRound(final SignedData<NewRoundPayload> payload) {
+    super(payload);
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Prepare.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Prepare.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
+
+import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+
+public class Prepare extends IbftMessage<PreparePayload> {
+
+  public Prepare(final SignedData<PreparePayload> payload) {
+    super(payload);
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Proposal.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Proposal.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
+
+import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+
+public class Proposal extends IbftMessage<ProposalPayload> {
+
+  public Proposal(final SignedData<ProposalPayload> payload) {
+    super(payload);
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
+
+import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+
+public class RoundChange extends IbftMessage<RoundChangePayload> {
+
+  public RoundChange(final SignedData<RoundChangePayload> payload) {
+    super(payload);
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/IbftMessageTransmitter.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/IbftMessageTransmitter.java
@@ -18,14 +18,15 @@ import tech.pegasys.pantheon.consensus.ibft.messagedata.NewRoundMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.PrepareMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.ProposalMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.RoundChangeMessageData;
-import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Block;
@@ -45,19 +46,19 @@ public class IbftMessageTransmitter {
   }
 
   public void multicastProposal(final ConsensusRoundIdentifier roundIdentifier, final Block block) {
-    final SignedData<ProposalPayload> signedPayload =
-        messageFactory.createSignedProposalPayload(roundIdentifier, block);
+    final Proposal data =
+        new Proposal(messageFactory.createSignedProposalPayload(roundIdentifier, block));
 
-    final ProposalMessageData message = ProposalMessageData.create(signedPayload);
+    final ProposalMessageData message = ProposalMessageData.create(data);
 
     multicaster.send(message);
   }
 
   public void multicastPrepare(final ConsensusRoundIdentifier roundIdentifier, final Hash digest) {
-    final SignedData<PreparePayload> signedPayload =
-        messageFactory.createSignedPreparePayload(roundIdentifier, digest);
+    final Prepare data =
+        new Prepare(messageFactory.createSignedPreparePayload(roundIdentifier, digest));
 
-    final PrepareMessageData message = PrepareMessageData.create(signedPayload);
+    final PrepareMessageData message = PrepareMessageData.create(data);
 
     multicaster.send(message);
   }
@@ -66,10 +67,10 @@ public class IbftMessageTransmitter {
       final ConsensusRoundIdentifier roundIdentifier,
       final Hash digest,
       final Signature commitSeal) {
-    final SignedData<CommitPayload> signedPayload =
-        messageFactory.createSignedCommitPayload(roundIdentifier, digest, commitSeal);
+    final Commit data =
+        new Commit(messageFactory.createSignedCommitPayload(roundIdentifier, digest, commitSeal));
 
-    final CommitMessageData message = CommitMessageData.create(signedPayload);
+    final CommitMessageData message = CommitMessageData.create(data);
 
     multicaster.send(message);
   }
@@ -78,10 +79,11 @@ public class IbftMessageTransmitter {
       final ConsensusRoundIdentifier roundIdentifier,
       final Optional<PreparedCertificate> preparedCertificate) {
 
-    final SignedData<RoundChangePayload> signedPayload =
-        messageFactory.createSignedRoundChangePayload(roundIdentifier, preparedCertificate);
+    final RoundChange data =
+        new RoundChange(
+            messageFactory.createSignedRoundChangePayload(roundIdentifier, preparedCertificate));
 
-    final RoundChangeMessageData message = RoundChangeMessageData.create(signedPayload);
+    final RoundChangeMessageData message = RoundChangeMessageData.create(data);
 
     multicaster.send(message);
   }
@@ -91,9 +93,10 @@ public class IbftMessageTransmitter {
       final RoundChangeCertificate roundChangeCertificate,
       final SignedData<ProposalPayload> proposalPayload) {
 
-    final SignedData<NewRoundPayload> signedPayload =
-        messageFactory.createSignedNewRoundPayload(
-            roundIdentifier, roundChangeCertificate, proposalPayload);
+    final NewRound signedPayload =
+        new NewRound(
+            messageFactory.createSignedNewRoundPayload(
+                roundIdentifier, roundChangeCertificate, proposalPayload));
 
     final NewRoundMessageData message = NewRoundMessageData.create(signedPayload);
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/Authored.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/Authored.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.payload;
+
+import tech.pegasys.pantheon.ethereum.core.Address;
+
+public interface Authored {
+
+  Address getAuthor();
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/Payload.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/Payload.java
@@ -12,18 +12,15 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.payload;
 
-import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
 import tech.pegasys.pantheon.ethereum.rlp.RLPInput;
 import tech.pegasys.pantheon.ethereum.rlp.RLPOutput;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
-public interface Payload {
+public interface Payload extends RoundSpecific {
 
   void writeTo(final RLPOutput rlpOutput);
-
-  ConsensusRoundIdentifier getRoundIdentifier();
 
   default BytesValue encoded() {
     BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/RoundSpecific.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/RoundSpecific.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.payload;
+
+import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
+
+public interface RoundSpecific {
+
+  ConsensusRoundIdentifier getRoundIdentifier();
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/SignedData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/SignedData.java
@@ -23,7 +23,7 @@ import tech.pegasys.pantheon.util.bytes.BytesValue;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-public class SignedData<M extends Payload> {
+public class SignedData<M extends Payload> implements Authored {
   private final Address sender;
   private final Signature signature;
   private final M unsignedPayload;
@@ -34,12 +34,9 @@ public class SignedData<M extends Payload> {
     this.signature = signature;
   }
 
+  @Override
   public Address getAuthor() {
     return sender;
-  }
-
-  public Signature getSignature() {
-    return signature;
   }
 
   public M getPayload() {
@@ -50,7 +47,7 @@ public class SignedData<M extends Payload> {
 
     output.startList();
     unsignedPayload.writeTo(output);
-    output.writeBytesValue(getSignature().encodedBytes());
+    output.writeBytesValue(signature.encodedBytes());
     output.endList();
   }
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftGossipTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftGossipTest.java
@@ -18,10 +18,9 @@ import static org.mockito.Mockito.verify;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.NewRoundMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.ProposalMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.RoundChangeMessageData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.IbftMessage;
 import tech.pegasys.pantheon.consensus.ibft.network.MockPeerFactory;
 import tech.pegasys.pantheon.consensus.ibft.network.ValidatorMulticaster;
-import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.AddressHelpers;
@@ -51,11 +50,10 @@ public class IbftGossipTest {
     peerConnection = MockPeerFactory.create(senderAddress);
   }
 
-  private <P extends Payload> void assertRebroadcastToAllExceptSignerAndSender(
-      final Function<KeyPair, SignedData<P>> createPayload,
-      final Function<SignedData<P>, MessageData> createMessageData) {
+  private <P extends IbftMessage<?>> void assertRebroadcastToAllExceptSignerAndSender(
+      final Function<KeyPair, P> createPayload, final Function<P, MessageData> createMessageData) {
     final KeyPair keypair = KeyPair.generate();
-    final SignedData<P> payload = createPayload.apply(keypair);
+    final P payload = createPayload.apply(keypair);
     final MessageData messageData = createMessageData.apply(payload);
     final Message message = new DefaultMessage(peerConnection, messageData);
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/TestHelpers.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/TestHelpers.java
@@ -15,14 +15,13 @@ package tech.pegasys.pantheon.consensus.ibft;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.singletonList;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Address;
@@ -62,52 +61,56 @@ public class TestHelpers {
     return new BlockDataGenerator().block(blockOptions);
   }
 
-  public static SignedData<ProposalPayload> createSignedProposalPayload(final KeyPair signerKeys) {
+  public static Proposal createSignedProposalPayload(final KeyPair signerKeys) {
     return createSignedProposalPayloadWithRound(signerKeys, 0xFEDCBA98);
   }
 
-  public static SignedData<ProposalPayload> createSignedProposalPayloadWithRound(
+  public static Proposal createSignedProposalPayloadWithRound(
       final KeyPair signerKeys, final int round) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, round);
     final Block block =
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), 0);
-    return messageFactory.createSignedProposalPayload(roundIdentifier, block);
+    return new Proposal(messageFactory.createSignedProposalPayload(roundIdentifier, block));
   }
 
-  public static SignedData<PreparePayload> createSignedPreparePayload(final KeyPair signerKeys) {
+  public static Prepare createSignedPreparePayload(final KeyPair signerKeys) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
-    return messageFactory.createSignedPreparePayload(
-        roundIdentifier, Hash.fromHexStringLenient("0"));
+    return new Prepare(
+        messageFactory.createSignedPreparePayload(roundIdentifier, Hash.fromHexStringLenient("0")));
   }
 
-  public static SignedData<CommitPayload> createSignedCommitPayload(final KeyPair signerKeys) {
+  public static Commit createSignedCommitPayload(final KeyPair signerKeys) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
-    return messageFactory.createSignedCommitPayload(
-        roundIdentifier,
-        Hash.fromHexStringLenient("0"),
-        Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0));
+    return new Commit(
+        messageFactory.createSignedCommitPayload(
+            roundIdentifier,
+            Hash.fromHexStringLenient("0"),
+            Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0)));
   }
 
-  public static SignedData<RoundChangePayload> createSignedRoundChangePayload(
-      final KeyPair signerKeys) {
+  public static RoundChange createSignedRoundChangePayload(final KeyPair signerKeys) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
-    return messageFactory.createSignedRoundChangePayload(roundIdentifier, Optional.empty());
+    return new RoundChange(
+        messageFactory.createSignedRoundChangePayload(roundIdentifier, Optional.empty()));
   }
 
-  public static SignedData<NewRoundPayload> createSignedNewRoundPayload(final KeyPair signerKeys) {
+  public static NewRound createSignedNewRoundPayload(final KeyPair signerKeys) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
-    final SignedData<ProposalPayload> proposalPayload = createSignedProposalPayload(signerKeys);
-    return messageFactory.createSignedNewRoundPayload(
-        roundIdentifier, new RoundChangeCertificate(newArrayList()), proposalPayload);
+    final Proposal proposalPayload = createSignedProposalPayload(signerKeys);
+    return new NewRound(
+        messageFactory.createSignedNewRoundPayload(
+            roundIdentifier,
+            new RoundChangeCertificate(newArrayList()),
+            proposalPayload.getSignedPayload()));
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/CommitMessageTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/CommitMessageTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
@@ -29,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommitMessageTest {
-  @Mock private SignedData<CommitPayload> commitPayload;
+  @Mock private Commit commitPayload;
   @Mock private BytesValue messageBytes;
   @Mock private MessageData messageData;
   @Mock private CommitMessageData commitMessage;

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
@@ -29,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NewRoundMessageTest {
-  @Mock private SignedData<NewRoundPayload> newRoundPayload;
+  @Mock private NewRound newRoundPayload;
   @Mock private BytesValue messageBytes;
   @Mock private MessageData messageData;
   @Mock private NewRoundMessageData newRoundMessage;

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/PrepareMessageTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/PrepareMessageTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
@@ -29,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PrepareMessageTest {
-  @Mock private SignedData<PreparePayload> preparePayload;
+  @Mock private Prepare preparePayload;
   @Mock private BytesValue messageBytes;
   @Mock private MessageData messageData;
   @Mock private PrepareMessageData prepareMessage;

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
@@ -29,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProposalMessageTest {
-  @Mock private SignedData<ProposalPayload> proposalMessageData;
+  @Mock private Proposal proposalMessageData;
   @Mock private BytesValue messageBytes;
   @Mock private MessageData messageData;
   @Mock private ProposalMessageData proposalMessage;

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
@@ -29,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RoundChangeMessageTest {
-  @Mock private SignedData<RoundChangePayload> roundChangePayload;
+  @Mock private RoundChange roundChangePayload;
   @Mock private BytesValue messageBytes;
   @Mock private MessageData messageData;
   @Mock private RoundChangeMessageData roundChangeMessage;

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftControllerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftControllerTest.java
@@ -34,6 +34,11 @@ import tech.pegasys.pantheon.consensus.ibft.messagedata.NewRoundMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.PrepareMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.ProposalMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.RoundChangeMessageData;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
@@ -456,7 +461,7 @@ public class IbftControllerTest {
     when(signedProposal.getAuthor()).thenReturn(validator);
     when(proposalPayload.getRoundIdentifier()).thenReturn(roundIdentifier);
     when(proposalMessageData.getCode()).thenReturn(IbftV2.PROPOSAL);
-    when(proposalMessageData.decode()).thenReturn(signedProposal);
+    when(proposalMessageData.decode()).thenReturn(new Proposal(signedProposal));
     proposalMessage = new DefaultMessage(null, proposalMessageData);
   }
 
@@ -466,7 +471,7 @@ public class IbftControllerTest {
     when(signedPrepare.getAuthor()).thenReturn(validator);
     when(preparePayload.getRoundIdentifier()).thenReturn(roundIdentifier);
     when(prepareMessageData.getCode()).thenReturn(IbftV2.PREPARE);
-    when(prepareMessageData.decode()).thenReturn(signedPrepare);
+    when(prepareMessageData.decode()).thenReturn(new Prepare(signedPrepare));
     prepareMessage = new DefaultMessage(null, prepareMessageData);
   }
 
@@ -476,7 +481,7 @@ public class IbftControllerTest {
     when(signedCommit.getAuthor()).thenReturn(validator);
     when(commitPayload.getRoundIdentifier()).thenReturn(roundIdentifier);
     when(commitMessageData.getCode()).thenReturn(IbftV2.COMMIT);
-    when(commitMessageData.decode()).thenReturn(signedCommit);
+    when(commitMessageData.decode()).thenReturn(new Commit(signedCommit));
     commitMessage = new DefaultMessage(null, commitMessageData);
   }
 
@@ -486,7 +491,7 @@ public class IbftControllerTest {
     when(signedNewRound.getAuthor()).thenReturn(validator);
     when(newRoundPayload.getRoundIdentifier()).thenReturn(roundIdentifier);
     when(newRoundMessageData.getCode()).thenReturn(IbftV2.NEW_ROUND);
-    when(newRoundMessageData.decode()).thenReturn(signedNewRound);
+    when(newRoundMessageData.decode()).thenReturn(new NewRound(signedNewRound));
     newRoundMessage = new DefaultMessage(null, newRoundMessageData);
   }
 
@@ -496,7 +501,7 @@ public class IbftControllerTest {
     when(signedRoundChange.getAuthor()).thenReturn(validator);
     when(roundChangePayload.getRoundIdentifier()).thenReturn(roundIdentifier);
     when(roundChangeMessageData.getCode()).thenReturn(IbftV2.ROUND_CHANGE);
-    when(roundChangeMessageData.decode()).thenReturn(signedRoundChange);
+    when(roundChangeMessageData.decode()).thenReturn(new RoundChange(signedRoundChange));
     roundChangeMessage = new DefaultMessage(null, roundChangeMessageData);
   }
 }


### PR DESCRIPTION
As future IBFT message will require only subsets of the data to be signed,
the message structures need to be modified such taht the signed-data
aspects can be a component of the message (Rather than the whole
message).

This change starts this process by having a "flat" message which allows
clients to query the required round, and author of the message.