### PR TITLE
Implement IBFT 2.1 Message and validation

### DIFF
--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
@@ -27,8 +27,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.IbftMessage;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
@@ -139,10 +137,7 @@ public class RoundSpecificPeers {
       final ConsensusRoundIdentifier preparedRound, final Hash hash) {
     return nonProposingPeers
         .stream()
-        .map(
-            role ->
-                role.getMessageFactory()
-                    .createSignedPreparePayload(preparedRound, hash))
+        .map(role -> role.getMessageFactory().createSignedPreparePayload(preparedRound, hash))
         .collect(Collectors.toList());
   }
 

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
@@ -166,7 +166,7 @@ public class RoundSpecificPeers {
     verifyMessagesReceived(candidates, msgs);
   }
 
-  public final void verifyMessagesReceivedNonPropsing(final IbftMessage<?>... msgs) {
+  public final void verifyMessagesReceivedNonProposing(final IbftMessage<?>... msgs) {
     verifyMessagesReceived(nonProposingPeers, msgs);
   }
 

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
@@ -24,12 +24,14 @@ import tech.pegasys.pantheon.consensus.ibft.messagedata.PrepareMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.ProposalMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.RoundChangeMessageData;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.IbftMessage;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
@@ -113,13 +115,14 @@ public class RoundSpecificPeers {
   }
 
   public List<SignedData<RoundChangePayload>> createSignedRoundChangePayload(
-      final ConsensusRoundIdentifier roundId, final PreparedCertificate preparedCertificate) {
+      final ConsensusRoundIdentifier roundId,
+      final TerminatedRoundArtefacts terminatedRoundArtefacts) {
     return peers
         .stream()
         .map(
             p ->
                 p.getMessageFactory()
-                    .createSignedRoundChangePayload(roundId, Optional.of(preparedCertificate))
+                    .createSignedRoundChangePayload(roundId, Optional.of(terminatedRoundArtefacts))
                     .getSignedPayload())
         .collect(Collectors.toList());
   }
@@ -132,15 +135,14 @@ public class RoundSpecificPeers {
     nonProposingPeers.forEach(peer -> peer.injectCommit(roundId, hash));
   }
 
-  public Collection<SignedData<PreparePayload>> createSignedPreparePayloadOfNonProposing(
+  public Collection<Prepare> createSignedPreparePayloadOfNonProposing(
       final ConsensusRoundIdentifier preparedRound, final Hash hash) {
     return nonProposingPeers
         .stream()
         .map(
             role ->
                 role.getMessageFactory()
-                    .createSignedPreparePayload(preparedRound, hash)
-                    .getSignedPayload())
+                    .createSignedPreparePayload(preparedRound, hash))
         .collect(Collectors.toList());
   }
 

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/RoundSpecificPeers.java
@@ -184,8 +184,8 @@ public class RoundSpecificPeers {
       final int index = i;
       final IbftMessage<? extends Payload> msg = msgList.get(index);
       candidates.forEach(
-          n -> {
-            final List<MessageData> rxMsgs = n.getReceivedMessages();
+          candidate -> {
+            final List<MessageData> rxMsgs = candidate.getReceivedMessages();
             final MessageData rxMsgData = rxMsgs.get(index);
             verifyMessage(rxMsgData, msg);
           });

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestContextBuilder.java
@@ -300,7 +300,10 @@ public class TestContextBuilder {
             new IbftBlockHeightManagerFactory(
                 finalState,
                 new IbftRoundFactory(
-                    finalState, protocolContext, protocolSchedule, minedBlockObservers,
+                    finalState,
+                    protocolContext,
+                    protocolSchedule,
+                    minedBlockObservers,
                     messageValidatorFactory),
                 messageValidatorFactory),
             gossiper,

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestContextBuilder.java
@@ -300,7 +300,8 @@ public class TestContextBuilder {
             new IbftBlockHeightManagerFactory(
                 finalState,
                 new IbftRoundFactory(
-                    finalState, protocolContext, protocolSchedule, minedBlockObservers),
+                    finalState, protocolContext, protocolSchedule, minedBlockObservers,
+                    messageValidatorFactory),
                 messageValidatorFactory),
             gossiper,
             new HashMap<>());

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestHelpers.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestHelpers.java
@@ -19,7 +19,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
@@ -69,8 +68,6 @@ public class TestHelpers {
         proposer.getMessageFactory().createSignedProposalPayload(targetRoundId, blockToPropose);
 
     return proposer.injectNewRound(
-        targetRoundId,
-        new RoundChangeCertificate(roundChangePayloads),
-        proposal);
+        targetRoundId, new RoundChangeCertificate(roundChangePayloads), proposal);
   }
 }

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestHelpers.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/TestHelpers.java
@@ -23,6 +23,7 @@ import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
@@ -49,16 +50,12 @@ public class TestHelpers {
         .getSignedPayload();
   }
 
-  public static PreparedCertificate createValidPreparedCertificate(
+  public static TerminatedRoundArtefacts createValidTerminatedRoundArtefacts(
       final TestContext context, final ConsensusRoundIdentifier preparedRound, final Block block) {
     final RoundSpecificPeers peers = context.roundSpecificPeers(preparedRound);
 
-    return new PreparedCertificate(
-        peers
-            .getProposer()
-            .getMessageFactory()
-            .createSignedProposalPayload(preparedRound, block)
-            .getSignedPayload(),
+    return new TerminatedRoundArtefacts(
+        peers.getProposer().getMessageFactory().createSignedProposalPayload(preparedRound, block),
         peers.createSignedPreparePayloadOfNonProposing(preparedRound, block.getHash()));
   }
 
@@ -74,6 +71,6 @@ public class TestHelpers {
     return proposer.injectNewRound(
         targetRoundId,
         new RoundChangeCertificate(roundChangePayloads),
-        proposal.getSignedPayload());
+        proposal);
   }
 }

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/ValidatorPeer.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/ValidatorPeer.java
@@ -30,6 +30,7 @@ import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
@@ -111,18 +112,20 @@ public class ValidatorPeer {
   public NewRound injectNewRound(
       final ConsensusRoundIdentifier rId,
       final RoundChangeCertificate roundChangeCertificate,
-      final SignedData<ProposalPayload> proposalPayload) {
+      final Proposal proposalPayload) {
 
     final NewRound payload =
-        messageFactory.createSignedNewRoundPayload(rId, roundChangeCertificate, proposalPayload);
+        messageFactory.createSignedNewRoundPayload(rId, roundChangeCertificate,
+            proposalPayload.getSignedPayload(), proposalPayload.getBlock());
     injectMessage(NewRoundMessageData.create(payload));
     return payload;
   }
 
   public RoundChange injectRoundChange(
-      final ConsensusRoundIdentifier rId, final Optional<PreparedCertificate> preparedCertificate) {
+      final ConsensusRoundIdentifier rId,
+      final Optional<TerminatedRoundArtefacts> terminatedRoundArtefacts) {
     final RoundChange payload =
-        messageFactory.createSignedRoundChangePayload(rId, preparedCertificate);
+        messageFactory.createSignedRoundChangePayload(rId, terminatedRoundArtefacts);
     injectMessage(RoundChangeMessageData.create(payload));
     return payload;
   }

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/ValidatorPeer.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/ValidatorPeer.java
@@ -26,10 +26,7 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
@@ -115,8 +112,11 @@ public class ValidatorPeer {
       final Proposal proposalPayload) {
 
     final NewRound payload =
-        messageFactory.createSignedNewRoundPayload(rId, roundChangeCertificate,
-            proposalPayload.getSignedPayload(), proposalPayload.getBlock());
+        messageFactory.createSignedNewRoundPayload(
+            rId,
+            roundChangeCertificate,
+            proposalPayload.getSignedPayload(),
+            proposalPayload.getBlock());
     injectMessage(NewRoundMessageData.create(payload));
     return payload;
   }

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
@@ -79,15 +79,15 @@ public class GossipTest {
 
     final Proposal proposal = sender.injectProposal(roundId, block);
     // sender node will have a prepare message as an effect of the proposal being sent
-    peers.verifyMessagesReceivedNonPropsing(proposal, localPrepare);
+    peers.verifyMessagesReceivedNonProposing(proposal, localPrepare);
     peers.verifyMessagesReceivedProposer(localPrepare);
 
     final Prepare prepare = sender.injectPrepare(roundId, block.getHash());
-    peers.verifyMessagesReceivedNonPropsing(prepare);
+    peers.verifyMessagesReceivedNonProposing(prepare);
     peers.verifyNoMessagesReceivedProposer();
 
     final Commit commit = sender.injectCommit(roundId, block.getHash());
-    peers.verifyMessagesReceivedNonPropsing(commit);
+    peers.verifyMessagesReceivedNonProposing(commit);
     peers.verifyNoMessagesReceivedProposer();
 
     final RoundChange roundChange =
@@ -95,18 +95,18 @@ public class GossipTest {
     final RoundChangeCertificate roundChangeCert =
         new RoundChangeCertificate(singleton(roundChange.getSignedPayload()));
     final NewRound newRound = sender.injectNewRound(roundId, roundChangeCert, proposal);
-    peers.verifyMessagesReceivedNonPropsing(newRound);
+    peers.verifyMessagesReceivedNonProposing(newRound);
     peers.verifyNoMessagesReceivedProposer();
 
     sender.injectRoundChange(roundId, Optional.empty());
-    peers.verifyMessagesReceivedNonPropsing(roundChange);
+    peers.verifyMessagesReceivedNonProposing(roundChange);
     peers.verifyNoMessagesReceivedProposer();
   }
 
   @Test
   public void onlyGossipOnce() {
     final Prepare prepare = sender.injectPrepare(roundId, block.getHash());
-    peers.verifyMessagesReceivedNonPropsing(prepare);
+    peers.verifyMessagesReceivedNonProposing(prepare);
 
     sender.injectPrepare(roundId, block.getHash());
     peers.verifyNoMessagesReceivedNonProposing();
@@ -169,6 +169,6 @@ public class GossipTest {
         .getController()
         .handleNewBlockEvent(new NewChainHead(signedCurrentHeightBlock.getHeader()));
 
-    peers.verifyMessagesReceivedNonPropsing(futurePrepare);
+    peers.verifyMessagesReceivedNonProposing(futurePrepare);
   }
 }

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
@@ -94,8 +94,7 @@ public class GossipTest {
         msgFactory.createSignedRoundChangePayload(roundId, Optional.empty());
     final RoundChangeCertificate roundChangeCert =
         new RoundChangeCertificate(singleton(roundChange.getSignedPayload()));
-    final NewRound newRound =
-        sender.injectNewRound(roundId, roundChangeCert, proposal);
+    final NewRound newRound = sender.injectNewRound(roundId, roundChangeCert, proposal);
     peers.verifyMessagesReceivedNonPropsing(newRound);
     peers.verifyNoMessagesReceivedProposer();
 

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/GossipTest.java
@@ -95,7 +95,7 @@ public class GossipTest {
     final RoundChangeCertificate roundChangeCert =
         new RoundChangeCertificate(singleton(roundChange.getSignedPayload()));
     final NewRound newRound =
-        sender.injectNewRound(roundId, roundChangeCert, proposal.getSignedPayload());
+        sender.injectNewRound(roundId, roundChangeCert, proposal);
     peers.verifyMessagesReceivedNonPropsing(newRound);
     peers.verifyNoMessagesReceivedProposer();
 
@@ -122,8 +122,7 @@ public class GossipTest {
     final MessageFactory unknownMsgFactory = new MessageFactory(unknownKeyPair);
     final Proposal unknownProposal = unknownMsgFactory.createSignedProposalPayload(roundId, block);
 
-    sender.injectMessage(
-        ProposalMessageData.create(new Proposal(unknownProposal.getSignedPayload())));
+    sender.injectMessage(ProposalMessageData.create(unknownProposal));
     peers.verifyNoMessagesReceived();
   }
 

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/ReceivedNewRoundTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/ReceivedNewRoundTest.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.tests;
 
-import static tech.pegasys.pantheon.consensus.ibft.support.TestHelpers.createValidPreparedCertificate;
+import static tech.pegasys.pantheon.consensus.ibft.support.TestHelpers.createValidTerminatedRoundArtefacts;
 
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
@@ -23,6 +23,7 @@ import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.consensus.ibft.support.RoundSpecificPeers;
 import tech.pegasys.pantheon.consensus.ibft.support.TestContext;
 import tech.pegasys.pantheon.consensus.ibft.support.TestContextBuilder;
@@ -73,8 +74,7 @@ public class ReceivedNewRoundTest {
         new RoundChangeCertificate(roundChanges),
         nextProposer
             .getMessageFactory()
-            .createSignedProposalPayload(targetRound, blockToPropose)
-            .getSignedPayload());
+            .createSignedProposalPayload(targetRound, blockToPropose));
 
     final Prepare expectedPrepare =
         localNodeMessageFactory.createSignedPreparePayload(targetRound, blockToPropose.getHash());
@@ -99,8 +99,7 @@ public class ReceivedNewRoundTest {
         new RoundChangeCertificate(roundChanges),
         illegalProposer
             .getMessageFactory()
-            .createSignedProposalPayload(nextRoundId, blockToPropose)
-            .getSignedPayload());
+            .createSignedProposalPayload(nextRoundId, blockToPropose));
 
     peers.verifyNoMessagesReceived();
   }
@@ -111,11 +110,11 @@ public class ReceivedNewRoundTest {
     final Block reproposedBlock = context.createBlockForProposalFromChainHead(1, 15);
     final ConsensusRoundIdentifier nextRoundId = new ConsensusRoundIdentifier(1, 1);
 
-    final PreparedCertificate preparedCertificate =
-        createValidPreparedCertificate(context, roundId, initialBlock);
+    final TerminatedRoundArtefacts terminatedRoundArtefacts =
+        createValidTerminatedRoundArtefacts(context, roundId, initialBlock);
 
     final List<SignedData<RoundChangePayload>> roundChanges =
-        peers.createSignedRoundChangePayload(nextRoundId, preparedCertificate);
+        peers.createSignedRoundChangePayload(nextRoundId, terminatedRoundArtefacts);
 
     final ValidatorPeer nextProposer = context.roundSpecificPeers(nextRoundId).getProposer();
 
@@ -125,8 +124,7 @@ public class ReceivedNewRoundTest {
         peers
             .getNonProposing(0)
             .getMessageFactory()
-            .createSignedProposalPayload(nextRoundId, reproposedBlock)
-            .getSignedPayload());
+            .createSignedProposalPayload(nextRoundId, reproposedBlock));
 
     peers.verifyMessagesReceived(
         localNodeMessageFactory.createSignedPreparePayload(nextRoundId, reproposedBlock.getHash()));
@@ -153,7 +151,7 @@ public class ReceivedNewRoundTest {
                 interimRound, context.createBlockForProposalFromChainHead(1, 30));
 
     interimRoundProposer.injectNewRound(
-        interimRound, new RoundChangeCertificate(roundChangePayloads), proposal.getSignedPayload());
+        interimRound, new RoundChangeCertificate(roundChangePayloads), proposal);
 
     peers.verifyNoMessagesReceived();
   }
@@ -164,11 +162,11 @@ public class ReceivedNewRoundTest {
     final Block reproposedBlock = context.createBlockForProposalFromChainHead(1, 15);
     final ConsensusRoundIdentifier nextRoundId = new ConsensusRoundIdentifier(1, 1);
 
-    final PreparedCertificate preparedCertificate =
-        createValidPreparedCertificate(context, roundId, initialBlock);
+    final TerminatedRoundArtefacts terminatedRoundArtefacts =
+        createValidTerminatedRoundArtefacts(context, roundId, initialBlock);
 
     final List<SignedData<RoundChangePayload>> roundChanges =
-        peers.createSignedRoundChangePayload(nextRoundId, preparedCertificate);
+        peers.createSignedRoundChangePayload(nextRoundId, terminatedRoundArtefacts);
 
     final RoundSpecificPeers nextRoles = context.roundSpecificPeers(nextRoundId);
     final ValidatorPeer nextProposer = nextRoles.getProposer();
@@ -179,8 +177,7 @@ public class ReceivedNewRoundTest {
         peers
             .getNonProposing(0)
             .getMessageFactory()
-            .createSignedProposalPayload(nextRoundId, reproposedBlock)
-            .getSignedPayload());
+            .createSignedProposalPayload(nextRoundId, reproposedBlock));
 
     peers.verifyMessagesReceived(
         localNodeMessageFactory.createSignedPreparePayload(nextRoundId, reproposedBlock.getHash()));
@@ -195,8 +192,7 @@ public class ReceivedNewRoundTest {
         peers
             .getNonProposing(0)
             .getMessageFactory()
-            .createSignedProposalPayload(nextRoundId, reproposedBlock)
-            .getSignedPayload());
+            .createSignedProposalPayload(nextRoundId, reproposedBlock));
 
     peers.verifyNoMessagesReceived();
 

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/ReceivedNewRoundTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/ReceivedNewRoundTest.java
@@ -19,7 +19,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
@@ -72,9 +71,7 @@ public class ReceivedNewRoundTest {
     nextProposer.injectNewRound(
         targetRound,
         new RoundChangeCertificate(roundChanges),
-        nextProposer
-            .getMessageFactory()
-            .createSignedProposalPayload(targetRound, blockToPropose));
+        nextProposer.getMessageFactory().createSignedProposalPayload(targetRound, blockToPropose));
 
     final Prepare expectedPrepare =
         localNodeMessageFactory.createSignedPreparePayload(targetRound, blockToPropose.getHash());

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/RoundChangeTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/RoundChangeTest.java
@@ -24,7 +24,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
@@ -132,11 +131,7 @@ public class RoundChangeTest {
             targetRound,
             Optional.of(
                 new TerminatedRoundArtefacts(
-                    proposal,
-                    Lists.newArrayList(
-                        localPrepareMessage,
-                        p1,
-                        p2))));
+                    proposal, Lists.newArrayList(localPrepareMessage, p1, p2))));
 
     context.getController().handleRoundExpiry(new RoundExpiry(roundId));
     peers.verifyMessagesReceived(expectedTxRoundChange);

--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/RoundChangeTest.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/tests/RoundChangeTest.java
@@ -14,7 +14,7 @@ package tech.pegasys.pantheon.consensus.ibft.tests;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
-import static tech.pegasys.pantheon.consensus.ibft.support.TestHelpers.createValidPreparedCertificate;
+import static tech.pegasys.pantheon.consensus.ibft.support.TestHelpers.createValidTerminatedRoundArtefacts;
 
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftHelpers;
@@ -28,6 +28,7 @@ import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.consensus.ibft.support.RoundSpecificPeers;
 import tech.pegasys.pantheon.consensus.ibft.support.TestContext;
 import tech.pegasys.pantheon.consensus.ibft.support.TestContextBuilder;
@@ -130,12 +131,12 @@ public class RoundChangeTest {
         localNodeMessageFactory.createSignedRoundChangePayload(
             targetRound,
             Optional.of(
-                new PreparedCertificate(
-                    proposal.getSignedPayload(),
+                new TerminatedRoundArtefacts(
+                    proposal,
                     Lists.newArrayList(
-                        localPrepareMessage.getSignedPayload(),
-                        p1.getSignedPayload(),
-                        p2.getSignedPayload()))));
+                        localPrepareMessage,
+                        p1,
+                        p2))));
 
     context.getController().handleRoundExpiry(new RoundExpiry(roundId));
     peers.verifyMessagesReceived(expectedTxRoundChange);
@@ -164,7 +165,8 @@ public class RoundChangeTest {
                     rc4.getSignedPayload())),
             localNodeMessageFactory
                 .createSignedProposalPayload(targetRound, locallyProposedBlock)
-                .getSignedPayload());
+                .getSignedPayload(),
+            locallyProposedBlock);
 
     peers.verifyMessagesReceived(expectedNewRound);
   }
@@ -173,14 +175,14 @@ public class RoundChangeTest {
   public void newRoundMessageContainsBlockOnWhichPeerPrepared() {
     final long ARBITRARY_BLOCKTIME = 1500;
 
-    final PreparedCertificate earlierPrepCert =
-        createValidPreparedCertificate(
+    final TerminatedRoundArtefacts earlierPrepCert =
+        createValidTerminatedRoundArtefacts(
             context,
             new ConsensusRoundIdentifier(1, 1),
             context.createBlockForProposalFromChainHead(1, ARBITRARY_BLOCKTIME / 2));
 
-    final PreparedCertificate bestPrepCert =
-        createValidPreparedCertificate(
+    final TerminatedRoundArtefacts bestPrepCert =
+        createValidTerminatedRoundArtefacts(
             context,
             new ConsensusRoundIdentifier(1, 2),
             context.createBlockForProposalFromChainHead(2, ARBITRARY_BLOCKTIME));
@@ -218,7 +220,8 @@ public class RoundChangeTest {
                     rc4.getSignedPayload())),
             localNodeMessageFactory
                 .createSignedProposalPayload(targetRound, expectedBlockToPropose)
-                .getSignedPayload());
+                .getSignedPayload(),
+            expectedBlockToPropose);
 
     peers.verifyMessagesReceived(expectedNewRound);
   }
@@ -242,7 +245,8 @@ public class RoundChangeTest {
             new RoundChangeCertificate(roundChangeMessages),
             localNodeMessageFactory
                 .createSignedProposalPayload(futureRound, locallyProposedBlock)
-                .getSignedPayload());
+                .getSignedPayload(),
+            locallyProposedBlock);
 
     peers.verifyMessagesReceived(expectedNewRound);
   }
@@ -267,8 +271,8 @@ public class RoundChangeTest {
 
     final ConsensusRoundIdentifier targetRound = new ConsensusRoundIdentifier(1, 4);
 
-    final PreparedCertificate prepCert =
-        createValidPreparedCertificate(
+    final TerminatedRoundArtefacts termintedRoundArtefacts =
+        createValidTerminatedRoundArtefacts(
             context,
             new ConsensusRoundIdentifier(1, 2),
             context.createBlockForProposalFromChainHead(2, ARBITRARY_BLOCKTIME));
@@ -278,7 +282,7 @@ public class RoundChangeTest {
     roundChangeMessages.add(
         peers
             .getProposer()
-            .injectRoundChange(targetRound, Optional.of(prepCert))
+            .injectRoundChange(targetRound, Optional.of(termintedRoundArtefacts))
             .getSignedPayload());
 
     // Attempt to override the previously received RoundChange (but now without a payload).
@@ -296,7 +300,8 @@ public class RoundChangeTest {
             new RoundChangeCertificate(Lists.newArrayList(roundChangeMessages)),
             localNodeMessageFactory
                 .createSignedProposalPayload(targetRound, expectedBlockToPropose)
-                .getSignedPayload());
+                .getSignedPayload(),
+            expectedBlockToPropose);
 
     peers.verifyMessagesReceived(expectedNewRound);
   }
@@ -333,18 +338,17 @@ public class RoundChangeTest {
     final RoundChange rc3 = peers.getNonProposing(2).injectRoundChange(targetRound, empty());
 
     // create illegal RoundChangeMessage
-    final PreparedCertificate illegalPreparedCertificate =
-        new PreparedCertificate(
+    final TerminatedRoundArtefacts illegalTerminatedRoundArtefacts =
+        new TerminatedRoundArtefacts(
             peers
                 .getNonProposing(0)
                 .getMessageFactory()
-                .createSignedProposalPayload(roundId, blockToPropose)
-                .getSignedPayload(),
+                .createSignedProposalPayload(roundId, blockToPropose),
             emptyList());
 
     peers
         .getNonProposing(2)
-        .injectRoundChange(targetRound, Optional.of(illegalPreparedCertificate));
+        .injectRoundChange(targetRound, Optional.of(illegalTerminatedRoundArtefacts));
 
     // Ensure no NewRound message is sent.
     peers.verifyNoMessagesReceived();

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
@@ -58,8 +58,8 @@ public class IbftBlockInterface implements BlockInterface {
     return ibftExtraData.getRound();
   }
 
-  public static Block replaceRoundInBlock(final Block block, final int round,
-      final BlockHashFunction blockHashFunction) {
+  public static Block replaceRoundInBlock(
+      final Block block, final int round, final BlockHashFunction blockHashFunction) {
     final IbftExtraData prevExtraData = IbftExtraData.decode(block.getHeader().getExtraData());
     final IbftExtraData substituteExtraData =
         new IbftExtraData(

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
@@ -16,10 +16,12 @@ import tech.pegasys.pantheon.consensus.common.BlockInterface;
 import tech.pegasys.pantheon.consensus.common.ValidatorVote;
 import tech.pegasys.pantheon.consensus.common.VoteType;
 import tech.pegasys.pantheon.ethereum.core.Address;
+import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 
 import java.util.Collection;
 import java.util.Optional;
+import tech.pegasys.pantheon.ethereum.core.BlockHeaderBuilder;
 
 public class IbftBlockInterface implements BlockInterface {
 
@@ -53,5 +55,28 @@ public class IbftBlockInterface implements BlockInterface {
   public int roundOfBlock(final BlockHeader header) {
     final IbftExtraData ibftExtraData = IbftExtraData.decode(header.getExtraData());
     return ibftExtraData.getRound();
+  }
+
+  public static Block replaceRoundInBlock(final Block block, final int round) {
+    final IbftExtraData prevExtraData = IbftExtraData.decode(block.getHeader().getExtraData());
+    final IbftExtraData substituteExtraData =
+        new IbftExtraData(
+            prevExtraData.getVanityData(),
+            prevExtraData.getSeals(),
+            prevExtraData.getVote(),
+            round,
+            prevExtraData.getValidators());
+
+    final BlockHeaderBuilder headerBuilder = BlockHeaderBuilder.fromHeader(block.getHeader());
+    headerBuilder
+        .extraData(substituteExtraData.encode())
+        .blockHashFunction(
+            blockHeader ->
+                IbftBlockHashing.calculateDataHashForCommittedSeal(
+                    blockHeader, substituteExtraData));
+
+    final BlockHeader newHeader = headerBuilder.buildBlockHeader();
+
+    return new Block(newHeader, block.getBody());
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
@@ -18,10 +18,10 @@ import tech.pegasys.pantheon.consensus.common.VoteType;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
+import tech.pegasys.pantheon.ethereum.core.BlockHeaderBuilder;
 
 import java.util.Collection;
 import java.util.Optional;
-import tech.pegasys.pantheon.ethereum.core.BlockHeaderBuilder;
 
 public class IbftBlockInterface implements BlockInterface {
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
@@ -49,4 +49,9 @@ public class IbftBlockInterface implements BlockInterface {
     final IbftExtraData ibftExtraData = IbftExtraData.decode(header.getExtraData());
     return ibftExtraData.getValidators();
   }
+
+  public int roundOfBlock(final BlockHeader header) {
+    final IbftExtraData ibftExtraData = IbftExtraData.decode(header.getExtraData());
+    return ibftExtraData.getRound();
+  }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftBlockInterface.java
@@ -17,6 +17,7 @@ import tech.pegasys.pantheon.consensus.common.ValidatorVote;
 import tech.pegasys.pantheon.consensus.common.VoteType;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
+import tech.pegasys.pantheon.ethereum.core.BlockHashFunction;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 import tech.pegasys.pantheon.ethereum.core.BlockHeaderBuilder;
 
@@ -57,7 +58,8 @@ public class IbftBlockInterface implements BlockInterface {
     return ibftExtraData.getRound();
   }
 
-  public static Block replaceRoundInBlock(final Block block, final int round) {
+  public static Block replaceRoundInBlock(final Block block, final int round,
+      final BlockHashFunction blockHashFunction) {
     final IbftExtraData prevExtraData = IbftExtraData.decode(block.getHeader().getExtraData());
     final IbftExtraData substituteExtraData =
         new IbftExtraData(

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpers.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpers.java
@@ -59,4 +59,28 @@ public class IbftHelpers {
 
     return new Block(sealedHeader, block.getBody());
   }
+
+  public static Optional<PreparedCertificate> findLatestPreparedCertificate(
+      final Collection<SignedData<RoundChangePayload>> msgs) {
+
+    Optional<PreparedCertificate> result = Optional.empty();
+
+    for (SignedData<RoundChangePayload> roundChangeMsg : msgs) {
+      final RoundChangePayload payload = roundChangeMsg.getPayload();
+      if (payload.getPreparedCertificate().isPresent()) {
+        if (!result.isPresent()) {
+          result = payload.getPreparedCertificate();
+        } else {
+          final PreparedCertificate currentLatest = result.get();
+          final PreparedCertificate nextCert = payload.getPreparedCertificate().get();
+
+          if (currentLatest.getProposalPayload().getPayload().getRoundIdentifier().getRoundNumber()
+              < nextCert.getProposalPayload().getPayload().getRoundIdentifier().getRoundNumber()) {
+            result = Optional.of(nextCert);
+          }
+        }
+      }
+    }
+    return result;
+  }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpers.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpers.java
@@ -59,28 +59,4 @@ public class IbftHelpers {
 
     return new Block(sealedHeader, block.getBody());
   }
-
-  public static Optional<PreparedCertificate> findLatestPreparedCertificate(
-      final Collection<SignedData<RoundChangePayload>> msgs) {
-
-    Optional<PreparedCertificate> result = Optional.empty();
-
-    for (SignedData<RoundChangePayload> roundChangeMsg : msgs) {
-      final RoundChangePayload payload = roundChangeMsg.getPayload();
-      if (payload.getPreparedCertificate().isPresent()) {
-        if (!result.isPresent()) {
-          result = payload.getPreparedCertificate();
-        } else {
-          final PreparedCertificate currentLatest = result.get();
-          final PreparedCertificate nextCert = payload.getPreparedCertificate().get();
-
-          if (currentLatest.getProposalPayload().getPayload().getRoundIdentifier().getRoundNumber()
-              < nextCert.getProposalPayload().getPayload().getRoundIdentifier().getRoundNumber()) {
-            result = Optional.of(nextCert);
-          }
-        }
-      }
-    }
-    return result;
-  }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageData.java
@@ -32,7 +32,7 @@ public class NewRoundMessageData extends AbstractIbftMessageData {
   }
 
   public NewRound decode() {
-    return new NewRound(SignedData.readSignedNewRoundPayloadFrom(RLP.input(data)));
+    return NewRound.decode(data);
   }
 
   public static NewRoundMessageData create(final NewRound newRound) {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/NewRoundMessageData.java
@@ -13,9 +13,7 @@
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
-import tech.pegasys.pantheon.ethereum.rlp.RLP;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class NewRoundMessageData extends AbstractIbftMessageData {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageData.java
@@ -32,11 +32,10 @@ public class ProposalMessageData extends AbstractIbftMessageData {
   }
 
   public Proposal decode() {
-    return new Proposal(SignedData.readSignedProposalPayloadFrom(RLP.input(data)));
+    return Proposal.decode(data);
   }
 
   public static ProposalMessageData create(final Proposal proposal) {
-
     return new ProposalMessageData(proposal.encode());
   }
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/ProposalMessageData.java
@@ -13,9 +13,7 @@
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
-import tech.pegasys.pantheon.ethereum.rlp.RLP;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class ProposalMessageData extends AbstractIbftMessageData {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageData.java
@@ -13,9 +13,7 @@
 package tech.pegasys.pantheon.consensus.ibft.messagedata;
 
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
-import tech.pegasys.pantheon.ethereum.rlp.RLP;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class RoundChangeMessageData extends AbstractIbftMessageData {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagedata/RoundChangeMessageData.java
@@ -32,7 +32,7 @@ public class RoundChangeMessageData extends AbstractIbftMessageData {
   }
 
   public RoundChange decode() {
-    return new RoundChange(SignedData.readSignedRoundChangePayloadFrom(RLP.input(data)));
+    return RoundChange.decode(data);
   }
 
   public static RoundChangeMessageData create(final RoundChange signedPayload) {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Commit.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Commit.java
@@ -24,10 +24,10 @@ public class Commit extends IbftMessage<CommitPayload> {
   }
 
   public Signature getCommitSeal() {
-    return getSignedPayload().getPayload().getCommitSeal();
+    return getPayload().getCommitSeal();
   }
 
   public Hash getDigest() {
-    return getSignedPayload().getPayload().getDigest();
+    return getPayload().getDigest();
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Commit.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Commit.java
@@ -14,10 +14,20 @@ package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
 
 import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
+import tech.pegasys.pantheon.ethereum.core.Hash;
 
 public class Commit extends IbftMessage<CommitPayload> {
 
   public Commit(final SignedData<CommitPayload> payload) {
     super(payload);
+  }
+
+  public Signature getCommitSeal() {
+    return getSignedPayload().getPayload().getCommitSeal();
+  }
+
+  public Hash getDigest() {
+    return getSignedPayload().getPayload().getDigest();
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/IbftMessage.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/IbftMessage.java
@@ -18,6 +18,7 @@ import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundSpecific;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.core.Address;
+import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class IbftMessage<P extends Payload> implements Authored, RoundSpecific {
@@ -39,7 +40,9 @@ public class IbftMessage<P extends Payload> implements Authored, RoundSpecific {
   }
 
   public BytesValue encode() {
-    return payload.encode();
+    final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
+    payload.writeTo(rlpOut);
+    return rlpOut.encoded();
   }
 
   public SignedData<P> getSignedPayload() {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/IbftMessage.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/IbftMessage.java
@@ -49,4 +49,8 @@ public class IbftMessage<P extends Payload> implements Authored, RoundSpecific {
   public int getMessageType() {
     return payload.getPayload().getMessageType();
   }
+
+  protected P getPayload() {
+    return payload.getPayload();
+  }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/NewRound.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/NewRound.java
@@ -18,7 +18,6 @@ import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.core.Block;
-import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPInput;
 import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
 import tech.pegasys.pantheon.ethereum.rlp.RLP;
 import tech.pegasys.pantheon.ethereum.rlp.RLPInput;
@@ -26,10 +25,9 @@ import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class NewRound extends IbftMessage<NewRoundPayload> {
 
-  final private Block proposedBlock;
+  private final Block proposedBlock;
 
-  public NewRound(final SignedData<NewRoundPayload> payload,
-      final Block proposedBlock) {
+  public NewRound(final SignedData<NewRoundPayload> payload, final Block proposedBlock) {
     super(payload);
     this.proposedBlock = proposedBlock;
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/NewRound.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/NewRound.java
@@ -48,8 +48,8 @@ public class NewRound extends IbftMessage<NewRoundPayload> {
   public BytesValue encode() {
     final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
     rlpOut.startList();
-    rlpOut.writeBytesValue(getSignedPayload().encode());
-    rlpOut.writeBytesValue(proposedBlock.toRlp());
+    getSignedPayload().writeTo(rlpOut);
+    proposedBlock.writeTo(rlpOut);
     rlpOut.endList();
     return rlpOut.encoded();
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Prepare.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Prepare.java
@@ -23,6 +23,6 @@ public class Prepare extends IbftMessage<PreparePayload> {
   }
 
   public Hash getDigest() {
-    return getSignedPayload().getPayload().getDigest();
+    return getPayload().getDigest();
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Prepare.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Prepare.java
@@ -14,10 +14,15 @@ package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
 
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.ethereum.core.Hash;
 
 public class Prepare extends IbftMessage<PreparePayload> {
 
   public Prepare(final SignedData<PreparePayload> payload) {
     super(payload);
+  }
+
+  public Hash getDigest() {
+    return getSignedPayload().getPayload().getDigest();
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Proposal.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Proposal.java
@@ -13,7 +13,6 @@
 package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
 
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
-import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.core.Block;
@@ -25,7 +24,7 @@ import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class Proposal extends IbftMessage<ProposalPayload> {
 
-  final private Block proposedBlock;
+  private final Block proposedBlock;
 
   public Proposal(final SignedData<ProposalPayload> payload, final Block proposedBlock) {
     super(payload);

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Proposal.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/Proposal.java
@@ -43,8 +43,8 @@ public class Proposal extends IbftMessage<ProposalPayload> {
   public BytesValue encode() {
     final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
     rlpOut.startList();
-    rlpOut.writeBytesValue(getSignedPayload().encode());
-    rlpOut.writeBytesValue(proposedBlock.toRlp());
+    getSignedPayload().writeTo(rlpOut);
+    proposedBlock.writeTo(rlpOut);
     rlpOut.endList();
     return rlpOut.encoded();
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
@@ -66,6 +66,9 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
       proposedBlock =
           Optional.of(Block.readFrom(rlpIn, IbftBlockHashing::calculateDataHashForCommittedSeal));
     }
+    else {
+      rlpIn.skipNext();
+    }
     rlpIn.leaveList();
     return new RoundChange(payload, proposedBlock);
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
@@ -65,8 +65,7 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
     if (!rlpIn.nextIsNull()) {
       proposedBlock =
           Optional.of(Block.readFrom(rlpIn, IbftBlockHashing::calculateDataHashForCommittedSeal));
-    }
-    else {
+    } else {
       rlpIn.skipNext();
     }
     rlpIn.leaveList();

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
@@ -39,7 +39,7 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
   }
 
   public Optional<PreparedCertificate> getPreparedCertificate() {
-    getPayload().getPreparedCertificate();
+    return getPayload().getPreparedCertificate();
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
@@ -12,9 +12,7 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
 
-import java.util.Optional;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
-import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
@@ -24,12 +22,14 @@ import tech.pegasys.pantheon.ethereum.rlp.RLP;
 import tech.pegasys.pantheon.ethereum.rlp.RLPInput;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
+import java.util.Optional;
+
 public class RoundChange extends IbftMessage<RoundChangePayload> {
 
-  final private Optional<Block> proposedBlock;
+  private final Optional<Block> proposedBlock;
 
-  public RoundChange(final SignedData<RoundChangePayload> payload,
-      final Optional<Block> proposedBlock) {
+  public RoundChange(
+      final SignedData<RoundChangePayload> payload, final Optional<Block> proposedBlock) {
     super(payload);
     this.proposedBlock = proposedBlock;
   }
@@ -47,10 +47,9 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
     final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
     rlpOut.startList();
     rlpOut.writeBytesValue(getSignedPayload().encode());
-    if(proposedBlock.isPresent()) {
+    if (proposedBlock.isPresent()) {
       rlpOut.writeBytesValue(proposedBlock.get().toRlp());
-    }
-    else {
+    } else {
       rlpOut.writeNull();
     }
     rlpOut.endList();

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
@@ -15,6 +15,7 @@ package tech.pegasys.pantheon.consensus.ibft.messagewrappers;
 import java.util.Optional;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.core.Block;
@@ -35,6 +36,10 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
 
   public Optional<Block> getProposedBlock() {
     return proposedBlock;
+  }
+
+  public Optional<PreparedCertificate> getPreparedCertificate() {
+    getPayload().getPreparedCertificate();
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/messagewrappers/RoundChange.java
@@ -46,9 +46,9 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
   public BytesValue encode() {
     final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
     rlpOut.startList();
-    rlpOut.writeBytesValue(getSignedPayload().encode());
+    getSignedPayload().writeTo(rlpOut);
     if (proposedBlock.isPresent()) {
-      rlpOut.writeBytesValue(proposedBlock.get().toRlp());
+      proposedBlock.get().writeTo(rlpOut);
     } else {
       rlpOut.writeNull();
     }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/IbftMessageTransmitter.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/IbftMessageTransmitter.java
@@ -24,10 +24,7 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Block;
@@ -93,7 +90,9 @@ public class IbftMessageTransmitter {
 
     final NewRound signedPayload =
         messageFactory.createSignedNewRoundPayload(
-            roundIdentifier, roundChangeCertificate, proposal.getSignedPayload(),
+            roundIdentifier,
+            roundChangeCertificate,
+            proposal.getSignedPayload(),
             proposal.getBlock());
 
     final NewRoundMessageData message = NewRoundMessageData.create(signedPayload);

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/IbftMessageTransmitter.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/IbftMessageTransmitter.java
@@ -28,6 +28,7 @@ import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.Hash;
@@ -75,10 +76,10 @@ public class IbftMessageTransmitter {
 
   public void multicastRoundChange(
       final ConsensusRoundIdentifier roundIdentifier,
-      final Optional<PreparedCertificate> preparedCertificate) {
+      final Optional<TerminatedRoundArtefacts> artefacts) {
 
     final RoundChange data =
-        messageFactory.createSignedRoundChangePayload(roundIdentifier, preparedCertificate);
+        messageFactory.createSignedRoundChangePayload(roundIdentifier, artefacts);
 
     final RoundChangeMessageData message = RoundChangeMessageData.create(data);
 
@@ -88,11 +89,12 @@ public class IbftMessageTransmitter {
   public void multicastNewRound(
       final ConsensusRoundIdentifier roundIdentifier,
       final RoundChangeCertificate roundChangeCertificate,
-      final SignedData<ProposalPayload> proposalPayload) {
+      final Proposal proposal) {
 
     final NewRound signedPayload =
         messageFactory.createSignedNewRoundPayload(
-            roundIdentifier, roundChangeCertificate, proposalPayload);
+            roundIdentifier, roundChangeCertificate, proposal.getSignedPayload(),
+            proposal.getBlock());
 
     final NewRoundMessageData message = NewRoundMessageData.create(signedPayload);
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/MessageFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/MessageFactory.java
@@ -68,14 +68,14 @@ public class MessageFactory {
       final Optional<TerminatedRoundArtefacts> artefacts) {
 
     if (artefacts.isPresent()) {
-      final RoundChangePayload payload = new RoundChangePayload(roundIdentifier,
-          Optional.of(artefacts.get().getPreparedCertificate()));
+      final RoundChangePayload payload =
+          new RoundChangePayload(
+              roundIdentifier, Optional.of(artefacts.get().getPreparedCertificate()));
       return new RoundChange(createSignedMessage(payload), Optional.of(artefacts.get().getBlock()));
     }
 
     final RoundChangePayload payload = new RoundChangePayload(roundIdentifier, Optional.empty());
     return new RoundChange(createSignedMessage(payload), Optional.empty());
-
   }
 
   public NewRound createSignedNewRoundPayload(

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/ProposalPayload.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/ProposalPayload.java
@@ -13,9 +13,7 @@
 package tech.pegasys.pantheon.consensus.ibft.payload;
 
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
-import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.IbftV2;
-import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.rlp.RLPInput;
 import tech.pegasys.pantheon.ethereum.rlp.RLPOutput;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/ProposalPayload.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/ProposalPayload.java
@@ -16,6 +16,7 @@ import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.messagedata.IbftV2;
 import tech.pegasys.pantheon.ethereum.core.Block;
+import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.rlp.RLPInput;
 import tech.pegasys.pantheon.ethereum.rlp.RLPOutput;
 
@@ -25,33 +26,32 @@ import java.util.StringJoiner;
 public class ProposalPayload implements Payload {
   private static final int TYPE = IbftV2.PROPOSAL;
   private final ConsensusRoundIdentifier roundIdentifier;
-  private final Block block;
+  private final Hash digest;
 
-  public ProposalPayload(final ConsensusRoundIdentifier roundIdentifier, final Block block) {
+  public ProposalPayload(final ConsensusRoundIdentifier roundIdentifier, final Hash digest) {
     this.roundIdentifier = roundIdentifier;
-    this.block = block;
+    this.digest = digest;
   }
 
   public static ProposalPayload readFrom(final RLPInput rlpInput) {
     rlpInput.enterList();
     final ConsensusRoundIdentifier roundIdentifier = ConsensusRoundIdentifier.readFrom(rlpInput);
-    final Block block =
-        Block.readFrom(rlpInput, IbftBlockHashing::calculateDataHashForCommittedSeal);
+    final Hash digest = Hash.wrap(rlpInput.readBytes32());
     rlpInput.leaveList();
 
-    return new ProposalPayload(roundIdentifier, block);
+    return new ProposalPayload(roundIdentifier, digest);
   }
 
   @Override
   public void writeTo(final RLPOutput rlpOutput) {
     rlpOutput.startList();
     roundIdentifier.writeTo(rlpOutput);
-    block.writeTo(rlpOutput);
+    rlpOutput.writeBytesValue(digest);
     rlpOutput.endList();
   }
 
-  public Block getBlock() {
-    return block;
+  public Hash getDigest() {
+    return digest;
   }
 
   @Override
@@ -74,19 +74,19 @@ public class ProposalPayload implements Payload {
     }
     final ProposalPayload that = (ProposalPayload) o;
     return Objects.equals(roundIdentifier, that.roundIdentifier)
-        && Objects.equals(block, that.block);
+        && Objects.equals(digest, that.digest);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(roundIdentifier, block);
+    return Objects.hash(roundIdentifier, digest);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", ProposalPayload.class.getSimpleName() + "[", "]")
         .add("roundIdentifier=" + roundIdentifier)
-        .add("block=" + block)
+        .add("digest=" + digest)
         .toString();
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/SignedData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/SignedData.java
@@ -15,10 +15,8 @@ package tech.pegasys.pantheon.consensus.ibft.payload;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Util;
-import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
 import tech.pegasys.pantheon.ethereum.rlp.RLPInput;
 import tech.pegasys.pantheon.ethereum.rlp.RLPOutput;
-import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.util.Objects;
 import java.util.StringJoiner;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/SignedData.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/payload/SignedData.java
@@ -51,12 +51,6 @@ public class SignedData<M extends Payload> implements Authored {
     output.endList();
   }
 
-  public BytesValue encode() {
-    final BytesValueRLPOutput rlpEncode = new BytesValueRLPOutput();
-    writeTo(rlpEncode);
-    return rlpEncode.encoded();
-  }
-
   public static SignedData<ProposalPayload> readSignedProposalPayloadFrom(final RLPInput rlpInput) {
 
     rlpInput.enterList();

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -29,7 +29,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.network.IbftMessageTransmitter;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
-import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.RoundChangeManager.RoundChangeArtefacts;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidatorFactory;
 import tech.pegasys.pantheon.consensus.ibft.validation.NewRoundMessageValidator;
@@ -143,12 +142,12 @@ public class IbftBlockHeightManager implements BlockHeightManager {
 
     startNewRound(currentRound.getRoundIdentifier().getRoundNumber() + 1);
 
-    final RoundChange localRoundChange = messageFactory.createSignedRoundChangePayload(
-        currentRound.getRoundIdentifier(),
-        latestAcceptableRoundArtefacts);
+    final RoundChange localRoundChange =
+        messageFactory.createSignedRoundChangePayload(
+            currentRound.getRoundIdentifier(), latestAcceptableRoundArtefacts);
 
-    transmitter.multicastRoundChange(currentRound.getRoundIdentifier(),
-        latestAcceptableRoundArtefacts);
+    transmitter.multicastRoundChange(
+        currentRound.getRoundIdentifier(), latestAcceptableRoundArtefacts);
 
     // Its possible the locally created RoundChange triggers the transmission of a NewRound
     // message - so it must be handled accordingly.

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -29,8 +29,8 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.network.IbftMessageTransmitter;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.RoundChangeManager.RoundChangeArtefacts;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidatorFactory;
 import tech.pegasys.pantheon.consensus.ibft.validation.NewRoundMessageValidator;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
@@ -70,7 +70,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
   private final Function<ConsensusRoundIdentifier, RoundState> roundStateCreator;
   private final IbftFinalState finalState;
 
-  private Optional<PreparedCertificate> latestPreparedCertificate = Optional.empty();
+  private Optional<TerminatedRoundArtefacts> latestAcceptableRoundArtefacts = Optional.empty();
 
   private IbftRound currentRound;
 
@@ -134,19 +134,21 @@ public class IbftBlockHeightManager implements BlockHeightManager {
     LOG.info(
         "Round has expired, creating PreparedCertificate and notifying peers. round={}",
         currentRound.getRoundIdentifier());
-    final Optional<PreparedCertificate> preparedCertificate =
-        currentRound.createPrepareCertificate();
+    final Optional<TerminatedRoundArtefacts> preparedCertificate =
+        currentRound.getTerminatedRoundArtefacts();
 
     if (preparedCertificate.isPresent()) {
-      latestPreparedCertificate = preparedCertificate;
+      latestAcceptableRoundArtefacts = preparedCertificate;
     }
 
     startNewRound(currentRound.getRoundIdentifier().getRoundNumber() + 1);
 
-    final RoundChange localRoundChange =
-        messageFactory.createSignedRoundChangePayload(
-            currentRound.getRoundIdentifier(), latestPreparedCertificate);
-    transmitter.multicastRoundChange(currentRound.getRoundIdentifier(), latestPreparedCertificate);
+    final RoundChange localRoundChange = messageFactory.createSignedRoundChangePayload(
+        currentRound.getRoundIdentifier(),
+        latestAcceptableRoundArtefacts);
+
+    transmitter.multicastRoundChange(currentRound.getRoundIdentifier(),
+        latestAcceptableRoundArtefacts);
 
     // Its possible the locally created RoundChange triggers the transmission of a NewRound
     // message - so it must be handled accordingly.
@@ -202,7 +204,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
       return;
     }
 
-    final Optional<RoundChangeCertificate> result =
+    final Optional<RoundChangeArtefacts> result =
         roundChangeManager.appendRoundChangeMessage(message);
     if (result.isPresent()) {
       if (messageAge == FUTURE_ROUND) {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -253,7 +253,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
 
   @Override
   public long getChainHeight() {
-    return currentRound.getRoundIdentifier().getSequenceNumber();
+    return parentHeader.getNumber() + 1;
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -98,7 +98,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
             new RoundState(
                 roundIdentifier,
                 finalState.getQuorum(),
-                messageValidatorFactory.createMessageValidator(roundIdentifier, parentHeader));
+                messageValidatorFactory.createMessageValidator(roundIdentifier));
   }
 
   @Override
@@ -244,7 +244,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
     }
     LOG.info("Received NewRound Payload for {}", newRound.getRoundIdentifier());
 
-    if (newRoundMessageValidator.validateNewRoundMessage(newRound.getSignedPayload())) {
+    if (newRoundMessageValidator.validateNewRoundMessage(newRound)) {
       if (messageAge == FUTURE_ROUND) {
         startNewRound(newRound.getRoundIdentifier().getRoundNumber());
       }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -91,7 +91,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
     this.roundChangeManager = roundChangeManager;
     this.finalState = finalState;
 
-    newRoundMessageValidator = messageValidatorFactory.createNewRoundValidator(parentHeader);
+    newRoundMessageValidator = messageValidatorFactory.createNewRoundValidator(getChainHeight());
 
     roundStateCreator =
         (roundIdentifier) ->

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerFactory.java
@@ -49,8 +49,8 @@ public class IbftBlockHeightManagerFactory {
         finalState,
         new RoundChangeManager(
             IbftHelpers.calculateRequiredValidatorQuorum(finalState.getValidators().size()),
-            messageValidatorFactory
-                .createRoundChangeMessageValidator(parentHeader.getNumber() + 1)),
+            messageValidatorFactory.createRoundChangeMessageValidator(
+                parentHeader.getNumber() + 1)),
         roundFactory,
         finalState.getClock(),
         messageValidatorFactory);

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerFactory.java
@@ -49,7 +49,8 @@ public class IbftBlockHeightManagerFactory {
         finalState,
         new RoundChangeManager(
             IbftHelpers.calculateRequiredValidatorQuorum(finalState.getValidators().size()),
-            messageValidatorFactory.createRoundChangeMessageValidator(parentHeader)),
+            messageValidatorFactory
+                .createRoundChangeMessageValidator(parentHeader.getNumber() + 1)),
         roundFactory,
         finalState.getClock(),
         messageValidatorFactory);

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
@@ -12,9 +12,6 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.statemachine;
 
-import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
@@ -40,6 +37,11 @@ import tech.pegasys.pantheon.ethereum.core.BlockImporter;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
 import tech.pegasys.pantheon.util.Subscribers;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class IbftRound {
 
@@ -116,7 +118,6 @@ public class IbftRound {
         IbftBlockInterface.replaceRoundInBlock(block, getRoundIdentifier().getRoundNumber());
     return messageFactory.createSignedProposalPayload(getRoundIdentifier(), blockToPublish);
   }
-
 
   public void handleProposalMessage(final Proposal msg) {
     LOG.info("Handling a Proposal message.");

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
@@ -115,7 +115,9 @@ public class IbftRound {
 
   private Proposal createProposalAroundBlock(final Block block) {
     final Block blockToPublish =
-        IbftBlockInterface.replaceRoundInBlock(block, getRoundIdentifier().getRoundNumber(),
+        IbftBlockInterface.replaceRoundInBlock(
+            block,
+            getRoundIdentifier().getRoundNumber(),
             IbftBlockHashing::calculateDataHashForCommittedSeal);
     return messageFactory.createSignedProposalPayload(getRoundIdentifier(), blockToPublish);
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
@@ -12,8 +12,9 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.statemachine;
 
-import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.findLatestPreparedCertificate;
-
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
@@ -27,8 +28,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.network.IbftMessageTransmitter;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.RoundChangeManager.RoundChangeArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
@@ -37,16 +36,10 @@ import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.chain.MinedBlockObserver;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
-import tech.pegasys.pantheon.ethereum.core.BlockHeaderBuilder;
 import tech.pegasys.pantheon.ethereum.core.BlockImporter;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
 import tech.pegasys.pantheon.util.Subscribers;
-
-import java.util.Optional;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class IbftRound {
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRound.java
@@ -115,7 +115,8 @@ public class IbftRound {
 
   private Proposal createProposalAroundBlock(final Block block) {
     final Block blockToPublish =
-        IbftBlockInterface.replaceRoundInBlock(block, getRoundIdentifier().getRoundNumber());
+        IbftBlockInterface.replaceRoundInBlock(block, getRoundIdentifier().getRoundNumber(),
+            IbftBlockHashing::calculateDataHashForCommittedSeal);
     return messageFactory.createSignedProposalPayload(getRoundIdentifier(), blockToPublish);
   }
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundFactory.java
@@ -56,7 +56,7 @@ public class IbftRoundFactory {
         new RoundState(
             roundIdentifier,
             finalState.getQuorum(),
-            messageValidatorFactory.createMessageValidator(roundIdentifier, parentHeader));
+            messageValidatorFactory.createMessageValidator(roundIdentifier));
 
     return createNewRoundWithState(parentHeader, roundState);
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundFactory.java
@@ -16,9 +16,7 @@ import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftContext;
 import tech.pegasys.pantheon.consensus.ibft.blockcreation.IbftBlockCreator;
 import tech.pegasys.pantheon.consensus.ibft.blockcreation.IbftBlockCreatorFactory;
-import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidatorFactory;
-import tech.pegasys.pantheon.ethereum.BlockValidator;
 import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.chain.MinedBlockObserver;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
@@ -38,7 +36,7 @@ public class IbftRoundFactory {
       final ProtocolContext<IbftContext> protocolContext,
       final ProtocolSchedule<IbftContext> protocolSchedule,
       final Subscribers<MinedBlockObserver> minedBlockObservers,
-      MessageValidatorFactory messageValidatorFactory) {
+      final MessageValidatorFactory messageValidatorFactory) {
     this.finalState = finalState;
     this.blockCreatorFactory = finalState.getBlockCreatorFactory();
     this.protocolContext = protocolContext;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManager.java
@@ -18,6 +18,7 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeMessageValidator;
 import tech.pegasys.pantheon.ethereum.core.Address;
+import tech.pegasys.pantheon.ethereum.core.Block;
 
 import java.util.Map;
 import java.util.Optional;
@@ -27,7 +28,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.pantheon.ethereum.core.Block;
 
 /**
  * Responsible for handling all RoundChange messages received for a given block height
@@ -60,7 +60,6 @@ public class RoundChangeManager {
     }
   }
 
-
   public static class RoundChangeStatus {
 
     private final long quorum;
@@ -68,8 +67,7 @@ public class RoundChangeManager {
     private final IbftBlockInterface blockInterface = new IbftBlockInterface();
 
     // Store only 1 round change per round per validator
-    @VisibleForTesting
-    final Map<Address, RoundChange> receivedMessages = Maps.newLinkedHashMap();
+    @VisibleForTesting final Map<Address, RoundChange> receivedMessages = Maps.newLinkedHashMap();
 
     private boolean actioned = false;
 
@@ -82,7 +80,6 @@ public class RoundChangeManager {
         receivedMessages.putIfAbsent(msg.getAuthor(), msg);
         updateSelectedBlock(msg.getProposedBlock());
       }
-
     }
 
     private void updateSelectedBlock(final Optional<Block> reportedBlock) {
@@ -92,8 +89,8 @@ public class RoundChangeManager {
       }
 
       if (reportedBlock.isPresent()) {
-        if (blockInterface.roundOfBlock(reportedBlock.get().getHeader()) >
-            blockInterface.roundOfBlock(selectedBlock.get().getHeader())) {
+        if (blockInterface.roundOfBlock(reportedBlock.get().getHeader())
+            > blockInterface.roundOfBlock(selectedBlock.get().getHeader())) {
           selectedBlock = reportedBlock;
         }
       }
@@ -106,12 +103,13 @@ public class RoundChangeManager {
     public RoundChangeArtefacts createRoundChangeArtefacts() {
       if (roundChangeReady()) {
         actioned = true;
-        final RoundChangeCertificate certificate = new RoundChangeCertificate(
-            receivedMessages
-                .values()
-                .stream()
-                .map(RoundChange::getSignedPayload)
-                .collect(Collectors.toList()));
+        final RoundChangeCertificate certificate =
+            new RoundChangeCertificate(
+                receivedMessages
+                    .values()
+                    .stream()
+                    .map(RoundChange::getSignedPayload)
+                    .collect(Collectors.toList()));
         return new RoundChangeArtefacts(certificate, selectedBlock);
       } else {
         throw new IllegalStateException("Unable to create RoundChangeCertificate at this time.");
@@ -138,7 +136,7 @@ public class RoundChangeManager {
    *
    * @param msg The signed round change message to add
    * @return Empty if the round change threshold hasn't been hit, otherwise a round change
-   * certificate
+   *     certificate
    */
   public Optional<RoundChangeArtefacts> appendRoundChangeMessage(final RoundChange msg) {
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManager.java
@@ -157,7 +157,7 @@ public class RoundChangeManager {
   }
 
   private boolean isMessageValid(final RoundChange msg) {
-    return roundChangeMessageValidator.validateMessage(msg.getSignedPayload());
+    return roundChangeMessageValidator.validateMessage(msg);
   }
 
   private RoundChangeStatus storeRoundChangeMessage(final RoundChange msg) {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundState.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundState.java
@@ -125,19 +125,13 @@ public class RoundState {
   public Collection<Signature> getCommitSeals() {
     return commitPayloads
         .stream()
-        .map(cp -> cp.getSignedPayload().getPayload().getCommitSeal())
+        .map(Commit::getCommitSeal)
         .collect(Collectors.toList());
   }
 
-  public Optional<PreparedCertificate> constructPreparedCertificate() {
+  public Optional<TerminatedRoundArtefacts> getReceivedArtefacts() {
     if (isPrepared()) {
-      return Optional.of(
-          new PreparedCertificate(
-              proposalMessage.get().getSignedPayload(),
-              preparePayloads
-                  .stream()
-                  .map(Prepare::getSignedPayload)
-                  .collect(Collectors.toList())));
+      return Optional.of(new TerminatedRoundArtefacts(proposalMessage.get(), preparePayloads));
     }
     return Optional.empty();
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundState.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundState.java
@@ -121,10 +121,7 @@ public class RoundState {
   }
 
   public Collection<Signature> getCommitSeals() {
-    return commitPayloads
-        .stream()
-        .map(Commit::getCommitSeal)
-        .collect(Collectors.toList());
+    return commitPayloads.stream().map(Commit::getCommitSeal).collect(Collectors.toList());
   }
 
   public Optional<TerminatedRoundArtefacts> getReceivedArtefacts() {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundState.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundState.java
@@ -18,9 +18,7 @@ import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
-import tech.pegasys.pantheon.consensus.ibft.validation.SignedDataValidator;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Block;
 
@@ -67,7 +65,7 @@ public class RoundState {
   public boolean setProposedBlock(final Proposal msg) {
 
     if (!proposalMessage.isPresent()) {
-      if (validator.addSignedProposalPayload(msg)) {
+      if (validator.addProposalMessage(msg)) {
         proposalMessage = Optional.of(msg);
         preparePayloads.removeIf(p -> !validator.validatePrepareMessage(p));
         commitPayloads.removeIf(p -> !validator.validateCommitMessage(p));

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/TerminatedRoundArtefacts.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/TerminatedRoundArtefacts.java
@@ -1,0 +1,34 @@
+package tech.pegasys.pantheon.consensus.ibft.statemachine;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
+import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
+import tech.pegasys.pantheon.ethereum.core.Block;
+
+public class TerminatedRoundArtefacts {
+
+  private Proposal proposal;
+  private Collection<Prepare> prepares;
+
+  public TerminatedRoundArtefacts(
+      Proposal proposal,
+      Collection<Prepare> prepares) {
+    this.proposal = proposal;
+    this.prepares = prepares;
+  }
+
+  public Block getBlock() {
+    return proposal.getBlock();
+  }
+
+  public PreparedCertificate getPreparedCertificate() {
+    return new PreparedCertificate(
+        proposal.getSignedPayload(),
+        prepares
+            .stream()
+            .map(Prepare::getSignedPayload)
+            .collect(Collectors.toList()));
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/TerminatedRoundArtefacts.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/TerminatedRoundArtefacts.java
@@ -1,20 +1,31 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package tech.pegasys.pantheon.consensus.ibft.statemachine;
 
-import java.util.Collection;
-import java.util.stream.Collectors;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.ethereum.core.Block;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class TerminatedRoundArtefacts {
 
   private Proposal proposal;
   private Collection<Prepare> prepares;
 
-  public TerminatedRoundArtefacts(
-      Proposal proposal,
-      Collection<Prepare> prepares) {
+  public TerminatedRoundArtefacts(final Proposal proposal, final Collection<Prepare> prepares) {
     this.proposal = proposal;
     this.prepares = prepares;
   }
@@ -26,9 +37,6 @@ public class TerminatedRoundArtefacts {
   public PreparedCertificate getPreparedCertificate() {
     return new PreparedCertificate(
         proposal.getSignedPayload(),
-        prepares
-            .stream()
-            .map(Prepare::getSignedPayload)
-            .collect(Collectors.toList()));
+        prepares.stream().map(Prepare::getSignedPayload).collect(Collectors.toList()));
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
@@ -1,46 +1,28 @@
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import com.fasterxml.jackson.databind.annotation.JsonAppend.Prop;
-import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
-import tech.pegasys.pantheon.consensus.ibft.IbftContext;
-import tech.pegasys.pantheon.consensus.ibft.IbftExtraData;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
-import tech.pegasys.pantheon.ethereum.BlockValidator;
-import tech.pegasys.pantheon.ethereum.BlockValidator.BlockProcessingOutputs;
-import tech.pegasys.pantheon.ethereum.ProtocolContext;
-import tech.pegasys.pantheon.ethereum.core.Block;
-import tech.pegasys.pantheon.ethereum.core.BlockHeader;
-import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
 
 public class MessageValidator {
 
   private static final Logger LOG = LogManager.getLogger();
   private final SignedDataValidator dataValidator;
-  private final BlockValidator<IbftContext> blockValidator;
-  private final ProtocolContext<IbftContext> protocolContext;
+  private final ProposalBlockConsistencyChecker consistencyChecker;
 
   public MessageValidator(
-      SignedDataValidator dataValidator,
-      BlockValidator<IbftContext> blockValidator,
-      ProtocolContext<IbftContext> protocolContext,
-      BlockHeader parentHeader) {
+      final SignedDataValidator dataValidator,
+      final ProposalBlockConsistencyChecker consistencyChecker) {
     this.dataValidator = dataValidator;
-    this.blockValidator = blockValidator;
-    this.protocolContext = protocolContext;
+    this.consistencyChecker = consistencyChecker;
   }
 
   public boolean addProposalMessage(final Proposal msg) {
     final SignedData<ProposalPayload> signedPayload = msg.getSignedPayload();
-
-    ProposalBlockConsistencyChecker consistencyChecker = new ProposalBlockConsistencyChecker(
-        blockValidator, protocolContext);
 
     if(!consistencyChecker.validateProposalMatchesBlock(msg.getSignedPayload(), msg.getBlock())) {
       LOG.info("Invalid Proposal, Block does not validate, or does not align with proposal data.");

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
@@ -36,7 +36,7 @@ public class MessageValidator {
     this.protocolContext = protocolContext;
   }
 
-  public boolean addSignedProposalPayload(final Proposal msg) {
+  public boolean addProposalMessage(final Proposal msg) {
     final SignedData<ProposalPayload> signedPayload = msg.getSignedPayload();
 
     ProposalBlockConsistencyChecker consistencyChecker = new ProposalBlockConsistencyChecker(

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
@@ -1,12 +1,25 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class MessageValidator {
 
@@ -24,7 +37,7 @@ public class MessageValidator {
   public boolean addProposalMessage(final Proposal msg) {
     final SignedData<ProposalPayload> signedPayload = msg.getSignedPayload();
 
-    if(!consistencyChecker.validateProposalMatchesBlock(msg.getSignedPayload(), msg.getBlock())) {
+    if (!consistencyChecker.validateProposalMatchesBlock(msg.getSignedPayload(), msg.getBlock())) {
       LOG.info("Invalid Proposal, Block does not validate, or does not align with proposal data.");
     }
 
@@ -38,6 +51,4 @@ public class MessageValidator {
   public boolean validateCommitMessage(final Commit msg) {
     return dataValidator.validateCommitPayload(msg.getSignedPayload());
   }
-
-
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
@@ -1,102 +1,50 @@
-/*
- * Copyright 2018 ConsenSys AG.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
- */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
+import com.fasterxml.jackson.databind.annotation.JsonAppend.Prop;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftContext;
 import tech.pegasys.pantheon.consensus.ibft.IbftExtraData;
-import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.BlockValidator;
 import tech.pegasys.pantheon.ethereum.BlockValidator.BlockProcessingOutputs;
 import tech.pegasys.pantheon.ethereum.ProtocolContext;
-import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.BlockHeader;
-import tech.pegasys.pantheon.ethereum.core.Hash;
-import tech.pegasys.pantheon.ethereum.core.Util;
 import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
-
-import java.util.Collection;
-import java.util.Optional;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class MessageValidator {
 
   private static final Logger LOG = LogManager.getLogger();
-
-  private final Collection<Address> validators;
-  private final Address expectedProposer;
-  private final ConsensusRoundIdentifier roundIdentifier;
+  private final SignedDataValidator dataValidator;
   private final BlockValidator<IbftContext> blockValidator;
   private final ProtocolContext<IbftContext> protocolContext;
   private final BlockHeader parentHeader;
 
-  private Optional<SignedData<ProposalPayload>> proposal = Optional.empty();
-
   public MessageValidator(
-      final Collection<Address> validators,
-      final Address expectedProposer,
-      final ConsensusRoundIdentifier roundIdentifier,
-      final BlockValidator<IbftContext> blockValidator,
-      final ProtocolContext<IbftContext> protocolContext,
-      final BlockHeader parentHeader) {
-    this.validators = validators;
-    this.expectedProposer = expectedProposer;
-    this.roundIdentifier = roundIdentifier;
+      SignedDataValidator dataValidator,
+      BlockValidator<IbftContext> blockValidator,
+      ProtocolContext<IbftContext> protocolContext,
+      BlockHeader parentHeader) {
+    this.dataValidator = dataValidator;
     this.blockValidator = blockValidator;
     this.protocolContext = protocolContext;
     this.parentHeader = parentHeader;
   }
 
-  public boolean addSignedProposalPayload(final SignedData<ProposalPayload> msg) {
-
-    if (proposal.isPresent()) {
-      return handleSubsequentProposal(proposal.get(), msg);
-    }
-
-    if (!validateSignedProposalPayload(msg)) {
+  public boolean addSignedProposalPayload(final Proposal msg) {
+    final SignedData<ProposalPayload> signedPayload = msg.getSignedPayload();
+    if (!validateBlockMatchesProposalRound(signedPayload.getPayload(), msg.getBlock())) {
       return false;
     }
 
-    if (!validateBlockMatchesProposalRound(msg.getPayload())) {
-      return false;
-    }
-
-    proposal = Optional.of(msg);
-    return true;
-  }
-
-  private boolean validateSignedProposalPayload(final SignedData<ProposalPayload> msg) {
-
-    if (!msg.getPayload().getRoundIdentifier().equals(roundIdentifier)) {
-      LOG.info("Invalid Proposal message, does not match current round.");
-      return false;
-    }
-
-    if (!msg.getAuthor().equals(expectedProposer)) {
-      LOG.info(
-          "Invalid Proposal message, was not created by the proposer expected for the "
-              + "associated round.");
-      return false;
-    }
-
-    final Block proposedBlock = msg.getPayload().getBlock();
+    final Block proposedBlock = msg.getBlock();
 
     final Optional<BlockProcessingOutputs> validationResult =
         blockValidator.validateAndProcessBlock(
@@ -107,106 +55,22 @@ public class MessageValidator {
       return false;
     }
 
-    return true;
+    return dataValidator.addSignedProposalPayload(signedPayload);
   }
 
-  private boolean handleSubsequentProposal(
-      final SignedData<ProposalPayload> existingMsg, final SignedData<ProposalPayload> newMsg) {
-    if (!existingMsg.getAuthor().equals(newMsg.getAuthor())) {
-      LOG.debug("Received subsequent invalid Proposal message; sender differs from original.");
-      return false;
-    }
-
-    final ProposalPayload existingData = existingMsg.getPayload();
-    final ProposalPayload newData = newMsg.getPayload();
-
-    if (!proposalMessagesAreIdentical(existingData, newData)) {
-      LOG.debug("Received subsequent invalid Proposal message; content differs from original.");
-      return false;
-    }
-
-    return true;
+  public boolean validatePrepareMessage(final Prepare msg) {
+    return dataValidator.validatePrepareMessage(msg.getSignedPayload());
   }
 
-  public boolean validatePrepareMessage(final SignedData<PreparePayload> msg) {
-    final String msgType = "Prepare";
-
-    if (!isMessageForCurrentRoundFromValidatorAndProposalAvailable(msg, msgType)) {
-      return false;
-    }
-
-    if (msg.getAuthor().equals(expectedProposer)) {
-      LOG.info("Illegal Prepare message; was sent by the round's proposer.");
-      return false;
-    }
-
-    return validateDigestMatchesProposal(msg.getPayload().getDigest(), msgType);
+  public boolean validateCommitMessage(final Commit msg) {
+    return dataValidator.validateCommitMessage(msg.getSignedPayload());
   }
 
-  public boolean validateCommmitMessage(final SignedData<CommitPayload> msg) {
-    final String msgType = "Commit";
-
-    if (!isMessageForCurrentRoundFromValidatorAndProposalAvailable(msg, msgType)) {
-      return false;
-    }
-
-    final Block proposedBlock = proposal.get().getPayload().getBlock();
-    final Address commitSealCreator =
-        Util.signatureToAddress(msg.getPayload().getCommitSeal(), proposedBlock.getHash());
-
-    if (!commitSealCreator.equals(msg.getAuthor())) {
-      LOG.info("Invalid Commit message. Seal was not created by the message transmitter.");
-      return false;
-    }
-
-    return validateDigestMatchesProposal(msg.getPayload().getDigest(), msgType);
-  }
-
-  private boolean isMessageForCurrentRoundFromValidatorAndProposalAvailable(
-      final SignedData<? extends Payload> msg, final String msgType) {
-
-    if (!msg.getPayload().getRoundIdentifier().equals(roundIdentifier)) {
-      LOG.info("Invalid {} message, does not match current round.", msgType);
-      return false;
-    }
-
-    if (!validators.contains(msg.getAuthor())) {
-      LOG.info(
-          "Invalid {} message, was not transmitted by a validator for the " + "associated round.",
-          msgType);
-      return false;
-    }
-
-    if (!proposal.isPresent()) {
-      LOG.info(
-          "Unable to validate {} message. No Proposal exists against which to validate "
-              + "block digest.",
-          msgType);
-      return false;
-    }
-    return true;
-  }
-
-  private boolean validateDigestMatchesProposal(final Hash digest, final String msgType) {
-    final Block proposedBlock = proposal.get().getPayload().getBlock();
-    if (!digest.equals(proposedBlock.getHash())) {
-      LOG.info(
-          "Illegal {} message, digest does not match the block in the Prepare Message.", msgType);
-      return false;
-    }
-    return true;
-  }
-
-  private boolean proposalMessagesAreIdentical(
-      final ProposalPayload right, final ProposalPayload left) {
-    return right.getBlock().getHash().equals(left.getBlock().getHash())
-        && right.getRoundIdentifier().equals(left.getRoundIdentifier());
-  }
-
-  private boolean validateBlockMatchesProposalRound(final ProposalPayload payload) {
+  private boolean validateBlockMatchesProposalRound(final ProposalPayload payload,
+      final Block block) {
     final ConsensusRoundIdentifier msgRound = payload.getRoundIdentifier();
     final IbftExtraData extraData =
-        IbftExtraData.decode(payload.getBlock().getHeader().getExtraData());
+        IbftExtraData.decode(block.getHeader().getExtraData());
     if (extraData.getRound() != msgRound.getRoundNumber()) {
       LOG.info("Invalid Proposal message, round number in block does not match that in message.");
       return false;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidator.java
@@ -59,11 +59,11 @@ public class MessageValidator {
   }
 
   public boolean validatePrepareMessage(final Prepare msg) {
-    return dataValidator.validatePrepareMessage(msg.getSignedPayload());
+    return dataValidator.validatePreparePayload(msg.getSignedPayload());
   }
 
   public boolean validateCommitMessage(final Commit msg) {
-    return dataValidator.validateCommitMessage(msg.getSignedPayload());
+    return dataValidator.validateCommitPayload(msg.getSignedPayload());
   }
 
   private boolean validateBlockMatchesProposalRound(final ProposalPayload payload,

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
@@ -12,8 +12,6 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.prepareMessageCountForQuorum;
-
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftContext;
 import tech.pegasys.pantheon.consensus.ibft.IbftHelpers;
@@ -21,7 +19,6 @@ import tech.pegasys.pantheon.consensus.ibft.blockcreation.ProposerSelector;
 import tech.pegasys.pantheon.ethereum.BlockValidator;
 import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.core.Address;
-import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 import tech.pegasys.pantheon.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Collection;
@@ -49,8 +46,7 @@ public class MessageValidatorFactory {
         roundIdentifier);
   }
 
-  public MessageValidator createMessageValidator(
-      final ConsensusRoundIdentifier roundIdentifier) {
+  public MessageValidator createMessageValidator(final ConsensusRoundIdentifier roundIdentifier) {
     final BlockValidator<IbftContext> blockValidator =
         protocolSchedule.getByBlockNumber(roundIdentifier.getSequenceNumber()).getBlockValidator();
 
@@ -92,5 +88,4 @@ public class MessageValidatorFactory {
         IbftHelpers.calculateRequiredValidatorQuorum(validators.size()),
         chainHeight);
   }
-
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
@@ -59,10 +59,8 @@ public class MessageValidatorFactory {
         new ProposalBlockConsistencyChecker(blockValidator, protocolContext));
   }
 
-  public RoundChangeMessageValidator createRoundChangeMessageValidator(
-      final ConsensusRoundIdentifier roundIdentifier) {
+  public RoundChangeMessageValidator createRoundChangeMessageValidator(final long chainHeight) {
 
-    final long chainHeight = roundIdentifier.getSequenceNumber();
     final Collection<Address> validators =
         protocolContext.getConsensusState().getVoteTally().getValidators();
 
@@ -79,15 +77,20 @@ public class MessageValidatorFactory {
         new ProposalBlockConsistencyChecker(blockValidator, protocolContext));
   }
 
-  public NewRoundMessageValidator createNewRoundValidator(final BlockHeader parentHeader) {
+  public NewRoundMessageValidator createNewRoundValidator(final long chainHeight) {
     final Collection<Address> validators =
         protocolContext.getConsensusState().getVoteTally().getValidators();
+
+    final BlockValidator<IbftContext> blockValidator =
+        protocolSchedule.getByBlockNumber(chainHeight).getBlockValidator();
+
     return new NewRoundMessageValidator(
         validators,
         proposerSelector,
-        this::createMessageValidator,
+        this::createSignedDataValidator,
+        new ProposalBlockConsistencyChecker(blockValidator, protocolContext),
         IbftHelpers.calculateRequiredValidatorQuorum(validators.size()),
-        parentHeader.getNumber() + 1);
+        chainHeight);
   }
 
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
@@ -41,15 +41,22 @@ public class MessageValidatorFactory {
     this.protocolContext = protocolContext;
   }
 
+  public SignedDataValidator createSignedDataValidator(
+      final ConsensusRoundIdentifier roundIdentifier)
+  {
+    return new SignedDataValidator(
+        protocolContext.getConsensusState().getVoteTally().getValidators(),
+        proposerSelector.selectProposerForRound(roundIdentifier),
+        roundIdentifier);
+  }
+
   public MessageValidator createMessageValidator(
       final ConsensusRoundIdentifier roundIdentifier, final BlockHeader parentHeader) {
     final BlockValidator<IbftContext> blockValidator =
         protocolSchedule.getByBlockNumber(roundIdentifier.getSequenceNumber()).getBlockValidator();
 
     return new MessageValidator(
-        protocolContext.getConsensusState().getVoteTally().getValidators(),
-        proposerSelector.selectProposerForRound(roundIdentifier),
-        roundIdentifier,
+        createSignedDataValidator(roundIdentifier),
         blockValidator,
         protocolContext,
         parentHeader);

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
@@ -178,8 +178,8 @@ public class NewRoundMessageValidator {
     final Hash oldRoundHash =
         IbftBlockHashing.calculateDataHashForCommittedSeal(currentBlockWithOldRound.getHeader());
 
-    if (!oldRoundHash
-        .equals(latestPreparedCertificate.get().getProposalPayload().getPayload().getDigest()) {
+    if (!oldRoundHash.equals(
+        latestPreparedCertificate.get().getProposalPayload().getPayload().getDigest())) {
       LOG.info(
           "Invalid NewRound message, block in latest RoundChange does not match proposed block.");
       return false;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
@@ -15,6 +15,10 @@ package tech.pegasys.pantheon.consensus.ibft.validation;
 import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.findLatestPreparedCertificate;
 import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.prepareMessageCountForQuorum;
 
+import java.util.Collection;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
@@ -30,12 +34,6 @@ import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeSignedDataVali
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.Hash;
-
-import java.util.Collection;
-import java.util.Optional;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class NewRoundMessageValidator {
 

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
@@ -18,6 +18,7 @@ import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.prepareMessageCou
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.blockcreation.ProposerSelector;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
@@ -80,9 +81,9 @@ public class NewRoundMessageValidator {
     }
 
     final SignedData<ProposalPayload> proposalPayload = payload.getProposalPayload();
-    final MessageValidator proposalValidator =
+    final SignedDataValidator proposalValidator =
         messageValidatorFactory.createAt(rootRoundIdentifier);
-    if (!proposalValidator.addSignedProposalPayload(proposalPayload)) {
+    if (!proposalValidator.addSignedProposalPayload(new Proposal(proposalPayload))) {
       LOG.info("Invalid NewRound message, embedded proposal failed validation");
       return false;
     }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
@@ -15,10 +15,6 @@ package tech.pegasys.pantheon.consensus.ibft.validation;
 import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.findLatestPreparedCertificate;
 import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.prepareMessageCountForQuorum;
 
-import java.util.Collection;
-import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockHashing;
 import tech.pegasys.pantheon.consensus.ibft.IbftBlockInterface;
@@ -34,6 +30,12 @@ import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeSignedDataVali
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.Hash;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class NewRoundMessageValidator {
 
@@ -91,7 +93,8 @@ public class NewRoundMessageValidator {
       return false;
     }
 
-    if(!proposalBlockConsistencyChecker.validateProposalMatchesBlock(proposalPayload, msg.getBlock())) {
+    if (!proposalBlockConsistencyChecker.validateProposalMatchesBlock(
+        proposalPayload, msg.getBlock())) {
       LOG.info("Invalid New Round, proposal payload did not align with supplied block.");
       return false;
     }
@@ -162,15 +165,21 @@ public class NewRoundMessageValidator {
 
     // Need to check that if we substitute the LatestedPrepareCert round number into the supplied
     // block that we get the SAME hash as PreparedCert.
-    final Block currentBlockWithOldRound = IbftBlockInterface.replaceRoundInBlock(
-        proposedBlock,
-        latestPreparedCertificate.get().getProposalPayload().getPayload().getRoundIdentifier()
-            .getRoundNumber());
+    final Block currentBlockWithOldRound =
+        IbftBlockInterface.replaceRoundInBlock(
+            proposedBlock,
+            latestPreparedCertificate
+                .get()
+                .getProposalPayload()
+                .getPayload()
+                .getRoundIdentifier()
+                .getRoundNumber());
 
     final Hash oldRoundHash =
         IbftBlockHashing.calculateDataHashForCommittedSeal(currentBlockWithOldRound.getHeader());
 
-    if(oldRoundHash != latestPreparedCertificate.get().getProposalPayload().getPayload().getDigest()) {
+    if (!oldRoundHash
+        .equals(latestPreparedCertificate.get().getProposalPayload().getPayload().getDigest()) {
       LOG.info(
           "Invalid NewRound message, block in latest RoundChange does not match proposed block.");
       return false;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
@@ -29,7 +29,6 @@ import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
-import tech.pegasys.pantheon.ethereum.core.Hash;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -176,11 +175,9 @@ public class NewRoundMessageValidator {
                 .getRoundNumber(),
             IbftBlockHashing::calculateDataHashForCommittedSeal);
 
-    final Hash oldRoundHash =
-        IbftBlockHashing.calculateDataHashForCommittedSeal(currentBlockWithOldRound.getHeader());
-
-    if (!oldRoundHash.equals(
-        latestPreparedCertificate.get().getProposalPayload().getPayload().getDigest())) {
+    if (!currentBlockWithOldRound
+        .getHash()
+        .equals(latestPreparedCertificate.get().getProposalPayload().getPayload().getDigest())) {
       LOG.info(
           "Invalid NewRound message, block in latest RoundChange does not match proposed block.");
       return false;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidator.java
@@ -151,11 +151,11 @@ public class NewRoundMessageValidator {
       final NewRoundPayload payload, final Block proposedBlock) {
 
     final RoundChangeCertificate roundChangeCert = payload.getRoundChangeCertificate();
-    final Collection<SignedData<RoundChangePayload>> roundChangeMsgs =
+    final Collection<SignedData<RoundChangePayload>> roundChangePayloads =
         roundChangeCert.getRoundChangePayloads();
 
     final Optional<PreparedCertificate> latestPreparedCertificate =
-        findLatestPreparedCertificate(roundChangeMsgs);
+        findLatestPreparedCertificate(roundChangePayloads);
 
     if (!latestPreparedCertificate.isPresent()) {
       LOG.info(
@@ -173,7 +173,8 @@ public class NewRoundMessageValidator {
                 .getProposalPayload()
                 .getPayload()
                 .getRoundIdentifier()
-                .getRoundNumber());
+                .getRoundNumber(),
+            IbftBlockHashing::calculateDataHashForCommittedSeal);
 
     final Hash oldRoundHash =
         IbftBlockHashing.calculateDataHashForCommittedSeal(currentBlockWithOldRound.getHeader());

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
@@ -1,0 +1,61 @@
+package tech.pegasys.pantheon.consensus.ibft.validation;
+
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
+import tech.pegasys.pantheon.consensus.ibft.IbftContext;
+import tech.pegasys.pantheon.consensus.ibft.IbftExtraData;
+import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.ethereum.BlockValidator;
+import tech.pegasys.pantheon.ethereum.BlockValidator.BlockProcessingOutputs;
+import tech.pegasys.pantheon.ethereum.ProtocolContext;
+import tech.pegasys.pantheon.ethereum.core.Block;
+import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
+
+public class ProposalBlockConsistencyChecker {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final BlockValidator<IbftContext> blockValidator;
+  private final ProtocolContext<IbftContext> protocolContext;
+
+  public ProposalBlockConsistencyChecker(
+      BlockValidator<IbftContext> blockValidator,
+      ProtocolContext<IbftContext> protocolContext) {
+    this.blockValidator = blockValidator;
+    this.protocolContext = protocolContext;
+  }
+
+  public boolean validateProposalMatchesBlock(final SignedData<ProposalPayload> signedPayload,
+      final Block proposedBlock) {
+    if (!validateBlockMatchesProposalRound(signedPayload.getPayload(), proposedBlock)) {
+      return false;
+    }
+
+    final Optional<BlockProcessingOutputs> validationResult =
+        blockValidator.validateAndProcessBlock(
+            protocolContext, proposedBlock, HeaderValidationMode.LIGHT, HeaderValidationMode.FULL);
+
+    if (!validationResult.isPresent()) {
+      LOG.info("Invalid Proposal message, block did not pass validation.");
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean validateBlockMatchesProposalRound(final ProposalPayload payload,
+      final Block block) {
+    final ConsensusRoundIdentifier msgRound = payload.getRoundIdentifier();
+    final IbftExtraData extraData =
+        IbftExtraData.decode(block.getHeader().getExtraData());
+    if (extraData.getRound() != msgRound.getRoundNumber()) {
+      //LOG.info("Invalid Proposal message, round number in block does not match that in message.");
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
@@ -1,8 +1,17 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.IbftContext;
 import tech.pegasys.pantheon.consensus.ibft.IbftExtraData;
@@ -14,6 +23,11 @@ import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
 
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class ProposalBlockConsistencyChecker {
 
   private static final Logger LOG = LogManager.getLogger();
@@ -22,14 +36,13 @@ public class ProposalBlockConsistencyChecker {
   private final ProtocolContext<IbftContext> protocolContext;
 
   public ProposalBlockConsistencyChecker(
-      BlockValidator<IbftContext> blockValidator,
-      ProtocolContext<IbftContext> protocolContext) {
+      BlockValidator<IbftContext> blockValidator, ProtocolContext<IbftContext> protocolContext) {
     this.blockValidator = blockValidator;
     this.protocolContext = protocolContext;
   }
 
-  public boolean validateProposalMatchesBlock(final SignedData<ProposalPayload> signedPayload,
-      final Block proposedBlock) {
+  public boolean validateProposalMatchesBlock(
+      final SignedData<ProposalPayload> signedPayload, final Block proposedBlock) {
     if (!validateBlockMatchesProposalRound(signedPayload.getPayload(), proposedBlock)) {
       return false;
     }
@@ -46,16 +59,15 @@ public class ProposalBlockConsistencyChecker {
     return true;
   }
 
-  private boolean validateBlockMatchesProposalRound(final ProposalPayload payload,
-      final Block block) {
+  private boolean validateBlockMatchesProposalRound(
+      final ProposalPayload payload, final Block block) {
     final ConsensusRoundIdentifier msgRound = payload.getRoundIdentifier();
-    final IbftExtraData extraData =
-        IbftExtraData.decode(block.getHeader().getExtraData());
+    final IbftExtraData extraData = IbftExtraData.decode(block.getHeader().getExtraData());
     if (extraData.getRound() != msgRound.getRoundNumber()) {
-      //LOG.info("Invalid Proposal message, round number in block does not match that in message.");
+      // LOG.info("Invalid Proposal message, round number in block does not match that in
+      // message.");
       return false;
     }
     return true;
   }
-
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
@@ -65,8 +65,7 @@ public class ProposalBlockConsistencyChecker {
     final ConsensusRoundIdentifier msgRound = payload.getRoundIdentifier();
     final IbftExtraData extraData = IbftExtraData.decode(block.getHeader().getExtraData());
     if (extraData.getRound() != msgRound.getRoundNumber()) {
-      // LOG.info("Invalid Proposal message, round number in block does not match that in
-      // message.");
+      LOG.info("Invalid Proposal message, round number in block does not match that in message.");
       return false;
     }
     return true;

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/ProposalBlockConsistencyChecker.java
@@ -36,7 +36,8 @@ public class ProposalBlockConsistencyChecker {
   private final ProtocolContext<IbftContext> protocolContext;
 
   public ProposalBlockConsistencyChecker(
-      BlockValidator<IbftContext> blockValidator, ProtocolContext<IbftContext> protocolContext) {
+      final BlockValidator<IbftContext> blockValidator,
+      final ProtocolContext<IbftContext> protocolContext) {
     this.blockValidator = blockValidator;
     this.protocolContext = protocolContext;
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
@@ -81,15 +81,15 @@ public class RoundChangeMessageValidator {
       return false;
     }
 
-    final MessageValidator messageValidator =
+    final MessageValidator signedDataValidator =
         messageValidatorFactory.createAt(proposalRoundIdentifier);
-    return validateConsistencyOfPrepareCertificateMessages(certificate, messageValidator);
+    return validateConsistencyOfPrepareCertificateMessages(certificate, signedDataValidator);
   }
 
   private boolean validateConsistencyOfPrepareCertificateMessages(
-      final PreparedCertificate certificate, final MessageValidator messageValidator) {
+      final PreparedCertificate certificate, final MessageValidator signedDataValidator) {
 
-    if (!messageValidator.addSignedProposalPayload(certificate.getProposalPayload())) {
+    if (!signedDataValidator.addSignedProposalPayload(certificate.getProposalPayload())) {
       LOG.info("Invalid RoundChange message, embedded Proposal message failed validation.");
       return false;
     }
@@ -102,7 +102,7 @@ public class RoundChangeMessageValidator {
     }
 
     for (final SignedData<PreparePayload> prepareMsg : certificate.getPreparePayloads()) {
-      if (!messageValidator.validatePrepareMessage(prepareMsg)) {
+      if (!signedDataValidator.validatePrepareMessage(prepareMsg)) {
         LOG.info("Invalid RoundChange message, embedded Prepare message failed validation.");
         return false;
       }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
@@ -34,7 +34,7 @@ public class RoundChangeMessageValidator {
 
   public boolean validateMessage(final RoundChange msg) {
 
-    if (signedDataValidator.validatePayload(msg.getSignedPayload())) {
+    if (!signedDataValidator.validatePayload(msg.getSignedPayload())) {
       LOG.info("Invalid RoundChange message, signed data did not validate correctly.");
       return false;
     }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
@@ -81,15 +81,15 @@ public class RoundChangeMessageValidator {
       return false;
     }
 
-    final MessageValidator signedDataValidator =
-        messageValidatorFactory.createAt(proposalRoundIdentifier);
-    return validateConsistencyOfPrepareCertificateMessages(certificate, signedDataValidator);
+    final SignedDataValidator messageValidator =
+        new SignedDataValidator(validators, null, proposalRoundIdentifier);
+    return validateConsistencyOfPrepareCertificateMessages(certificate, messageValidator);
   }
 
   private boolean validateConsistencyOfPrepareCertificateMessages(
-      final PreparedCertificate certificate, final MessageValidator signedDataValidator) {
+      final PreparedCertificate certificate, final SignedDataValidator dataValidator) {
 
-    if (!signedDataValidator.addSignedProposalPayload(certificate.getProposalPayload())) {
+    if (!dataValidator.addSignedProposalPayload(certificate.getProposalPayload())) {
       LOG.info("Invalid RoundChange message, embedded Proposal message failed validation.");
       return false;
     }
@@ -102,7 +102,7 @@ public class RoundChangeMessageValidator {
     }
 
     for (final SignedData<PreparePayload> prepareMsg : certificate.getPreparePayloads()) {
-      if (!signedDataValidator.validatePrepareMessage(prepareMsg)) {
+      if (!dataValidator.validatePreparePayload(prepareMsg)) {
         LOG.info("Invalid RoundChange message, embedded Prepare message failed validation.");
         return false;
       }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidator.java
@@ -12,10 +12,11 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class RoundChangeMessageValidator {
 
@@ -23,7 +24,6 @@ public class RoundChangeMessageValidator {
 
   private final RoundChangeSignedDataValidator signedDataValidator;
   private final ProposalBlockConsistencyChecker proposalBlockConsistencyChecker;
-
 
   public RoundChangeMessageValidator(
       final RoundChangeSignedDataValidator signedDataValidator,
@@ -40,15 +40,15 @@ public class RoundChangeMessageValidator {
     }
 
     if (msg.getPreparedCertificate().isPresent() != msg.getProposedBlock().isPresent()) {
-      LOG.info("Invalid RoundChange message, availability of certificate does not correlate with"
-          + "availability of block.");
+      LOG.info(
+          "Invalid RoundChange message, availability of certificate does not correlate with"
+              + "availability of block.");
       return false;
     }
 
     if (msg.getPreparedCertificate().isPresent()) {
-      if (!proposalBlockConsistencyChecker
-          .validateProposalMatchesBlock(msg.getPreparedCertificate().get().getProposalPayload(),
-              msg.getProposedBlock().get())) {
+      if (!proposalBlockConsistencyChecker.validateProposalMatchesBlock(
+          msg.getPreparedCertificate().get().getProposalPayload(), msg.getProposedBlock().get())) {
         LOG.info("Invalid RoundChange message, proposal did not align with supplied block.");
         return false;
       }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
@@ -67,7 +67,7 @@ public class RoundChangeSignedDataValidator {
 
     final PreparedCertificate certificate = payload.getPreparedCertificate().get();
 
-    if(!validatePrepareCertificate(certificate, targetRound)) {
+    if (!validatePrepareCertificate(certificate, targetRound)) {
       LOG.info("Invalid RoundChange payload, prepare certificate is illegal.");
       return false;
     }
@@ -90,7 +90,7 @@ public class RoundChangeSignedDataValidator {
     final SignedDataValidator signedDataValidator =
         signedDataValidatorFactory.createAt(proposalRoundIdentifier);
 
-    if(!validateConsistencyOfPrepareCertificateMessages(certificate, signedDataValidator)) {
+    if (!validateConsistencyOfPrepareCertificateMessages(certificate, signedDataValidator)) {
       LOG.info("Invalid RoundChange payload, prepare certificate message are not consistent.");
       return false;
     }
@@ -114,7 +114,7 @@ public class RoundChangeSignedDataValidator {
     }
 
     for (final SignedData<PreparePayload> prepareMsg : certificate.getPreparePayloads()) {
-      if(!dataValidator.validatePreparePayload(prepareMsg)) {
+      if (!dataValidator.validatePreparePayload(prepareMsg)) {
         LOG.info("Invalid RoundChange payload, embedded Prepare message failed validation.");
         return false;
       }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
@@ -1,8 +1,17 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import java.util.Collection;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
@@ -10,6 +19,11 @@ import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.core.Address;
+
+import java.util.Collection;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class RoundChangeSignedDataValidator {
 
@@ -56,8 +70,7 @@ public class RoundChangeSignedDataValidator {
   }
 
   private boolean validatePrepareCertificate(
-      final PreparedCertificate certificate,
-      final ConsensusRoundIdentifier roundChangeTarget) {
+      final PreparedCertificate certificate, final ConsensusRoundIdentifier roundChangeTarget) {
     final SignedData<ProposalPayload> proposalPayload = certificate.getProposalPayload();
 
     final ConsensusRoundIdentifier proposalRoundIdentifier =
@@ -119,6 +132,4 @@ public class RoundChangeSignedDataValidator {
 
     SignedDataValidator createAt(ConsensusRoundIdentifier roundIdentifier);
   }
-
-
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
@@ -1,0 +1,124 @@
+package tech.pegasys.pantheon.consensus.ibft.validation;
+
+import java.util.Collection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
+import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
+import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.ethereum.core.Address;
+
+public class RoundChangeSignedDataValidator {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Collection<Address> validators;
+  private final long minimumPrepareMessages;
+  private final long chainHeight;
+  private final SignedDataValidatorForHeightFactory signedDataValidatorFactory;
+
+  public RoundChangeSignedDataValidator(
+      final SignedDataValidatorForHeightFactory signedDataValidatorFactory,
+      final Collection<Address> validators,
+      final long minimumPrepareMessages,
+      final long chainHeight) {
+    this.validators = validators;
+    this.minimumPrepareMessages = minimumPrepareMessages;
+    this.chainHeight = chainHeight;
+    this.signedDataValidatorFactory = signedDataValidatorFactory;
+  }
+
+  public boolean validatePayload(final SignedData<RoundChangePayload> signedPayload) {
+    final RoundChangePayload payload = signedPayload.getPayload();
+    if (!validators.contains(signedPayload.getAuthor())) {
+      LOG.info(
+          "Invalid RoundChange message, was not transmitted by a validator for the associated"
+              + " round.");
+      return false;
+    }
+
+    final ConsensusRoundIdentifier targetRound = payload.getRoundIdentifier();
+
+    if (targetRound.getSequenceNumber() != chainHeight) {
+      LOG.info("Invalid RoundChange message, not valid for local chain height.");
+      return false;
+    }
+
+    if (!payload.getPreparedCertificate().isPresent()) {
+      return true;
+    }
+
+    final PreparedCertificate certificate = payload.getPreparedCertificate().get();
+    return validatePrepareCertificate(certificate, targetRound);
+  }
+
+  private boolean validatePrepareCertificate(
+      final PreparedCertificate certificate,
+      final ConsensusRoundIdentifier roundChangeTarget) {
+    final SignedData<ProposalPayload> proposalPayload = certificate.getProposalPayload();
+
+    final ConsensusRoundIdentifier proposalRoundIdentifier =
+        proposalPayload.getPayload().getRoundIdentifier();
+
+    if (!validatePreparedCertificateRound(proposalRoundIdentifier, roundChangeTarget)) {
+      return false;
+    }
+
+    final SignedDataValidator signedDataValidator =
+        signedDataValidatorFactory.createAt(proposalRoundIdentifier);
+
+    return validateConsistencyOfPrepareCertificateMessages(certificate, signedDataValidator);
+  }
+
+  private boolean validateConsistencyOfPrepareCertificateMessages(
+      final PreparedCertificate certificate, final SignedDataValidator dataValidator) {
+
+    if (!dataValidator.addSignedProposalPayload(certificate.getProposalPayload())) {
+      LOG.info("Invalid RoundChange message, embedded Proposal message failed validation.");
+      return false;
+    }
+
+    if (certificate.getPreparePayloads().size() < minimumPrepareMessages) {
+      LOG.info(
+          "Invalid RoundChange message, insufficient Prepare messages exist to justify "
+              + "prepare certificate.");
+      return false;
+    }
+
+    for (final SignedData<PreparePayload> prepareMsg : certificate.getPreparePayloads()) {
+      dataValidator.validatePreparePayload(prepareMsg);
+      LOG.info("Invalid RoundChange message, embedded Prepare message failed validation.");
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean validatePreparedCertificateRound(
+      final ConsensusRoundIdentifier prepareCertRound,
+      final ConsensusRoundIdentifier roundChangeTarget) {
+
+    if (prepareCertRound.getSequenceNumber() != roundChangeTarget.getSequenceNumber()) {
+      LOG.info("Invalid RoundChange message, PreparedCertificate is not for local chain height.");
+      return false;
+    }
+
+    if (prepareCertRound.getRoundNumber() >= roundChangeTarget.getRoundNumber()) {
+      LOG.info(
+          "Invalid RoundChange message, PreparedCertificate not older than RoundChange target.");
+      return false;
+    }
+    return true;
+  }
+
+  @FunctionalInterface
+  public static interface SignedDataValidatorForHeightFactory {
+
+    SignedDataValidator createAt(ConsensusRoundIdentifier roundIdentifier);
+  }
+
+
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidator.java
@@ -115,7 +115,7 @@ public class RoundChangeSignedDataValidator {
   }
 
   @FunctionalInterface
-  public static interface SignedDataValidatorForHeightFactory {
+  public interface SignedDataValidatorForHeightFactory {
 
     SignedDataValidator createAt(ConsensusRoundIdentifier roundIdentifier);
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.consensus.ibft.validation;
+
+import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
+import tech.pegasys.pantheon.consensus.ibft.IbftContext;
+import tech.pegasys.pantheon.consensus.ibft.IbftExtraData;
+import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
+import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
+import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
+import tech.pegasys.pantheon.ethereum.BlockValidator;
+import tech.pegasys.pantheon.ethereum.BlockValidator.BlockProcessingOutputs;
+import tech.pegasys.pantheon.ethereum.ProtocolContext;
+import tech.pegasys.pantheon.ethereum.core.Address;
+import tech.pegasys.pantheon.ethereum.core.Block;
+import tech.pegasys.pantheon.ethereum.core.BlockHeader;
+import tech.pegasys.pantheon.ethereum.core.Hash;
+import tech.pegasys.pantheon.ethereum.core.Util;
+import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SignedDataValidator {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Collection<Address> validators;
+  private final Address expectedProposer;
+  private final ConsensusRoundIdentifier roundIdentifier;
+
+  private Optional<SignedData<ProposalPayload>> proposal = Optional.empty();
+
+  public SignedDataValidator(
+      final Collection<Address> validators,
+      final Address expectedProposer,
+      final ConsensusRoundIdentifier roundIdentifier) {
+    this.validators = validators;
+    this.expectedProposer = expectedProposer;
+    this.roundIdentifier = roundIdentifier;
+  }
+
+  public boolean addSignedProposalPayload(final SignedData<ProposalPayload> msg) {
+
+    if (proposal.isPresent()) {
+      return handleSubsequentProposal(proposal.get(), msg);
+    }
+
+    if (!validateSignedProposalPayload(msg)) {
+      return false;
+    }
+
+    proposal = Optional.of(msg);
+    return true;
+  }
+
+  private boolean validateSignedProposalPayload(final SignedData<ProposalPayload> msg) {
+
+    if (!msg.getPayload().getRoundIdentifier().equals(roundIdentifier)) {
+      LOG.info("Invalid Proposal message, does not match current round.");
+      return false;
+    }
+
+    if (!msg.getAuthor().equals(expectedProposer)) {
+      LOG.info(
+          "Invalid Proposal message, was not created by the proposer expected for the "
+              + "associated round.");
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean handleSubsequentProposal(
+      final SignedData<ProposalPayload> existingMsg, final SignedData<ProposalPayload> newMsg) {
+    if (!existingMsg.getAuthor().equals(newMsg.getAuthor())) {
+      LOG.debug("Received subsequent invalid Proposal message; sender differs from original.");
+      return false;
+    }
+
+    final ProposalPayload existingData = existingMsg.getPayload();
+    final ProposalPayload newData = newMsg.getPayload();
+
+    if (!proposalMessagesAreIdentical(existingData, newData)) {
+      LOG.debug("Received subsequent invalid Proposal message; content differs from original.");
+      return false;
+    }
+
+    return true;
+  }
+
+  public boolean validatePrepareMessage(final SignedData<PreparePayload> msg) {
+    final String msgType = "Prepare";
+
+    if (!isMessageForCurrentRoundFromValidatorAndProposalAvailable(msg, msgType)) {
+      return false;
+    }
+
+    if (msg.getAuthor().equals(expectedProposer)) {
+      LOG.info("Illegal Prepare message; was sent by the round's proposer.");
+      return false;
+    }
+
+    return validateDigestMatchesProposal(msg.getPayload().getDigest(), msgType);
+  }
+
+  public boolean validateCommitMessage(final SignedData<CommitPayload> msg) {
+    final String msgType = "Commit";
+
+    if (!isMessageForCurrentRoundFromValidatorAndProposalAvailable(msg, msgType)) {
+      return false;
+    }
+
+    final Address commitSealCreator =
+        Util.signatureToAddress(msg.getPayload().getCommitSeal(),
+            proposal.get().getPayload().getDigest());
+
+    if (!commitSealCreator.equals(msg.getAuthor())) {
+      LOG.info("Invalid Commit message. Seal was not created by the message transmitter.");
+      return false;
+    }
+
+    return validateDigestMatchesProposal(msg.getPayload().getDigest(), msgType);
+  }
+
+  private boolean isMessageForCurrentRoundFromValidatorAndProposalAvailable(
+      final SignedData<? extends Payload> msg, final String msgType) {
+
+    if (!msg.getPayload().getRoundIdentifier().equals(roundIdentifier)) {
+      LOG.info("Invalid {} message, does not match current round.", msgType);
+      return false;
+    }
+
+    if (!validators.contains(msg.getAuthor())) {
+      LOG.info(
+          "Invalid {} message, was not transmitted by a validator for the " + "associated round.",
+          msgType);
+      return false;
+    }
+
+    if (!proposal.isPresent()) {
+      LOG.info(
+          "Unable to validate {} message. No Proposal exists against which to validate "
+              + "block digest.",
+          msgType);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean validateDigestMatchesProposal(final Hash digest, final String msgType) {
+    if (!digest.equals(proposal.get().getPayload().getDigest())) {
+      LOG.info(
+          "Illegal {} message, digest does not match the digest in the Proposal Message.", msgType);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean proposalMessagesAreIdentical(
+      final ProposalPayload right, final ProposalPayload left) {
+    return right.getDigest().equals(left.getDigest())
+        && right.getRoundIdentifier().equals(left.getRoundIdentifier());
+  }
+}

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
@@ -87,7 +87,7 @@ public class SignedDataValidator {
     return validateDigestMatchesProposal(msg.getPayload().getDigest(), payloadType);
   }
 
-  public boolean validateCommmitPayload(final SignedData<CommitPayload> msg) {
+  public boolean validateCommitPayload(final SignedData<CommitPayload> msg) {
     final String payloadType = "Commit";
 
     if (!isMessageForCurrentRoundFromValidatorAndProposalAvailable(msg, payloadType)) {

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
@@ -12,10 +12,6 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import java.util.Collection;
-import java.util.Optional;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
@@ -25,6 +21,12 @@ import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.core.Util;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class SignedDataValidator {
 
@@ -95,8 +97,8 @@ public class SignedDataValidator {
     }
 
     final Address commitSealCreator =
-        Util.signatureToAddress(msg.getPayload().getCommitSeal(),
-            proposal.get().getPayload().getDigest());
+        Util.signatureToAddress(
+            msg.getPayload().getCommitSeal(), proposal.get().getPayload().getDigest());
 
     if (!commitSealCreator.equals(msg.getAuthor())) {
       LOG.info("Invalid Commit message. Seal was not created by the message transmitter.");

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidator.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
+import static java.util.Optional.empty;
+
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.payload.CommitPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.Payload;
@@ -36,7 +38,7 @@ public class SignedDataValidator {
   private final Address expectedProposer;
   private final ConsensusRoundIdentifier roundIdentifier;
 
-  private Optional<SignedData<ProposalPayload>> proposal;
+  private Optional<SignedData<ProposalPayload>> proposal = empty();
 
   public SignedDataValidator(
       final Collection<Address> validators,

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftGossipTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftGossipTest.java
@@ -65,13 +65,13 @@ public class IbftGossipTest {
   @Test
   public void assertRebroadcastsProposalToAllExceptSignerAndSender() {
     assertRebroadcastToAllExceptSignerAndSender(
-        TestHelpers::createSignedProposalPayload, ProposalMessageData::create);
+        TestHelpers::createProposal, ProposalMessageData::create);
   }
 
   @Test
   public void assertRebroadcastsRoundChangeToAllExceptSignerAndSender() {
     assertRebroadcastToAllExceptSignerAndSender(
-        TestHelpers::createSignedRoundChangePayload, RoundChangeMessageData::create);
+        TestHelpers::createRoundChange, RoundChangeMessageData::create);
   }
 
   @Test

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
@@ -20,6 +20,7 @@ import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.calculateRequired
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
+import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.Hash;
@@ -92,17 +93,15 @@ public class IbftHelpersTest {
     final Proposal differentProposal =
         proposerMessageFactory.createSignedProposalPayload(preparedRound, proposedBlock);
 
-    final Optional<PreparedCertificate> latterPreparedCert =
+    final Optional<TerminatedRoundArtefacts> latterPreparedCert =
         Optional.of(
-            new PreparedCertificate(
-                differentProposal.getSignedPayload(),
+            new TerminatedRoundArtefacts(
+                differentProposal,
                 Lists.newArrayList(
                     proposerMessageFactory
-                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash())
-                        .getSignedPayload(),
+                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash()),
                     proposerMessageFactory
-                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash())
-                        .getSignedPayload())));
+                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash()))));
 
     // An earlier PrepareCert is added to ensure the path to find the latest PrepareCert
     // is correctly followed.
@@ -110,17 +109,16 @@ public class IbftHelpersTest {
         TestHelpers.createFrom(roundIdentifier, 0, -2);
     final Proposal earlierProposal =
         proposerMessageFactory.createSignedProposalPayload(earlierPreparedRound, proposedBlock);
-    final Optional<PreparedCertificate> earlierPreparedCert =
+    final Optional<TerminatedRoundArtefacts> earlierPreparedCert =
         Optional.of(
-            new PreparedCertificate(
-                earlierProposal.getSignedPayload(),
+            new TerminatedRoundArtefacts(
+                earlierProposal,
                 Lists.newArrayList(
                     proposerMessageFactory
-                        .createSignedPreparePayload(earlierPreparedRound, proposedBlock.getHash())
-                        .getSignedPayload(),
+                        .createSignedPreparePayload(earlierPreparedRound, proposedBlock.getHash()),
                     proposerMessageFactory
-                        .createSignedPreparePayload(earlierPreparedRound, proposedBlock.getHash())
-                        .getSignedPayload())));
+                        .createSignedPreparePayload(earlierPreparedRound,
+                            proposedBlock.getHash()))));
 
     final Optional<PreparedCertificate> newestCert =
         IbftHelpers.findLatestPreparedCertificate(

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
@@ -98,10 +98,10 @@ public class IbftHelpersTest {
             new TerminatedRoundArtefacts(
                 differentProposal,
                 Lists.newArrayList(
-                    proposerMessageFactory
-                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash()),
-                    proposerMessageFactory
-                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash()))));
+                    proposerMessageFactory.createSignedPreparePayload(
+                        roundIdentifier, proposedBlock.getHash()),
+                    proposerMessageFactory.createSignedPreparePayload(
+                        roundIdentifier, proposedBlock.getHash()))));
 
     // An earlier PrepareCert is added to ensure the path to find the latest PrepareCert
     // is correctly followed.
@@ -114,11 +114,10 @@ public class IbftHelpersTest {
             new TerminatedRoundArtefacts(
                 earlierProposal,
                 Lists.newArrayList(
-                    proposerMessageFactory
-                        .createSignedPreparePayload(earlierPreparedRound, proposedBlock.getHash()),
-                    proposerMessageFactory
-                        .createSignedPreparePayload(earlierPreparedRound,
-                            proposedBlock.getHash()))));
+                    proposerMessageFactory.createSignedPreparePayload(
+                        earlierPreparedRound, proposedBlock.getHash()),
+                    proposerMessageFactory.createSignedPreparePayload(
+                        earlierPreparedRound, proposedBlock.getHash()))));
 
     final Optional<PreparedCertificate> newestCert =
         IbftHelpers.findLatestPreparedCertificate(

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
@@ -20,7 +20,6 @@ import static tech.pegasys.pantheon.consensus.ibft.IbftHelpers.calculateRequired
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
-import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.Hash;
@@ -75,5 +74,83 @@ public class IbftHelpersTest {
   @Test
   public void calculateRequiredValidatorQuorum20Validator() {
     assertThat(calculateRequiredValidatorQuorum(20)).isEqualTo(14);
+  }
+
+  @Test
+  public void latestPreparedCertificateIsExtractedFromRoundChangeCertificate() {
+    // NOTE: This function does not validate that all RoundCHanges/Prepares etc. come from valid
+    // sources, it is only responsible for determine which of the list or RoundChange messages
+    // contains the newest
+    // NOTE: This capability is tested as part of the NewRoundMessageValidationTests.
+    final KeyPair proposerKey = KeyPair.generate();
+    final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
+    final Block proposedBlock = mock(Block.class);
+    when(proposedBlock.getHash()).thenReturn(Hash.fromHexStringLenient("1"));
+    final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 4);
+
+    final ConsensusRoundIdentifier preparedRound = TestHelpers.createFrom(roundIdentifier, 0, -1);
+    final Proposal differentProposal =
+        proposerMessageFactory.createSignedProposalPayload(preparedRound, proposedBlock);
+
+    final Optional<PreparedCertificate> latterPreparedCert =
+        Optional.of(
+            new PreparedCertificate(
+                differentProposal.getSignedPayload(),
+                Lists.newArrayList(
+                    proposerMessageFactory
+                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash())
+                        .getSignedPayload(),
+                    proposerMessageFactory
+                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash())
+                        .getSignedPayload())));
+
+    // An earlier PrepareCert is added to ensure the path to find the latest PrepareCert
+    // is correctly followed.
+    final ConsensusRoundIdentifier earlierPreparedRound =
+        TestHelpers.createFrom(roundIdentifier, 0, -2);
+    final Proposal earlierProposal =
+        proposerMessageFactory.createSignedProposalPayload(earlierPreparedRound, proposedBlock);
+    final Optional<PreparedCertificate> earlierPreparedCert =
+        Optional.of(
+            new PreparedCertificate(
+                earlierProposal.getSignedPayload(),
+                Lists.newArrayList(
+                    proposerMessageFactory
+                        .createSignedPreparePayload(earlierPreparedRound, proposedBlock.getHash())
+                        .getSignedPayload(),
+                    proposerMessageFactory
+                        .createSignedPreparePayload(earlierPreparedRound, proposedBlock.getHash())
+                        .getSignedPayload())));
+
+    final Optional<PreparedCertificate> newestCert =
+        IbftHelpers.findLatestPreparedCertificate(
+            Lists.newArrayList(
+                proposerMessageFactory
+                    .createSignedRoundChangePayload(roundIdentifier, earlierPreparedCert)
+                    .getSignedPayload(),
+                proposerMessageFactory
+                    .createSignedRoundChangePayload(roundIdentifier, latterPreparedCert)
+                    .getSignedPayload()));
+
+    assertThat(newestCert).isEqualTo(latterPreparedCert);
+  }
+
+  @Test
+  public void allRoundChangeHaveNoPreparedReturnsEmptyOptional() {
+    final KeyPair proposerKey = KeyPair.generate();
+    final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
+    final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 4);
+
+    final Optional<PreparedCertificate> newestCert =
+        IbftHelpers.findLatestPreparedCertificate(
+            Lists.newArrayList(
+                proposerMessageFactory
+                    .createSignedRoundChangePayload(roundIdentifier, Optional.empty())
+                    .getSignedPayload(),
+                proposerMessageFactory
+                    .createSignedRoundChangePayload(roundIdentifier, Optional.empty())
+                    .getSignedPayload()));
+
+    assertThat(newestCert).isEmpty();
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/IbftHelpersTest.java
@@ -129,7 +129,7 @@ public class IbftHelpersTest {
                     .createSignedRoundChangePayload(roundIdentifier, latterPreparedCert)
                     .getSignedPayload()));
 
-    assertThat(newestCert).isEqualTo(latterPreparedCert);
+    assertThat(newestCert.get()).isEqualTo(latterPreparedCert.get().getPreparedCertificate());
   }
 
   @Test

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/TestHelpers.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/TestHelpers.java
@@ -65,8 +65,7 @@ public class TestHelpers {
     return createProposalWithRound(signerKeys, 0xFEDCBA98);
   }
 
-  public static Proposal createProposalWithRound(
-      final KeyPair signerKeys, final int round) {
+  public static Proposal createProposalWithRound(final KeyPair signerKeys, final int round) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, round);

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/TestHelpers.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/TestHelpers.java
@@ -61,11 +61,11 @@ public class TestHelpers {
     return new BlockDataGenerator().block(blockOptions);
   }
 
-  public static Proposal createSignedProposalPayload(final KeyPair signerKeys) {
-    return createSignedProposalPayloadWithRound(signerKeys, 0xFEDCBA98);
+  public static Proposal createProposal(final KeyPair signerKeys) {
+    return createProposalWithRound(signerKeys, 0xFEDCBA98);
   }
 
-  public static Proposal createSignedProposalPayloadWithRound(
+  public static Proposal createProposalWithRound(
       final KeyPair signerKeys, final int round) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
@@ -75,7 +75,7 @@ public class TestHelpers {
     return messageFactory.createSignedProposalPayload(roundIdentifier, block);
   }
 
-  public static Prepare createSignedPreparePayload(final KeyPair signerKeys) {
+  public static Prepare createPrepare(final KeyPair signerKeys) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
@@ -83,7 +83,7 @@ public class TestHelpers {
         roundIdentifier, Hash.fromHexStringLenient("0"));
   }
 
-  public static Commit createSignedCommitPayload(final KeyPair signerKeys) {
+  public static Commit createCommit(final KeyPair signerKeys) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
@@ -93,7 +93,7 @@ public class TestHelpers {
         Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0));
   }
 
-  public static RoundChange createSignedRoundChangePayload(final KeyPair signerKeys) {
+  public static RoundChange createRoundChange(final KeyPair signerKeys) {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
@@ -104,10 +104,11 @@ public class TestHelpers {
     final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
-    final Proposal proposalPayload = createSignedProposalPayload(signerKeys);
+    final Proposal proposalPayload = createProposal(signerKeys);
     return messageFactory.createSignedNewRoundPayload(
         roundIdentifier,
         new RoundChangeCertificate(newArrayList()),
-        proposalPayload.getSignedPayload());
+        proposalPayload.getSignedPayload(),
+        proposalPayload.getBlock());
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/message/ProposalTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/message/ProposalTest.java
@@ -1,0 +1,25 @@
+package tech.pegasys.pantheon.consensus.ibft.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.pantheon.consensus.ibft.TestHelpers.createProposalWithRound;
+
+import org.junit.Test;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
+import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+public class ProposalTest {
+
+  @Test
+  public void serialisedMessageDeserialises() {
+    final KeyPair keyPair = KeyPair.generate();
+
+    final Proposal proposal = createProposalWithRound(keyPair, 1);
+
+    final BytesValue serialisedBytes = proposal.encode();
+
+    final Proposal deserialisedProposal = Proposal.decode(serialisedBytes);
+
+    assertThat(proposal).isEqualToComparingFieldByField(deserialisedProposal);
+  }
+}

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/message/ProposalTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/message/ProposalTest.java
@@ -1,12 +1,25 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package tech.pegasys.pantheon.consensus.ibft.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.pantheon.consensus.ibft.TestHelpers.createProposalWithRound;
 
-import org.junit.Test;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import org.junit.Test;
 
 public class ProposalTest {
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/NewRoundPayloadTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/NewRoundPayloadTest.java
@@ -42,7 +42,7 @@ public class NewRoundPayloadTest {
   public void roundTripRlpWithNoRoundChangePayloads() {
     final Block block =
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), 0);
-    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block);
+    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     final SignedData<ProposalPayload> proposalPayloadSignedData =
         SignedData.from(proposalPayload, signature);
@@ -66,7 +66,7 @@ public class NewRoundPayloadTest {
   public void roundTripRlpWithRoundChangePayloads() {
     final Block block =
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), 0);
-    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block);
+    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     final SignedData<ProposalPayload> signedProposal = SignedData.from(proposalPayload, signature);
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/PreparedCertificateTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/PreparedCertificateTest.java
@@ -79,7 +79,7 @@ public class PreparedCertificateTest {
   private SignedData<ProposalPayload> signedProposal() {
     final Block block =
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), 0);
-    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block);
+    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     return SignedData.from(proposalPayload, signature);
   }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/ProposalPayloadTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/ProposalPayloadTest.java
@@ -35,14 +35,15 @@ public class ProposalPayloadTest {
   public void roundTripRlp() {
     final Block block =
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), 0);
-    final ProposalPayload expectedProposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block);
+    final ProposalPayload expectedProposalPayload =
+        new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
     expectedProposalPayload.writeTo(rlpOut);
 
     final RLPInput rlpInput = RLP.input(rlpOut.encoded());
     final ProposalPayload proposalPayload = ProposalPayload.readFrom(rlpInput);
     assertThat(proposalPayload.getRoundIdentifier()).isEqualTo(ROUND_IDENTIFIER);
-    assertThat(proposalPayload.getBlock()).isEqualTo(block);
+    assertThat(proposalPayload.getDigest()).isEqualTo(block.getHash());
     assertThat(proposalPayload.getMessageType()).isEqualTo(IbftV2.PROPOSAL);
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/RoundChangeCertificateTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/RoundChangeCertificateTest.java
@@ -55,7 +55,7 @@ public class RoundChangeCertificateTest {
   public void rlpRoundTripWithPreparedCertificate() {
     final Block block =
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), 0);
-    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block);
+    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     SignedData<ProposalPayload> signedProposal = SignedData.from(proposalPayload, signature);
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/RoundChangePayloadTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/payload/RoundChangePayloadTest.java
@@ -100,7 +100,7 @@ public class RoundChangePayloadTest {
   private SignedData<ProposalPayload> signedProposal() {
     final Block block =
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), 0);
-    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block);
+    final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     return SignedData.from(proposalPayload, signature);
   }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -125,7 +125,7 @@ public class IbftBlockHeightManagerTest {
 
     buildCreatedBlock();
 
-    final SignedDataValidator signedDataValidator = mock(SignedDataValidator.class);
+    final MessageValidator messageValidator = mock(SignedDataValidator.class);
     when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(true);
     when(signedDataValidator.validateCommmitMessage(any())).thenReturn(true);
     when(signedDataValidator.validatePrepareMessage(any())).thenReturn(true);
@@ -138,8 +138,7 @@ public class IbftBlockHeightManagerTest {
     when(newRoundMessageValidator.validateNewRoundMessage(any())).thenReturn(true);
     when(messageValidatorFactory.createNewRoundValidator(any()))
         .thenReturn(newRoundMessageValidator);
-    when(messageValidatorFactory.createMessageValidator(any(), any())).thenReturn(
-        signedDataValidator);
+    when(messageValidatorFactory.createMessageValidator(any(), any())).thenReturn(messageValidator);
 
     protocolContext =
         new ProtocolContext<>(null, null, new IbftContext(new VoteTally(validators), null));
@@ -151,7 +150,7 @@ public class IbftBlockHeightManagerTest {
               final int round = (int) invocation.getArgument(1);
               final ConsensusRoundIdentifier roundId = new ConsensusRoundIdentifier(1, round);
               final RoundState createdRoundState =
-                  new RoundState(roundId, finalState.getQuorum(), signedDataValidator);
+                  new RoundState(roundId, finalState.getQuorum(), messageValidator);
               return new IbftRound(
                   createdRoundState,
                   blockCreator,

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -82,30 +82,20 @@ public class IbftBlockHeightManagerTest {
   private final MessageFactory messageFactory = new MessageFactory(localNodeKeys);
   private final BlockHeaderTestFixture headerTestFixture = new BlockHeaderTestFixture();
 
-  @Mock
-  private IbftFinalState finalState;
-  @Mock
-  private IbftMessageTransmitter messageTransmitter;
-  @Mock
-  private RoundChangeManager roundChangeManager;
-  @Mock
-  private IbftRoundFactory roundFactory;
-  @Mock
-  private Clock clock;
+  @Mock private IbftFinalState finalState;
+  @Mock private IbftMessageTransmitter messageTransmitter;
+  @Mock private RoundChangeManager roundChangeManager;
+  @Mock private IbftRoundFactory roundFactory;
+  @Mock private Clock clock;
 
-  @Mock
-  private IbftBlockCreator blockCreator;
-  @Mock
-  private BlockImporter<IbftContext> blockImporter;
-  @Mock
-  private BlockTimer blockTimer;
-  @Mock
-  private RoundTimer roundTimer;
+  @Mock private IbftBlockCreator blockCreator;
+  @Mock private BlockImporter<IbftContext> blockImporter;
+  @Mock private BlockTimer blockTimer;
+  @Mock private RoundTimer roundTimer;
   private NewRoundMessageValidator newRoundMessageValidator = mock(NewRoundMessageValidator.class);
   private MessageValidatorFactory messageValidatorFactory = mock(MessageValidatorFactory.class);
 
-  @Captor
-  private ArgumentCaptor<Optional<TerminatedRoundArtefacts>> terminatedRoundArtefactsCaptor;
+  @Captor private ArgumentCaptor<Optional<TerminatedRoundArtefacts>> terminatedRoundArtefactsCaptor;
 
   private final List<KeyPair> validatorKeys = Lists.newArrayList();
   private final List<Address> validators = Lists.newArrayList();

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -42,7 +42,7 @@ import tech.pegasys.pantheon.consensus.ibft.network.IbftMessageTransmitter;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
-import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
+import tech.pegasys.pantheon.consensus.ibft.validation.SignedDataValidator;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidatorFactory;
 import tech.pegasys.pantheon.consensus.ibft.validation.NewRoundMessageValidator;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
@@ -125,10 +125,10 @@ public class IbftBlockHeightManagerTest {
 
     buildCreatedBlock();
 
-    final MessageValidator messageValidator = mock(MessageValidator.class);
-    when(messageValidator.addSignedProposalPayload(any())).thenReturn(true);
-    when(messageValidator.validateCommmitMessage(any())).thenReturn(true);
-    when(messageValidator.validatePrepareMessage(any())).thenReturn(true);
+    final SignedDataValidator signedDataValidator = mock(SignedDataValidator.class);
+    when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(true);
+    when(signedDataValidator.validateCommmitMessage(any())).thenReturn(true);
+    when(signedDataValidator.validatePrepareMessage(any())).thenReturn(true);
     when(finalState.getTransmitter()).thenReturn(messageTransmitter);
     when(finalState.getBlockTimer()).thenReturn(blockTimer);
     when(finalState.getRoundTimer()).thenReturn(roundTimer);
@@ -138,7 +138,8 @@ public class IbftBlockHeightManagerTest {
     when(newRoundMessageValidator.validateNewRoundMessage(any())).thenReturn(true);
     when(messageValidatorFactory.createNewRoundValidator(any()))
         .thenReturn(newRoundMessageValidator);
-    when(messageValidatorFactory.createMessageValidator(any(), any())).thenReturn(messageValidator);
+    when(messageValidatorFactory.createMessageValidator(any(), any())).thenReturn(
+        signedDataValidator);
 
     protocolContext =
         new ProtocolContext<>(null, null, new IbftContext(new VoteTally(validators), null));
@@ -150,7 +151,7 @@ public class IbftBlockHeightManagerTest {
               final int round = (int) invocation.getArgument(1);
               final ConsensusRoundIdentifier roundId = new ConsensusRoundIdentifier(1, round);
               final RoundState createdRoundState =
-                  new RoundState(roundId, finalState.getQuorum(), messageValidator);
+                  new RoundState(roundId, finalState.getQuorum(), signedDataValidator);
               return new IbftRound(
                   createdRoundState,
                   blockCreator,

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -82,19 +82,30 @@ public class IbftBlockHeightManagerTest {
   private final MessageFactory messageFactory = new MessageFactory(localNodeKeys);
   private final BlockHeaderTestFixture headerTestFixture = new BlockHeaderTestFixture();
 
-  @Mock private IbftFinalState finalState;
-  @Mock private IbftMessageTransmitter messageTransmitter;
-  @Mock private RoundChangeManager roundChangeManager;
-  @Mock private IbftRoundFactory roundFactory;
-  @Mock private Clock clock;
-  @Mock private MessageValidatorFactory messageValidatorFactory;
-  @Mock private IbftBlockCreator blockCreator;
-  @Mock private BlockImporter<IbftContext> blockImporter;
-  @Mock private BlockTimer blockTimer;
-  @Mock private RoundTimer roundTimer;
-  @Mock private NewRoundMessageValidator newRoundMessageValidator;
+  @Mock
+  private IbftFinalState finalState;
+  @Mock
+  private IbftMessageTransmitter messageTransmitter;
+  @Mock
+  private RoundChangeManager roundChangeManager;
+  @Mock
+  private IbftRoundFactory roundFactory;
+  @Mock
+  private Clock clock;
 
-  @Captor private ArgumentCaptor<Optional<TerminatedRoundArtefacts>> terminatedRoundArtefactsCaptor;
+  @Mock
+  private IbftBlockCreator blockCreator;
+  @Mock
+  private BlockImporter<IbftContext> blockImporter;
+  @Mock
+  private BlockTimer blockTimer;
+  @Mock
+  private RoundTimer roundTimer;
+  private NewRoundMessageValidator newRoundMessageValidator = mock(NewRoundMessageValidator.class);
+  private MessageValidatorFactory messageValidatorFactory = mock(MessageValidatorFactory.class);
+
+  @Captor
+  private ArgumentCaptor<Optional<TerminatedRoundArtefacts>> terminatedRoundArtefactsCaptor;
 
   private final List<KeyPair> validatorKeys = Lists.newArrayList();
   private final List<Address> validators = Lists.newArrayList();
@@ -126,9 +137,9 @@ public class IbftBlockHeightManagerTest {
     when(finalState.getMessageFactory()).thenReturn(messageFactory);
     when(blockCreator.createBlock(anyLong())).thenReturn(createdBlock);
     when(newRoundMessageValidator.validateNewRoundMessage(any())).thenReturn(true);
-    when(messageValidatorFactory.createNewRoundValidator(any()))
-        .thenReturn(newRoundMessageValidator);
     when(messageValidatorFactory.createMessageValidator(any())).thenReturn(messageValidator);
+    when(messageValidatorFactory.createNewRoundValidator(anyLong()))
+        .thenReturn(newRoundMessageValidator);
 
     protocolContext =
         new ProtocolContext<>(null, null, new IbftContext(new VoteTally(validators), null));
@@ -179,7 +190,7 @@ public class IbftBlockHeightManagerTest {
   }
 
   @Test
-  public void startsABlockTimerOnStartIfLocalNodeIsTheProoserForRound() {
+  public void startsABlockTimerOnStartIfLocalNodeIsTheProposerForRound() {
     when(finalState.isLocalNodeProposerForRound(any())).thenReturn(true);
 
     final IbftBlockHeightManager manager =

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -41,7 +41,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.network.IbftMessageTransmitter;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.RoundChangeManager.RoundChangeArtefacts;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
@@ -83,31 +82,19 @@ public class IbftBlockHeightManagerTest {
   private final MessageFactory messageFactory = new MessageFactory(localNodeKeys);
   private final BlockHeaderTestFixture headerTestFixture = new BlockHeaderTestFixture();
 
-  @Mock
-  private IbftFinalState finalState;
-  @Mock
-  private IbftMessageTransmitter messageTransmitter;
-  @Mock
-  private RoundChangeManager roundChangeManager;
-  @Mock
-  private IbftRoundFactory roundFactory;
-  @Mock
-  private Clock clock;
-  @Mock
-  private MessageValidatorFactory messageValidatorFactory;
-  @Mock
-  private IbftBlockCreator blockCreator;
-  @Mock
-  private BlockImporter<IbftContext> blockImporter;
-  @Mock
-  private BlockTimer blockTimer;
-  @Mock
-  private RoundTimer roundTimer;
-  @Mock
-  private NewRoundMessageValidator newRoundMessageValidator;
+  @Mock private IbftFinalState finalState;
+  @Mock private IbftMessageTransmitter messageTransmitter;
+  @Mock private RoundChangeManager roundChangeManager;
+  @Mock private IbftRoundFactory roundFactory;
+  @Mock private Clock clock;
+  @Mock private MessageValidatorFactory messageValidatorFactory;
+  @Mock private IbftBlockCreator blockCreator;
+  @Mock private BlockImporter<IbftContext> blockImporter;
+  @Mock private BlockTimer blockTimer;
+  @Mock private RoundTimer roundTimer;
+  @Mock private NewRoundMessageValidator newRoundMessageValidator;
 
-  @Captor
-  private ArgumentCaptor<Optional<TerminatedRoundArtefacts>> terminatedRoundArtefactsCaptor;
+  @Captor private ArgumentCaptor<Optional<TerminatedRoundArtefacts>> terminatedRoundArtefactsCaptor;
 
   private final List<KeyPair> validatorKeys = Lists.newArrayList();
   private final List<Address> validators = Lists.newArrayList();
@@ -184,8 +171,7 @@ public class IbftBlockHeightManagerTest {
   private void buildCreatedBlock() {
 
     IbftExtraData extraData =
-        new IbftExtraData(
-            BytesValue.wrap(new byte[32]), emptyList(), empty(), 0, validators);
+        new IbftExtraData(BytesValue.wrap(new byte[32]), emptyList(), empty(), 0, validators);
 
     headerTestFixture.extraData(extraData.encode());
     final BlockHeader header = headerTestFixture.buildHeader();
@@ -234,8 +220,9 @@ public class IbftBlockHeightManagerTest {
         messageFactory.createSignedRoundChangePayload(futureRoundIdentifier, empty());
     when(roundChangeManager.appendRoundChangeMessage(any()))
         .thenReturn(
-            Optional.of(new RoundChangeArtefacts(
-                new RoundChangeCertificate(singletonList(roundChange.getSignedPayload())),
+            Optional.of(
+                new RoundChangeArtefacts(
+                    new RoundChangeCertificate(singletonList(roundChange.getSignedPayload())),
                     empty())));
     when(finalState.isLocalNodeProposerForRound(any())).thenReturn(false);
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundTest.java
@@ -34,7 +34,7 @@ import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
-import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
+import tech.pegasys.pantheon.consensus.ibft.validation.SignedDataValidator;
 import tech.pegasys.pantheon.crypto.SECP256K1;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
@@ -78,7 +78,7 @@ public class IbftRoundTest {
   @Mock private IbftMessageTransmitter transmitter;
   @Mock private MinedBlockObserver minedBlockObserver;
   @Mock private IbftBlockCreator blockCreator;
-  @Mock private MessageValidator messageValidator;
+  @Mock private SignedDataValidator signedDataValidator;
 
   @Captor private ArgumentCaptor<SignedData<ProposalPayload>> payloadArgCaptor;
 
@@ -96,9 +96,9 @@ public class IbftRoundTest {
             worldStateArchive,
             new IbftContext(new VoteTally(Collections.emptyList()), new VoteProposer()));
 
-    when(messageValidator.addSignedProposalPayload(any())).thenReturn(true);
-    when(messageValidator.validatePrepareMessage(any())).thenReturn(true);
-    when(messageValidator.validateCommmitMessage(any())).thenReturn(true);
+    when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(true);
+    when(signedDataValidator.validatePrepareMessage(any())).thenReturn(true);
+    when(signedDataValidator.validateCommmitMessage(any())).thenReturn(true);
 
     proposedExtraData =
         new IbftExtraData(
@@ -124,7 +124,7 @@ public class IbftRoundTest {
 
   @Test
   public void onReceptionOfValidProposalSendsAPrepareToNetworkPeers() {
-    final RoundState roundState = new RoundState(roundIdentifier, 3, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 3, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -144,7 +144,7 @@ public class IbftRoundTest {
 
   @Test
   public void sendsAProposalWhenRequested() {
-    final RoundState roundState = new RoundState(roundIdentifier, 3, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 3, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -164,7 +164,7 @@ public class IbftRoundTest {
 
   @Test
   public void singleValidatorImportBlocksImmediatelyOnProposalCreation() {
-    final RoundState roundState = new RoundState(roundIdentifier, 1, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 1, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -184,7 +184,7 @@ public class IbftRoundTest {
 
   @Test
   public void twoValidatorNetworkSendsPrepareOnProposalReceptionThenSendsCommitOnCommitReceive() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -227,7 +227,7 @@ public class IbftRoundTest {
 
   @Test
   public void localNodeProposesToNetworkOfTwoValidatorsImportsOnReceptionOfCommitFromPeer() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -263,7 +263,7 @@ public class IbftRoundTest {
 
   @Test
   public void aNewRoundMessageWithAnewBlockIsSentUponReceptionOfARoundChangeWithNoCertificate() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -286,7 +286,7 @@ public class IbftRoundTest {
   @Test
   public void aNewRoundMessageWithTheSameBlockIsSentUponReceptionOfARoundChangeWithCertificate() {
     final ConsensusRoundIdentifier priorRoundChange = new ConsensusRoundIdentifier(1, 0);
-    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -332,7 +332,7 @@ public class IbftRoundTest {
 
   @Test
   public void creatingNewBlockFromEmptyPreparedCertificateUpdatesInternalState() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -365,7 +365,7 @@ public class IbftRoundTest {
 
   @Test
   public void creatingNewBlockNotifiesBlockMiningObservers() {
-    final RoundState roundState = new RoundState(roundIdentifier, 1, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 1, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -384,7 +384,7 @@ public class IbftRoundTest {
   public void blockIsOnlyImportedOnceWhenCommitsAreReceivedBeforeProposal() {
     final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
     final int QUORUM_SIZE = 2;
-    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -409,7 +409,7 @@ public class IbftRoundTest {
   @Test
   public void blockIsImportedOnlyOnceIfQuorumCommitsAreReceivedPriorToProposal() {
     final int QUORUM_SIZE = 1;
-    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, messageValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, signedDataValidator);
     final IbftRound round =
         new IbftRound(
             roundState,

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundTest.java
@@ -32,9 +32,7 @@ import tech.pegasys.pantheon.consensus.ibft.blockcreation.IbftBlockCreator;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.network.IbftMessageTransmitter;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.RoundChangeManager.RoundChangeArtefacts;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
 import tech.pegasys.pantheon.crypto.SECP256K1;
@@ -74,23 +72,15 @@ public class IbftRoundTest {
   private final Subscribers<MinedBlockObserver> subscribers = new Subscribers<>();
   private ProtocolContext<IbftContext> protocolContext;
 
-  @Mock
-  private MutableBlockchain blockChain;
-  @Mock
-  private WorldStateArchive worldStateArchive;
-  @Mock
-  private BlockImporter<IbftContext> blockImporter;
-  @Mock
-  private IbftMessageTransmitter transmitter;
-  @Mock
-  private MinedBlockObserver minedBlockObserver;
-  @Mock
-  private IbftBlockCreator blockCreator;
-  @Mock
-  private MessageValidator messageValidator;
+  @Mock private MutableBlockchain blockChain;
+  @Mock private WorldStateArchive worldStateArchive;
+  @Mock private BlockImporter<IbftContext> blockImporter;
+  @Mock private IbftMessageTransmitter transmitter;
+  @Mock private MinedBlockObserver minedBlockObserver;
+  @Mock private IbftBlockCreator blockCreator;
+  @Mock private MessageValidator messageValidator;
 
-  @Captor
-  private ArgumentCaptor<Proposal> proposalCaptor;
+  @Captor private ArgumentCaptor<Proposal> proposalCaptor;
 
   private Block proposedBlock;
   private IbftExtraData proposedExtraData;
@@ -315,10 +305,11 @@ public class IbftRoundTest {
                 messageFactory
                     .createSignedRoundChangePayload(
                         roundIdentifier,
-                        Optional.of(new TerminatedRoundArtefacts(
-                            messageFactory
-                                .createSignedProposalPayload(priorRoundChange, proposedBlock),
-                            Collections.emptyList())))
+                        Optional.of(
+                            new TerminatedRoundArtefacts(
+                                messageFactory.createSignedProposalPayload(
+                                    priorRoundChange, proposedBlock),
+                                Collections.emptyList())))
                     .getSignedPayload()));
     // NOTE: IbftRound assumes the prepare's are valid
 
@@ -329,8 +320,7 @@ public class IbftRoundTest {
             eq(roundIdentifier), eq(roundChangeCertificate), proposalCaptor.capture());
 
     final IbftExtraData proposedExtraData =
-        IbftExtraData.decode(
-            proposalCaptor.getValue().getBlock().getHeader().getExtraData());
+        IbftExtraData.decode(proposalCaptor.getValue().getBlock().getHeader().getExtraData());
     assertThat(proposedExtraData.getRound()).isEqualTo(roundIdentifier.getRoundNumber());
 
     // Inject a single Prepare message, and confirm the roundState has gone to Prepared (which

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftRoundTest.java
@@ -78,7 +78,7 @@ public class IbftRoundTest {
   @Mock private IbftMessageTransmitter transmitter;
   @Mock private MinedBlockObserver minedBlockObserver;
   @Mock private IbftBlockCreator blockCreator;
-  @Mock private SignedDataValidator signedDataValidator;
+  @Mock private MessageValidator messageValidator;
 
   @Captor private ArgumentCaptor<SignedData<ProposalPayload>> payloadArgCaptor;
 
@@ -96,9 +96,9 @@ public class IbftRoundTest {
             worldStateArchive,
             new IbftContext(new VoteTally(Collections.emptyList()), new VoteProposer()));
 
-    when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(true);
-    when(signedDataValidator.validatePrepareMessage(any())).thenReturn(true);
-    when(signedDataValidator.validateCommmitMessage(any())).thenReturn(true);
+    when(messageValidator.addSignedProposalPayload(any())).thenReturn(true);
+    when(messageValidator.validatePreparePayload(any())).thenReturn(true);
+    when(messageValidator.validateCommmitPayload(any())).thenReturn(true);
 
     proposedExtraData =
         new IbftExtraData(
@@ -124,7 +124,7 @@ public class IbftRoundTest {
 
   @Test
   public void onReceptionOfValidProposalSendsAPrepareToNetworkPeers() {
-    final RoundState roundState = new RoundState(roundIdentifier, 3, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 3, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -144,7 +144,7 @@ public class IbftRoundTest {
 
   @Test
   public void sendsAProposalWhenRequested() {
-    final RoundState roundState = new RoundState(roundIdentifier, 3, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 3, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -164,7 +164,7 @@ public class IbftRoundTest {
 
   @Test
   public void singleValidatorImportBlocksImmediatelyOnProposalCreation() {
-    final RoundState roundState = new RoundState(roundIdentifier, 1, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 1, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -184,7 +184,7 @@ public class IbftRoundTest {
 
   @Test
   public void twoValidatorNetworkSendsPrepareOnProposalReceptionThenSendsCommitOnCommitReceive() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -227,7 +227,7 @@ public class IbftRoundTest {
 
   @Test
   public void localNodeProposesToNetworkOfTwoValidatorsImportsOnReceptionOfCommitFromPeer() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -263,7 +263,7 @@ public class IbftRoundTest {
 
   @Test
   public void aNewRoundMessageWithAnewBlockIsSentUponReceptionOfARoundChangeWithNoCertificate() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -286,7 +286,7 @@ public class IbftRoundTest {
   @Test
   public void aNewRoundMessageWithTheSameBlockIsSentUponReceptionOfARoundChangeWithCertificate() {
     final ConsensusRoundIdentifier priorRoundChange = new ConsensusRoundIdentifier(1, 0);
-    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -332,7 +332,7 @@ public class IbftRoundTest {
 
   @Test
   public void creatingNewBlockFromEmptyPreparedCertificateUpdatesInternalState() {
-    final RoundState roundState = new RoundState(roundIdentifier, 2, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -365,7 +365,7 @@ public class IbftRoundTest {
 
   @Test
   public void creatingNewBlockNotifiesBlockMiningObservers() {
-    final RoundState roundState = new RoundState(roundIdentifier, 1, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, 1, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -384,7 +384,7 @@ public class IbftRoundTest {
   public void blockIsOnlyImportedOnceWhenCommitsAreReceivedBeforeProposal() {
     final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
     final int QUORUM_SIZE = 2;
-    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,
@@ -409,7 +409,7 @@ public class IbftRoundTest {
   @Test
   public void blockIsImportedOnlyOnceIfQuorumCommitsAreReceivedPriorToProposal() {
     final int QUORUM_SIZE = 1;
-    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, signedDataValidator);
+    final RoundState roundState = new RoundState(roundIdentifier, QUORUM_SIZE, messageValidator);
     final IbftRound round =
         new IbftRound(
             roundState,

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManagerTest.java
@@ -25,10 +25,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparePayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
-import tech.pegasys.pantheon.consensus.ibft.payload.ProposalPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.SignedData;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
 import tech.pegasys.pantheon.consensus.ibft.validation.ProposalBlockConsistencyChecker;
 import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeMessageValidator;
@@ -41,7 +37,6 @@ import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.chain.MutableBlockchain;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
-import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 import tech.pegasys.pantheon.ethereum.core.Util;
 import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
 
@@ -88,35 +83,38 @@ public class RoundChangeManagerTest {
 
     final RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory
         signedDataValidatorForHeightFactory =
-        mock(RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory.class);
+            mock(RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory.class);
 
     when(signedDataValidatorForHeightFactory.createAt(ri1))
         .thenAnswer(
             invocation ->
                 new MessageValidator(
-                    new SignedDataValidator(validators,
-                        Util.publicKeyToAddress(proposerKey.getPublicKey()), ri1),
+                    new SignedDataValidator(
+                        validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri1),
                     new ProposalBlockConsistencyChecker(blockValidator, protocolContext)));
     when(signedDataValidatorForHeightFactory.createAt(ri2))
         .thenAnswer(
             invocation ->
                 new MessageValidator(
-                    new SignedDataValidator(validators,
-                        Util.publicKeyToAddress(proposerKey.getPublicKey()), ri2),
+                    new SignedDataValidator(
+                        validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri2),
                     new ProposalBlockConsistencyChecker(blockValidator, protocolContext)));
     when(signedDataValidatorForHeightFactory.createAt(ri3))
         .thenAnswer(
             invocation ->
                 new MessageValidator(
-                    new SignedDataValidator(validators,
-                        Util.publicKeyToAddress(proposerKey.getPublicKey()), ri3),
+                    new SignedDataValidator(
+                        validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri3),
                     new ProposalBlockConsistencyChecker(blockValidator, protocolContext)));
 
     final RoundChangeMessageValidator roundChangeMessageValidator =
         new RoundChangeMessageValidator(
-            new RoundChangeSignedDataValidator(signedDataValidatorForHeightFactory, validators,
+            new RoundChangeSignedDataValidator(
+                signedDataValidatorForHeightFactory,
+                validators,
                 IbftHelpers.calculateRequiredValidatorQuorum(
-                    IbftHelpers.calculateRequiredValidatorQuorum(validators.size())), 2),
+                    IbftHelpers.calculateRequiredValidatorQuorum(validators.size())),
+                2),
             new ProposalBlockConsistencyChecker(blockValidator, protocolContext));
 
     manager = new RoundChangeManager(2, roundChangeMessageValidator);
@@ -139,8 +137,7 @@ public class RoundChangeManagerTest {
     final ConsensusRoundIdentifier proposalRound = TestHelpers.createFrom(round, 0, -1);
     final Block block = TestHelpers.createProposalBlock(validators, proposalRound.getRoundNumber());
     // Proposal must come from an earlier round.
-    final Proposal proposal =
-        messageFactory.createSignedProposalPayload(proposalRound, block);
+    final Proposal proposal = messageFactory.createSignedProposalPayload(proposalRound, block);
 
     final List<Prepare> preparePayloads =
         prepareProviders

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManagerTest.java
@@ -25,7 +25,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
-import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
 import tech.pegasys.pantheon.consensus.ibft.validation.ProposalBlockConsistencyChecker;
 import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeMessageValidator;
 import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeSignedDataValidator;
@@ -83,7 +82,7 @@ public class RoundChangeManagerTest {
 
     final RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory
         signedDataValidatorForHeightFactory =
-        mock(RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory.class);
+            mock(RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory.class);
 
     when(signedDataValidatorForHeightFactory.createAt(ri1))
         .thenAnswer(

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundChangeManagerTest.java
@@ -83,29 +83,23 @@ public class RoundChangeManagerTest {
 
     final RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory
         signedDataValidatorForHeightFactory =
-            mock(RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory.class);
+        mock(RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory.class);
 
     when(signedDataValidatorForHeightFactory.createAt(ri1))
         .thenAnswer(
             invocation ->
-                new MessageValidator(
-                    new SignedDataValidator(
-                        validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri1),
-                    new ProposalBlockConsistencyChecker(blockValidator, protocolContext)));
+                new SignedDataValidator(
+                    validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri1));
     when(signedDataValidatorForHeightFactory.createAt(ri2))
         .thenAnswer(
             invocation ->
-                new MessageValidator(
-                    new SignedDataValidator(
-                        validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri2),
-                    new ProposalBlockConsistencyChecker(blockValidator, protocolContext)));
+                new SignedDataValidator(
+                    validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri2));
     when(signedDataValidatorForHeightFactory.createAt(ri3))
         .thenAnswer(
             invocation ->
-                new MessageValidator(
-                    new SignedDataValidator(
-                        validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri3),
-                    new ProposalBlockConsistencyChecker(blockValidator, protocolContext)));
+                new SignedDataValidator(
+                    validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), ri3));
 
     final RoundChangeMessageValidator roundChangeMessageValidator =
         new RoundChangeMessageValidator(

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundStateTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/RoundStateTest.java
@@ -24,7 +24,6 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.validation.MessageValidator;
-import tech.pegasys.pantheon.consensus.ibft.validation.SignedDataValidator;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.crypto.SECP256K1.Signature;
 import tech.pegasys.pantheon.ethereum.core.Address;
@@ -101,7 +100,8 @@ public class RoundStateTest {
     assertThat(roundState.isPrepared()).isTrue();
     assertThat(roundState.isCommitted()).isFalse();
     assertThat(roundState.getReceivedArtefacts()).isNotEmpty();
-    assertThat(roundState.getReceivedArtefacts().get().getPreparedCertificate().getProposalPayload())
+    assertThat(
+            roundState.getReceivedArtefacts().get().getPreparedCertificate().getProposalPayload())
         .isEqualTo(proposal.getSignedPayload());
   }
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidatorTest.java
@@ -58,7 +58,7 @@ public class NewRoundMessageValidatorTest {
   private final ProposerSelector proposerSelector = mock(ProposerSelector.class);
   private final MessageValidatorForHeightFactory validatorFactory =
       mock(MessageValidatorForHeightFactory.class);
-  private final SignedDataValidator signedDataValidator = mock(SignedDataValidator.class);
+  private final SignedDataValidator messageValidator = mock(SignedDataValidator.class);
 
   private Block proposedBlock;
   private NewRound validMsg;
@@ -78,9 +78,9 @@ public class NewRoundMessageValidatorTest {
 
     when(proposerSelector.selectProposerForRound(any())).thenReturn(proposerAddress);
 
-    when(validatorFactory.createAt(any())).thenReturn(signedDataValidator);
-    when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(true);
-    when(signedDataValidator.validatePrepareMessage(any())).thenReturn(true);
+    when(validatorFactory.createAt(any())).thenReturn(messageValidator);
+    when(messageValidator.addSignedProposalPayload(any())).thenReturn(true);
+    when(messageValidator.validatePreparePayload(any())).thenReturn(true);
 
     validator =
         new NewRoundMessageValidator(
@@ -226,7 +226,7 @@ public class NewRoundMessageValidatorTest {
     msgBuilder.setRoundChangeCertificate(roundChangeBuilder.buildCertificate());
 
     // The prepare Message in the RoundChange Cert will be deemed illegal.
-    when(signedDataValidator.validatePrepareMessage(any())).thenReturn(false);
+    when(messageValidator.validatePreparePayload(any())).thenReturn(false);
 
     final NewRound msg = signPayload(msgBuilder.build(), proposerKey);
 
@@ -293,7 +293,7 @@ public class NewRoundMessageValidatorTest {
 
   @Test
   public void embeddedProposalFailsValidation() {
-    when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(false, true);
+    when(messageValidator.addSignedProposalPayload(any())).thenReturn(false, true);
 
     final Proposal proposal =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, proposedBlock);

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidatorTest.java
@@ -25,10 +25,8 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.NewRound;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.NewRoundPayload;
-import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangeCertificate;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
-import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeMessageValidator.MessageValidatorForHeightFactory;
 import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.ethereum.core.Address;
@@ -86,7 +84,9 @@ public class NewRoundMessageValidatorTest {
 
     validator =
         new NewRoundMessageValidator(
-            validators, proposerSelector, validatorFactory,
+            validators,
+            proposerSelector,
+            validatorFactory,
             new ProposalBlockConsistencyChecker(null, null),
             1,
             chainHeight);
@@ -174,11 +174,10 @@ public class NewRoundMessageValidatorTest {
 
     final TerminatedRoundArtefacts terminatedRoundArtefact =
         new TerminatedRoundArtefacts(
-            proposerMessageFactory
-                .createSignedProposalPayload(preparedRound, prevProposedBlock),
+            proposerMessageFactory.createSignedProposalPayload(preparedRound, prevProposedBlock),
             singletonList(
-                validatorMessageFactory
-                    .createSignedPreparePayload(preparedRound, prevProposedBlock.getHash())));
+                validatorMessageFactory.createSignedPreparePayload(
+                    preparedRound, prevProposedBlock.getHash())));
 
     msgBuilder.setRoundChangeCertificate(
         new RoundChangeCertificate(
@@ -220,11 +219,10 @@ public class NewRoundMessageValidatorTest {
             roundIdentifier,
             Optional.of(
                 new TerminatedRoundArtefacts(
-                    proposerMessageFactory
-                        .createSignedProposalPayload(prevRound, proposedBlock),
+                    proposerMessageFactory.createSignedProposalPayload(prevRound, proposedBlock),
                     Lists.newArrayList(
-                        validatorMessageFactory
-                            .createSignedPreparePayload(prevRound, proposedBlock.getHash()))))));
+                        validatorMessageFactory.createSignedPreparePayload(
+                            prevRound, proposedBlock.getHash()))))));
 
     msgBuilder.setRoundChangeCertificate(roundChangeBuilder.buildCertificate());
 
@@ -248,8 +246,8 @@ public class NewRoundMessageValidatorTest {
             new TerminatedRoundArtefacts(
                 latterProposal,
                 Lists.newArrayList(
-                    validatorMessageFactory
-                        .createSignedPreparePayload(roundIdentifier, proposedBlock.getHash()))));
+                    validatorMessageFactory.createSignedPreparePayload(
+                        roundIdentifier, proposedBlock.getHash()))));
 
     // An earlier PrepareCert is added to ensure the path to find the latest PrepareCert
     // is correctly followed.
@@ -265,9 +263,8 @@ public class NewRoundMessageValidatorTest {
             new TerminatedRoundArtefacts(
                 earlierProposal,
                 Lists.newArrayList(
-                    validatorMessageFactory
-                        .createSignedPreparePayload(earlierPreparedRound,
-                            earlierBlock.getHash()))));
+                    validatorMessageFactory.createSignedPreparePayload(
+                        earlierPreparedRound, earlierBlock.getHash()))));
 
     final RoundChangeCertificate roundChangeCert =
         new RoundChangeCertificate(
@@ -282,17 +279,19 @@ public class NewRoundMessageValidatorTest {
     // Ensure a message containing the earlier proposal fails
     final NewRound newRoundWithEarlierProposal =
         proposerMessageFactory.createSignedNewRoundPayload(
-            roundIdentifier, roundChangeCert, earlierProposal.getSignedPayload(),
+            roundIdentifier,
+            roundChangeCert,
+            earlierProposal.getSignedPayload(),
             earlierProposal.getBlock());
-    assertThat(validator.validateNewRoundMessage(newRoundWithEarlierProposal))
-        .isFalse();
+    assertThat(validator.validateNewRoundMessage(newRoundWithEarlierProposal)).isFalse();
 
     final NewRound newRoundWithLatterProposal =
         proposerMessageFactory.createSignedNewRoundPayload(
-            roundIdentifier, roundChangeCert, latterProposal.getSignedPayload(),
+            roundIdentifier,
+            roundChangeCert,
+            latterProposal.getSignedPayload(),
             latterProposal.getBlock());
-    assertThat(validator.validateNewRoundMessage(newRoundWithLatterProposal))
-        .isTrue();
+    assertThat(validator.validateNewRoundMessage(newRoundWithLatterProposal)).isTrue();
   }
 
   @Test

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/NewRoundMessageValidatorTest.java
@@ -58,7 +58,7 @@ public class NewRoundMessageValidatorTest {
   private final ProposerSelector proposerSelector = mock(ProposerSelector.class);
   private final MessageValidatorForHeightFactory validatorFactory =
       mock(MessageValidatorForHeightFactory.class);
-  private final MessageValidator messageValidator = mock(MessageValidator.class);
+  private final SignedDataValidator signedDataValidator = mock(SignedDataValidator.class);
 
   private Block proposedBlock;
   private NewRound validMsg;
@@ -78,9 +78,9 @@ public class NewRoundMessageValidatorTest {
 
     when(proposerSelector.selectProposerForRound(any())).thenReturn(proposerAddress);
 
-    when(validatorFactory.createAt(any())).thenReturn(messageValidator);
-    when(messageValidator.addSignedProposalPayload(any())).thenReturn(true);
-    when(messageValidator.validatePrepareMessage(any())).thenReturn(true);
+    when(validatorFactory.createAt(any())).thenReturn(signedDataValidator);
+    when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(true);
+    when(signedDataValidator.validatePrepareMessage(any())).thenReturn(true);
 
     validator =
         new NewRoundMessageValidator(
@@ -226,7 +226,7 @@ public class NewRoundMessageValidatorTest {
     msgBuilder.setRoundChangeCertificate(roundChangeBuilder.buildCertificate());
 
     // The prepare Message in the RoundChange Cert will be deemed illegal.
-    when(messageValidator.validatePrepareMessage(any())).thenReturn(false);
+    when(signedDataValidator.validatePrepareMessage(any())).thenReturn(false);
 
     final NewRound msg = signPayload(msgBuilder.build(), proposerKey);
 
@@ -293,7 +293,7 @@ public class NewRoundMessageValidatorTest {
 
   @Test
   public void embeddedProposalFailsValidation() {
-    when(messageValidator.addSignedProposalPayload(any())).thenReturn(false, true);
+    when(signedDataValidator.addSignedProposalPayload(any())).thenReturn(false, true);
 
     final Proposal proposal =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, proposedBlock);

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
+import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
@@ -75,7 +76,7 @@ public class RoundChangeMessageValidatorTest {
     // By default, have all basic messages being valid thus any failures are attributed to logic
     // in the RoundChangeMessageValidator
     when(basicValidator.addSignedProposalPayload(any())).thenReturn(true);
-    when(basicValidator.validatePrepareMessage(any())).thenReturn(true);
+    when(basicValidator.validatePreparePayload(any())).thenReturn(true);
   }
 
   @Test
@@ -112,9 +113,9 @@ public class RoundChangeMessageValidatorTest {
     verify(validatorFactory, times(1))
         .createAt(prepareCertificate.getProposalPayload().getPayload().getRoundIdentifier());
     verify(basicValidator, times(1))
-        .addSignedProposalPayload(prepareCertificate.getProposalPayload());
-    verify(basicValidator, never()).validatePrepareMessage(any());
-    verify(basicValidator, never()).validateCommmitMessage(any());
+        .addSignedProposalPayload(new Proposal(prepareCertificate.getProposalPayload()));
+    verify(basicValidator, never()).validatePreparePayload(any());
+    verify(basicValidator, never()).validateCommmitPayload(any());
   }
 
   @Test
@@ -146,7 +147,7 @@ public class RoundChangeMessageValidatorTest {
             Lists.newArrayList(prepareMsg.getSignedPayload()));
 
     when(basicValidator.addSignedProposalPayload(any())).thenReturn(true);
-    when(basicValidator.validatePrepareMessage(any())).thenReturn(false);
+    when(basicValidator.validatePreparePayload(any())).thenReturn(false);
 
     final RoundChange msg =
         proposerMessageFactory.createSignedRoundChangePayload(
@@ -154,8 +155,8 @@ public class RoundChangeMessageValidatorTest {
 
     assertThat(validator.validateMessage(msg.getSignedPayload())).isFalse();
 
-    verify(basicValidator, times(1)).validatePrepareMessage(prepareMsg.getSignedPayload());
-    verify(basicValidator, never()).validateCommmitMessage(any());
+    verify(basicValidator, times(1)).validatePreparePayload(prepareMsg);
+    verify(basicValidator, never()).validateCommmitPayload(any());
   }
 
   @Test
@@ -168,7 +169,7 @@ public class RoundChangeMessageValidatorTest {
             latterRoundIdentifier, Optional.empty());
 
     assertThat(validator.validateMessage(msg.getSignedPayload())).isFalse();
-    verify(basicValidator, never()).validatePrepareMessage(any());
+    verify(basicValidator, never()).validatePreparePayload(any());
   }
 
   @Test
@@ -192,8 +193,8 @@ public class RoundChangeMessageValidatorTest {
 
     assertThat(validator.validateMessage(msg.getSignedPayload())).isFalse();
     verify(validatorFactory, never()).createAt(any());
-    verify(basicValidator, never()).validatePrepareMessage(prepareMsg.getSignedPayload());
-    verify(basicValidator, never()).validateCommmitMessage(any());
+    verify(basicValidator, never()).validatePreparePayload(prepareMsg);
+    verify(basicValidator, never()).validateCommmitPayload(any());
   }
 
   @Test
@@ -211,15 +212,16 @@ public class RoundChangeMessageValidatorTest {
         proposerMessageFactory.createSignedRoundChangePayload(
             targetRound, Optional.of(prepareCertificate));
 
-    when(basicValidator.addSignedProposalPayload(prepareCertificate.getProposalPayload()))
+    when(basicValidator.addSignedProposalPayload(
+            new Proposal(prepareCertificate.getProposalPayload())))
         .thenReturn(true);
-    when(basicValidator.validatePrepareMessage(prepareMsg.getSignedPayload())).thenReturn(true);
+    when(basicValidator.validatePreparePayload(prepareMsg)).thenReturn(true);
 
     assertThat(validator.validateMessage(msg.getSignedPayload())).isTrue();
     verify(validatorFactory, times(1))
         .createAt(prepareCertificate.getProposalPayload().getPayload().getRoundIdentifier());
     verify(basicValidator, times(1))
-        .addSignedProposalPayload(prepareCertificate.getProposalPayload());
-    verify(basicValidator, times(1)).validatePrepareMessage(prepareMsg.getSignedPayload());
+        .addSignedProposalPayload(new Proposal(prepareCertificate.getProposalPayload()));
+    verify(basicValidator, times(1)).validatePreparePayload(prepareMsg);
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
@@ -22,12 +22,10 @@ import static org.mockito.Mockito.when;
 
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
-import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.statemachine.TerminatedRoundArtefacts;
-import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeMessageValidator.MessageValidatorForHeightFactory;
 import tech.pegasys.pantheon.consensus.ibft.validation.RoundChangeSignedDataValidator.SignedDataValidatorForHeightFactory;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.ethereum.core.Address;
@@ -66,8 +64,8 @@ public class RoundChangeMessageValidatorTest {
       mock(SignedDataValidatorForHeightFactory.class);
   private final RoundChangeMessageValidator validator =
       new RoundChangeMessageValidator(
-          new RoundChangeSignedDataValidator(roundIdentifier -> basicValidator, validators, 1,
-              chainHeight),
+          new RoundChangeSignedDataValidator(
+              roundIdentifier -> basicValidator, validators, 1, chainHeight),
           new ProposalBlockConsistencyChecker(null, null));
 
   @Before
@@ -101,10 +99,10 @@ public class RoundChangeMessageValidatorTest {
 
   @Test
   public void roundChangeContainingInvalidProposalFails() {
-    final TerminatedRoundArtefacts terminatedRoundArtefacts = new TerminatedRoundArtefacts(
-        proposerMessageFactory
-            .createSignedProposalPayload(currentRound, block),
-        Collections.emptyList());
+    final TerminatedRoundArtefacts terminatedRoundArtefacts =
+        new TerminatedRoundArtefacts(
+            proposerMessageFactory.createSignedProposalPayload(currentRound, block),
+            Collections.emptyList());
 
     final RoundChange msg =
         proposerMessageFactory.createSignedRoundChangePayload(
@@ -117,8 +115,7 @@ public class RoundChangeMessageValidatorTest {
 
     assertThat(validator.validateMessage(msg)).isFalse();
     verify(validatorFactory, times(1))
-        .createAt(preparedCertificate.getProposalPayload()
-            .getPayload().getRoundIdentifier());
+        .createAt(preparedCertificate.getProposalPayload().getPayload().getRoundIdentifier());
     verify(basicValidator, times(1))
         .addSignedProposalPayload(preparedCertificate.getProposalPayload());
     verify(basicValidator, never()).validatePreparePayload(any());
@@ -127,10 +124,10 @@ public class RoundChangeMessageValidatorTest {
 
   @Test
   public void roundChangeContainingValidProposalButNoPrepareMessagesFails() {
-    final TerminatedRoundArtefacts terminatedRoundArtefacts = new TerminatedRoundArtefacts(
-        proposerMessageFactory
-            .createSignedProposalPayload(currentRound, block),
-        Collections.emptyList());
+    final TerminatedRoundArtefacts terminatedRoundArtefacts =
+        new TerminatedRoundArtefacts(
+            proposerMessageFactory.createSignedProposalPayload(currentRound, block),
+            Collections.emptyList());
 
     final RoundChange msg =
         proposerMessageFactory.createSignedRoundChangePayload(
@@ -144,9 +141,9 @@ public class RoundChangeMessageValidatorTest {
   public void roundChangeInvalidPrepareMessageFromProposerFails() {
     final Prepare prepareMsg =
         validatorMessageFactory.createSignedPreparePayload(currentRound, block.getHash());
-    final TerminatedRoundArtefacts terminatedRoundArtefacts = new TerminatedRoundArtefacts(
-            proposerMessageFactory
-                .createSignedProposalPayload(currentRound, block),
+    final TerminatedRoundArtefacts terminatedRoundArtefacts =
+        new TerminatedRoundArtefacts(
+            proposerMessageFactory.createSignedProposalPayload(currentRound, block),
             Lists.newArrayList(prepareMsg));
 
     when(basicValidator.addSignedProposalPayload(any())).thenReturn(true);
@@ -183,9 +180,9 @@ public class RoundChangeMessageValidatorTest {
 
     final Prepare prepareMsg =
         validatorMessageFactory.createSignedPreparePayload(futureRound, block.getHash());
-    final TerminatedRoundArtefacts terminatedRoundArtefacts = new TerminatedRoundArtefacts(
-            proposerMessageFactory
-                .createSignedProposalPayload(futureRound, block),
+    final TerminatedRoundArtefacts terminatedRoundArtefacts =
+        new TerminatedRoundArtefacts(
+            proposerMessageFactory.createSignedProposalPayload(futureRound, block),
             Lists.newArrayList(prepareMsg));
 
     final RoundChange msg =
@@ -202,16 +199,17 @@ public class RoundChangeMessageValidatorTest {
   public void roundChangeWithPastProposalForCurrentHeightIsSuccessful() {
     final Prepare prepareMsg =
         validatorMessageFactory.createSignedPreparePayload(currentRound, block.getHash());
-    final TerminatedRoundArtefacts terminatedRoundArtefacts = new TerminatedRoundArtefacts(
-            proposerMessageFactory
-                .createSignedProposalPayload(currentRound, block),
+    final TerminatedRoundArtefacts terminatedRoundArtefacts =
+        new TerminatedRoundArtefacts(
+            proposerMessageFactory.createSignedProposalPayload(currentRound, block),
             Lists.newArrayList(prepareMsg));
 
     final RoundChange msg =
         proposerMessageFactory.createSignedRoundChangePayload(
             targetRound, Optional.of(terminatedRoundArtefacts));
 
-    final PreparedCertificate prepareCertificate = terminatedRoundArtefacts.getPreparedCertificate();
+    final PreparedCertificate prepareCertificate =
+        terminatedRoundArtefacts.getPreparedCertificate();
 
     when(basicValidator.addSignedProposalPayload(prepareCertificate.getProposalPayload()))
         .thenReturn(true);

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
@@ -56,7 +56,7 @@ public class RoundChangeMessageValidatorTest {
 
   private final Block block = mock(Block.class);
 
-  private final MessageValidator basicValidator = mock(MessageValidator.class);
+  private final SignedDataValidator basicValidator = mock(SignedDataValidator.class);
   private final List<Address> validators = Lists.newArrayList();
 
   private final MessageValidatorForHeightFactory validatorFactory =

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeSignedDataValidatorTest.java
@@ -20,16 +20,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
 import tech.pegasys.pantheon.consensus.ibft.TestHelpers;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
-import tech.pegasys.pantheon.consensus.ibft.messagewrappers.RoundChange;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.consensus.ibft.payload.PreparedCertificate;
 import tech.pegasys.pantheon.consensus.ibft.payload.RoundChangePayload;
@@ -40,6 +33,14 @@ import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
 import tech.pegasys.pantheon.ethereum.core.Util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
 
 public class RoundChangeSignedDataValidatorTest {
 
@@ -63,8 +64,7 @@ public class RoundChangeSignedDataValidatorTest {
   private final SignedDataValidatorForHeightFactory validatorFactory =
       mock(SignedDataValidatorForHeightFactory.class);
   private final RoundChangeSignedDataValidator validator =
-      new RoundChangeSignedDataValidator(
-          validatorFactory, validators, 1, chainHeight);
+      new RoundChangeSignedDataValidator(validatorFactory, validators, 1, chainHeight);
 
   @Before
   public void setup() {
@@ -84,7 +84,8 @@ public class RoundChangeSignedDataValidatorTest {
   @Test
   public void roundChangeSentByNonValidatorFails() {
     final SignedData<RoundChangePayload> payload =
-        nonValidatorMessageFactory.createSignedRoundChangePayload(targetRound, Optional.empty())
+        nonValidatorMessageFactory
+            .createSignedRoundChangePayload(targetRound, Optional.empty())
             .getSignedPayload();
     assertThat(validator.validatePayload(payload)).isFalse();
   }
@@ -92,7 +93,8 @@ public class RoundChangeSignedDataValidatorTest {
   @Test
   public void roundChangeContainingNoCertificateIsSuccessful() {
     final SignedData<RoundChangePayload> payload =
-        proposerMessageFactory.createSignedRoundChangePayload(targetRound, Optional.empty())
+        proposerMessageFactory
+            .createSignedRoundChangePayload(targetRound, Optional.empty())
             .getSignedPayload();
 
     assertThat(validator.validatePayload(payload)).isTrue();
@@ -106,8 +108,9 @@ public class RoundChangeSignedDataValidatorTest {
             Collections.emptyList());
 
     final SignedData<RoundChangePayload> payload =
-        proposerMessageFactory.createSignedRoundChangePayload(
-            targetRound, Optional.of(terminatedRoundArtefacts)).getSignedPayload();
+        proposerMessageFactory
+            .createSignedRoundChangePayload(targetRound, Optional.of(terminatedRoundArtefacts))
+            .getSignedPayload();
 
     when(basicValidator.addSignedProposalPayload(any())).thenReturn(false);
 
@@ -131,8 +134,9 @@ public class RoundChangeSignedDataValidatorTest {
             Collections.emptyList());
 
     final SignedData<RoundChangePayload> payload =
-        proposerMessageFactory.createSignedRoundChangePayload(
-            targetRound, Optional.of(terminatedRoundArtefacts)).getSignedPayload();
+        proposerMessageFactory
+            .createSignedRoundChangePayload(targetRound, Optional.of(terminatedRoundArtefacts))
+            .getSignedPayload();
 
     when(basicValidator.addSignedProposalPayload(any())).thenReturn(true);
     assertThat(validator.validatePayload(payload)).isFalse();
@@ -151,8 +155,9 @@ public class RoundChangeSignedDataValidatorTest {
     when(basicValidator.validatePreparePayload(any())).thenReturn(false);
 
     final SignedData<RoundChangePayload> payload =
-        proposerMessageFactory.createSignedRoundChangePayload(
-            targetRound, Optional.of(terminatedRoundArtefacts)).getSignedPayload();
+        proposerMessageFactory
+            .createSignedRoundChangePayload(targetRound, Optional.of(terminatedRoundArtefacts))
+            .getSignedPayload();
 
     assertThat(validator.validatePayload(payload)).isFalse();
 
@@ -166,8 +171,9 @@ public class RoundChangeSignedDataValidatorTest {
         new ConsensusRoundIdentifier(currentRound.getSequenceNumber() + 1, 1);
 
     final SignedData<RoundChangePayload> payload =
-        proposerMessageFactory.createSignedRoundChangePayload(
-            latterRoundIdentifier, Optional.empty()).getSignedPayload();
+        proposerMessageFactory
+            .createSignedRoundChangePayload(latterRoundIdentifier, Optional.empty())
+            .getSignedPayload();
 
     assertThat(validator.validatePayload(payload)).isFalse();
     verify(basicValidator, never()).validatePreparePayload(any());
@@ -187,8 +193,9 @@ public class RoundChangeSignedDataValidatorTest {
             Lists.newArrayList(prepareMsg));
 
     final SignedData<RoundChangePayload> payload =
-        proposerMessageFactory.createSignedRoundChangePayload(
-            targetRound, Optional.of(terminatedRoundArtefacts)).getSignedPayload();
+        proposerMessageFactory
+            .createSignedRoundChangePayload(targetRound, Optional.of(terminatedRoundArtefacts))
+            .getSignedPayload();
 
     assertThat(validator.validatePayload(payload)).isFalse();
     verify(validatorFactory, never()).createAt(any());
@@ -206,8 +213,9 @@ public class RoundChangeSignedDataValidatorTest {
             Lists.newArrayList(prepareMsg));
 
     final SignedData<RoundChangePayload> payload =
-        proposerMessageFactory.createSignedRoundChangePayload(
-            targetRound, Optional.of(terminatedRoundArtefacts)).getSignedPayload();
+        proposerMessageFactory
+            .createSignedRoundChangePayload(targetRound, Optional.of(terminatedRoundArtefacts))
+            .getSignedPayload();
 
     final PreparedCertificate prepareCertificate =
         terminatedRoundArtefacts.getPreparedCertificate();

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -80,9 +80,7 @@ public class SignedDataValidatorTest {
 
     validator =
         new SignedDataValidator(
-            validators,
-            Util.publicKeyToAddress(proposerKey.getPublicKey()),
-            roundIdentifier);
+            validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), roundIdentifier);
 
     when(block.getHash()).thenReturn(Hash.fromHexStringLenient("1"));
     when(blockValidator.validateAndProcessBlock(any(), any(), any(), any()))

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -51,7 +51,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class MessageValidatorTest {
+public class SignedDataValidatorTest {
 
   private final KeyPair proposerKey = KeyPair.generate();
   private final KeyPair validatorKey = KeyPair.generate();
@@ -65,7 +65,7 @@ public class MessageValidatorTest {
   @Mock private BlockValidator<IbftContext> blockValidator;
   private final BlockHeader parentHeader = mock(BlockHeader.class);
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(2, 0);
-  private MessageValidator validator;
+  private SignedDataValidator validator;
 
   private final Block block = mock(Block.class);
 
@@ -79,7 +79,7 @@ public class MessageValidatorTest {
             mock(MutableBlockchain.class), mock(WorldStateArchive.class), mock(IbftContext.class));
 
     validator =
-        new MessageValidator(
+        new SignedDataValidator(
             validators,
             Util.publicKeyToAddress(proposerKey.getPublicKey()),
             roundIdentifier,

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -12,16 +12,9 @@
  */
 package tech.pegasys.pantheon.consensus.ibft.validation;
 
-import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import tech.pegasys.pantheon.consensus.common.ConsensusHelpers;
 import tech.pegasys.pantheon.consensus.ibft.ConsensusRoundIdentifier;
-import tech.pegasys.pantheon.consensus.ibft.IbftContext;
-import tech.pegasys.pantheon.consensus.ibft.IbftExtraData;
 import tech.pegasys.pantheon.consensus.ibft.TestHelpers;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Commit;
 import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Prepare;
@@ -29,27 +22,17 @@ import tech.pegasys.pantheon.consensus.ibft.messagewrappers.Proposal;
 import tech.pegasys.pantheon.consensus.ibft.payload.MessageFactory;
 import tech.pegasys.pantheon.crypto.SECP256K1;
 import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
-import tech.pegasys.pantheon.ethereum.BlockValidator;
-import tech.pegasys.pantheon.ethereum.BlockValidator.BlockProcessingOutputs;
-import tech.pegasys.pantheon.ethereum.ProtocolContext;
-import tech.pegasys.pantheon.ethereum.chain.MutableBlockchain;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Block;
-import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.core.Util;
-import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
-import tech.pegasys.pantheon.util.bytes.BytesValue;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -107,7 +107,7 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         proposerMessageFactory.createSignedPreparePayload(roundIdentifier, Hash.ZERO);
 
-    assertThat(validator.validatePrepareMessage(prepareMsg.getSignedPayload())).isFalse();
+    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
   }
 
   @Test
@@ -116,7 +116,7 @@ public class SignedDataValidatorTest {
         proposerMessageFactory.createSignedCommitPayload(
             roundIdentifier, Hash.ZERO, SECP256K1.sign(Hash.ZERO, proposerKey));
 
-    assertThat(validator.validateCommmitMessage(commitMsg.getSignedPayload())).isFalse();
+    assertThat(validator.validateCommmitPayload(commitMsg)).isFalse();
   }
 
   @Test
@@ -124,7 +124,7 @@ public class SignedDataValidatorTest {
     final Proposal proposalMsg =
         validatorMessageFactory.createSignedProposalPayload(roundIdentifier, mock(Block.class));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isFalse();
   }
 
   @Test
@@ -133,7 +133,7 @@ public class SignedDataValidatorTest {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, mock(Block.class));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isFalse();
   }
 
   @Test
@@ -144,8 +144,8 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         proposerMessageFactory.createSignedPreparePayload(roundIdentifier, block.getHash());
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
-    assertThat(validator.validatePrepareMessage(prepareMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
   }
 
   @Test
@@ -156,8 +156,8 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         nonValidatorMessageFactory.createSignedPreparePayload(roundIdentifier, block.getHash());
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
-    assertThat(validator.validatePrepareMessage(prepareMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
   }
 
   @Test
@@ -174,9 +174,9 @@ public class SignedDataValidatorTest {
         validatorMessageFactory.createSignedCommitPayload(
             invalidRoundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), proposerKey));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
-    assertThat(validator.validatePrepareMessage(prepareMsg.getSignedPayload())).isFalse();
-    assertThat(validator.validateCommmitMessage(commitMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
+    assertThat(validator.validateCommmitPayload(commitMsg)).isFalse();
   }
 
   @Test
@@ -186,8 +186,8 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         validatorMessageFactory.createSignedPreparePayload(roundIdentifier, block.getHash());
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
-    assertThat(validator.validatePrepareMessage(prepareMsg.getSignedPayload())).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg)).isTrue();
   }
 
   @Test
@@ -199,8 +199,8 @@ public class SignedDataValidatorTest {
         proposerMessageFactory.createSignedCommitPayload(
             roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), nonValidatorKey));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
-    assertThat(validator.validateCommmitMessage(commitMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.validateCommmitPayload(commitMsg)).isFalse();
   }
 
   @Test
@@ -216,43 +216,43 @@ public class SignedDataValidatorTest {
         validatorMessageFactory.createSignedCommitPayload(
             roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), validatorKey));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
-    assertThat(validator.validateCommmitMessage(proposerCommitMsg.getSignedPayload())).isTrue();
-    assertThat(validator.validateCommmitMessage(validatorCommitMsg.getSignedPayload())).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.validateCommmitPayload(proposerCommitMsg)).isTrue();
+    assertThat(validator.validateCommmitPayload(validatorCommitMsg)).isTrue();
   }
 
   @Test
   public void subsequentProposalHasDifferentSenderFails() {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
 
     final Proposal secondProposalMsg =
         validatorMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(secondProposalMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(secondProposalMsg)).isFalse();
   }
 
   @Test
   public void subsequentProposalHasDifferentContentFails() {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
 
     final ConsensusRoundIdentifier newRoundIdentifier = new ConsensusRoundIdentifier(3, 0);
     final Proposal secondProposalMsg =
         proposerMessageFactory.createSignedProposalPayload(newRoundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(secondProposalMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(secondProposalMsg)).isFalse();
   }
 
   @Test
   public void subsequentProposalHasIdenticalSenderAndContentIsSuccessful() {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
 
     final Proposal secondProposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(secondProposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.addSignedProposalPayload(secondProposalMsg)).isTrue();
   }
 
   @Test
@@ -262,6 +262,6 @@ public class SignedDataValidatorTest {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg)).isFalse();
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -82,10 +82,7 @@ public class SignedDataValidatorTest {
         new SignedDataValidator(
             validators,
             Util.publicKeyToAddress(proposerKey.getPublicKey()),
-            roundIdentifier,
-            blockValidator,
-            protocolContext,
-            parentHeader);
+            roundIdentifier);
 
     when(block.getHash()).thenReturn(Hash.fromHexStringLenient("1"));
     when(blockValidator.validateAndProcessBlock(any(), any(), any(), any()))
@@ -107,7 +104,7 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         proposerMessageFactory.createSignedPreparePayload(roundIdentifier, Hash.ZERO);
 
-    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
+    assertThat(validator.validatePreparePayload(prepareMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -116,7 +113,7 @@ public class SignedDataValidatorTest {
         proposerMessageFactory.createSignedCommitPayload(
             roundIdentifier, Hash.ZERO, SECP256K1.sign(Hash.ZERO, proposerKey));
 
-    assertThat(validator.validateCommmitPayload(commitMsg)).isFalse();
+    assertThat(validator.validateCommitPayload(commitMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -124,7 +121,7 @@ public class SignedDataValidatorTest {
     final Proposal proposalMsg =
         validatorMessageFactory.createSignedProposalPayload(roundIdentifier, mock(Block.class));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -133,7 +130,7 @@ public class SignedDataValidatorTest {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, mock(Block.class));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -144,8 +141,8 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         proposerMessageFactory.createSignedPreparePayload(roundIdentifier, block.getHash());
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
-    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -156,8 +153,8 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         nonValidatorMessageFactory.createSignedPreparePayload(roundIdentifier, block.getHash());
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
-    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -174,9 +171,9 @@ public class SignedDataValidatorTest {
         validatorMessageFactory.createSignedCommitPayload(
             invalidRoundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), proposerKey));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
-    assertThat(validator.validatePreparePayload(prepareMsg)).isFalse();
-    assertThat(validator.validateCommmitPayload(commitMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg.getSignedPayload())).isFalse();
+    assertThat(validator.validateCommitPayload(commitMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -186,8 +183,8 @@ public class SignedDataValidatorTest {
     final Prepare prepareMsg =
         validatorMessageFactory.createSignedPreparePayload(roundIdentifier, block.getHash());
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
-    assertThat(validator.validatePreparePayload(prepareMsg)).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.validatePreparePayload(prepareMsg.getSignedPayload())).isTrue();
   }
 
   @Test
@@ -199,8 +196,8 @@ public class SignedDataValidatorTest {
         proposerMessageFactory.createSignedCommitPayload(
             roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), nonValidatorKey));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
-    assertThat(validator.validateCommmitPayload(commitMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.validateCommitPayload(commitMsg.getSignedPayload())).isFalse();
   }
 
   @Test
@@ -216,43 +213,43 @@ public class SignedDataValidatorTest {
         validatorMessageFactory.createSignedCommitPayload(
             roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), validatorKey));
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
-    assertThat(validator.validateCommmitPayload(proposerCommitMsg)).isTrue();
-    assertThat(validator.validateCommmitPayload(validatorCommitMsg)).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
+    assertThat(validator.validateCommitPayload(proposerCommitMsg.getSignedPayload())).isTrue();
+    assertThat(validator.validateCommitPayload(validatorCommitMsg.getSignedPayload())).isTrue();
   }
 
   @Test
   public void subsequentProposalHasDifferentSenderFails() {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
 
     final Proposal secondProposalMsg =
         validatorMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(secondProposalMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(secondProposalMsg.getSignedPayload())).isFalse();
   }
 
   @Test
   public void subsequentProposalHasDifferentContentFails() {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
 
     final ConsensusRoundIdentifier newRoundIdentifier = new ConsensusRoundIdentifier(3, 0);
     final Proposal secondProposalMsg =
         proposerMessageFactory.createSignedProposalPayload(newRoundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(secondProposalMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(secondProposalMsg.getSignedPayload())).isFalse();
   }
 
   @Test
   public void subsequentProposalHasIdenticalSenderAndContentIsSuccessful() {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isTrue();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isTrue();
 
     final Proposal secondProposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
-    assertThat(validator.addSignedProposalPayload(secondProposalMsg)).isTrue();
+    assertThat(validator.addSignedProposalPayload(secondProposalMsg.getSignedPayload())).isTrue();
   }
 
   @Test
@@ -262,6 +259,6 @@ public class SignedDataValidatorTest {
     final Proposal proposalMsg =
         proposerMessageFactory.createSignedProposalPayload(roundIdentifier, block);
 
-    assertThat(validator.addSignedProposalPayload(proposalMsg)).isFalse();
+    assertThat(validator.addSignedProposalPayload(proposalMsg.getSignedPayload())).isFalse();
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -64,7 +64,6 @@ public class SignedDataValidatorTest {
 
   private final List<Address> validators = Lists.newArrayList();
 
-  @Mock private BlockValidator<IbftContext> blockValidator;
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(2, 0);
   private SignedDataValidator validator;
 
@@ -77,16 +76,9 @@ public class SignedDataValidatorTest {
 
     block = TestHelpers.createProposalBlock(validators, roundIdentifier.getRoundNumber());
 
-    final ProtocolContext<IbftContext> protocolContext =
-        new ProtocolContext<>(
-            mock(MutableBlockchain.class), mock(WorldStateArchive.class), mock(IbftContext.class));
-
     validator =
         new SignedDataValidator(
             validators, Util.publicKeyToAddress(proposerKey.getPublicKey()), roundIdentifier);
-
-    when(blockValidator.validateAndProcessBlock(any(), any(), any(), any()))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
   }
 
   @Test

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonController.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonController.java
@@ -242,7 +242,8 @@ public class IbftPantheonController implements PantheonController<IbftContext> {
             new IbftBlockHeightManagerFactory(
                 finalState,
                 new IbftRoundFactory(
-                    finalState, protocolContext, protocolSchedule, minedBlockObservers),
+                    finalState, protocolContext, protocolSchedule, minedBlockObservers,
+                    messageValidatorFactory),
                 messageValidatorFactory),
             gossiper);
     ibftController.start();

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonController.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonController.java
@@ -242,7 +242,10 @@ public class IbftPantheonController implements PantheonController<IbftContext> {
             new IbftBlockHeightManagerFactory(
                 finalState,
                 new IbftRoundFactory(
-                    finalState, protocolContext, protocolSchedule, minedBlockObservers,
+                    finalState,
+                    protocolContext,
+                    protocolSchedule,
+                    minedBlockObservers,
                     messageValidatorFactory),
                 messageValidatorFactory),
             gossiper);


### PR DESCRIPTION
IBFT 2.1 reworks the initial IBFT messaging by splitting block-carrying messages into 2 parts:
* Signed Data (typically round/sequence Number, block hash)
* Block
Prior changes to the code introduced the Proposal/Prepare/Commit/NewRound/RoundChange classes to wrap a single, underlying SignedData<> object - and the statemachine was updated to use these new wrapper types.

However, all validation etc. continued to operate on constructs which contained both the meta data and the block within the one SignedData<> object.

As this change splits up the messages into 2 components, the validation routines have to subtly change, such that the signed components can be validated, then the 'piggy-backing' block can be validated against the signed data.
