### PR TITLE
Rework Ibft's MessageValidatorFactory

### DIFF
--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -90,7 +90,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
     this.roundChangeManager = roundChangeManager;
     this.finalState = finalState;
 
-    newRoundMessageValidator = messageValidatorFactory.createNewRoundValidator(parentHeader);
+    newRoundMessageValidator = messageValidatorFactory.createNewRoundValidator(getChainHeight());
 
     roundStateCreator =
         (roundIdentifier) ->
@@ -255,7 +255,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
 
   @Override
   public long getChainHeight() {
-    return currentRound.getRoundIdentifier().getSequenceNumber();
+    return parentHeader.getNumber() + 1;
   }
 
   @Override

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerFactory.java
@@ -49,7 +49,8 @@ public class IbftBlockHeightManagerFactory {
         finalState,
         new RoundChangeManager(
             IbftHelpers.calculateRequiredValidatorQuorum(finalState.getValidators().size()),
-            messageValidatorFactory.createRoundChangeMessageValidator(parentHeader)),
+            messageValidatorFactory.createRoundChangeMessageValidator(
+                parentHeader.getNumber() + 1L)),
         roundFactory,
         finalState.getClock(),
         messageValidatorFactory);

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/MessageValidatorFactory.java
@@ -21,7 +21,6 @@ import tech.pegasys.pantheon.consensus.ibft.blockcreation.ProposerSelector;
 import tech.pegasys.pantheon.ethereum.BlockValidator;
 import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.core.Address;
-import tech.pegasys.pantheon.ethereum.core.BlockHeader;
 import tech.pegasys.pantheon.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Collection;
@@ -58,20 +57,20 @@ public class MessageValidatorFactory {
     return new MessageValidator(createSignedDataValidator(roundIdentifier));
   }
 
-  public RoundChangeMessageValidator createRoundChangeMessageValidator(
-      final BlockHeader parentHeader) {
+  public RoundChangeMessageValidator createRoundChangeMessageValidator(final long chainHeight) {
     final Collection<Address> validators =
         protocolContext.getConsensusState().getVoteTally().getValidators();
+
     return new RoundChangeMessageValidator(
         new RoundChangePayloadValidator(
             this::createSignedDataValidator,
             validators,
             prepareMessageCountForQuorum(
                 IbftHelpers.calculateRequiredValidatorQuorum(validators.size())),
-            parentHeader.getNumber() + 1));
+            chainHeight));
   }
 
-  public NewRoundMessageValidator createNewRoundValidator(final BlockHeader parentHeader) {
+  public NewRoundMessageValidator createNewRoundValidator(final long chainHeight) {
     final Collection<Address> validators =
         protocolContext.getConsensusState().getVoteTally().getValidators();
     return new NewRoundMessageValidator(
@@ -80,6 +79,6 @@ public class MessageValidatorFactory {
             proposerSelector,
             this::createSignedDataValidator,
             IbftHelpers.calculateRequiredValidatorQuorum(validators.size()),
-            parentHeader.getNumber() + 1));
+            chainHeight));
   }
 }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -135,7 +135,7 @@ public class IbftBlockHeightManagerTest {
     when(finalState.getMessageFactory()).thenReturn(messageFactory);
     when(blockCreator.createBlock(anyLong())).thenReturn(createdBlock);
     when(newRoundPayloadValidator.validateNewRoundMessage(any())).thenReturn(true);
-    when(messageValidatorFactory.createNewRoundValidator(any()))
+    when(messageValidatorFactory.createNewRoundValidator(anyLong()))
         .thenReturn(newRoundPayloadValidator);
     when(messageValidatorFactory.createMessageValidator(any())).thenReturn(messageValidator);
 


### PR DESCRIPTION
With a prior change swapping header validation for block
validation in the IBFT messages, the necessity to pass in the block
header was removed - though the code remained.

This change simplifies the MessageValidatorFactory interface to only
take the chain height (rather than the full parent header).