### PR TITLE
Good first issue link2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ We have a set of [coding conventions](CODING-CONVENTIONS.md) to which we try to 
 [search-label-bug]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Abug
 [search-label-help-wanted]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ahelp%20wanted
 
-[search-label-good-first-issue]:     https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3A%22good%20first%20issue%22
+[search-label-good-first-issue]:      https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3A%22good%20first%20issue%22
 [search-label-info-needed]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ainfo%20needed
 [search-label-needs-reproduction]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Aneeds%20reproduction
 [search-label-blocked]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ablocked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ We have a set of [coding conventions](CODING-CONVENTIONS.md) to which we try to 
 [search-label-enhancement]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Aenhancement
 [search-label-bug]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Abug
 [search-label-help-wanted]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ahelp%20wanted
-[search-label-good-first-issue]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Agood%20first%20issue
+[search-label-good-first-issue]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3A%22good%20first%20issue%22
 [search-label-info-needed]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ainfo%20needed
 [search-label-needs-reproduction]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Aneeds%20reproduction
 [search-label-blocked]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ablocked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,8 @@ We have a set of [coding conventions](CODING-CONVENTIONS.md) to which we try to 
 [search-label-enhancement]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Aenhancement
 [search-label-bug]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Abug
 [search-label-help-wanted]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ahelp%20wanted
-[search-label-good-first-issue]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3A%22good%20first%20issue%22
+
+[search-label-good-first-issue]:     https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3A%22good%20first%20issue%22
 [search-label-info-needed]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ainfo%20needed
 [search-label-needs-reproduction]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Aneeds%20reproduction
 [search-label-blocked]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ablocked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ We have a set of [coding conventions](CODING-CONVENTIONS.md) to which we try to 
 [search-label-bug]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Abug
 [search-label-help-wanted]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ahelp%20wanted
 
-[search-label-good-first-issue]:      https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3A%22good%20first%20issue%22
+[search-label-good-first-issue]:       https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3A%22good%20first%20issue%22
 [search-label-info-needed]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ainfo%20needed
 [search-label-needs-reproduction]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Aneeds%20reproduction
 [search-label-blocked]: https://github.com/search?q=is%3Aopen+is%3Aissue+repo%3APegasysEng%2FPantheon+label%3Ablocked


### PR DESCRIPTION
"Good First Issue" Link is Broken in CONTRIBUTING.md

### Description
As a prospective Pantheon developer, I want the "Good First Issue" Link in "Your First Code Contribution" section of /CONTRIBUTING.md to correctly display the issues with the label so that it is easy for prospective developers to get ramped up on this codebase. 

### Acceptance Criteria
* Fix the "Good First Issue" Link in "Your First Code Contribution" section of /CONTRIBUTING.md to correctly display the issues with that label

### Steps to Reproduce (Bug)
1. Navigate to https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md#your-first-code-contribution
2. click [Good First Issue] link.
**Expected behavior:** [What you expect to happen]
Navigate to list of good first issues
**Actual behavior:** [What actually happens]
Navigates to empty search screen

### Additional Information
Suggest: In the URL, "good first issue" might need to be encapsulated in quotes.  
