### PR TITLE
[PAN-2196] Implement world state cancel

### DIFF
--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloader.java
@@ -111,8 +111,12 @@ public class WorldStateDownloader {
         header.getNumber(),
         header.getHash());
     synchronized (this) {
-      if (status != Status.IDLE) {
-        return future;
+      if (status == Status.RUNNING) {
+        CompletableFuture<Void> failed = new CompletableFuture<>();
+        failed.completeExceptionally(
+            new IllegalStateException(
+                "Cannot run an already running " + this.getClass().getSimpleName()));
+        return failed;
       }
       status = Status.RUNNING;
       future = createFuture();

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloader.java
@@ -53,13 +53,6 @@ public class WorldStateDownloader {
   private final Counter completedRequestsCounter;
   private final Counter retriedRequestsTotal;
 
-  private enum Status {
-    IDLE,
-    RUNNING,
-    CANCELLED,
-    COMPLETED
-  }
-
   private final EthContext ethContext;
   private final TaskQueue<NodeDataRequest> pendingRequests;
   private final int hashCountPerRequest;
@@ -70,7 +63,6 @@ public class WorldStateDownloader {
   private final WorldStateStorage worldStateStorage;
   private final AtomicBoolean sendingRequests = new AtomicBoolean(false);
   private volatile CompletableFuture<Void> future;
-  private volatile Status status = Status.IDLE;
   private volatile BytesValue rootNode;
 
   public WorldStateDownloader(
@@ -106,15 +98,18 @@ public class WorldStateDownloader {
   }
 
   public CompletableFuture<Void> run(final BlockHeader header) {
-    LOG.info(
-        "Begin downloading world state from peers for block {} ({})",
-        header.getNumber(),
-        header.getHash());
     synchronized (this) {
-      if (status != Status.IDLE) {
-        return future;
+      if (isRunning()) {
+        CompletableFuture<Void> failed = new CompletableFuture<>();
+        failed.completeExceptionally(
+            new IllegalStateException(
+                "Cannot run an already running " + this.getClass().getSimpleName()));
+        return failed;
       }
-      status = Status.RUNNING;
+      LOG.info(
+          "Begin downloading world state from peers for block {} ({})",
+          header.getNumber(),
+          header.getHash());
       future = createFuture();
 
       Hash stateRoot = header.getStateRoot();
@@ -173,7 +168,7 @@ public class WorldStateDownloader {
                     synchronized (this) {
                       outstandingRequests.remove(task);
                       done =
-                          status == Status.RUNNING
+                          isRunning()
                               && outstandingRequests.size() == 0
                               && pendingRequests.allTasksCompleted();
                     }
@@ -253,9 +248,13 @@ public class WorldStateDownloader {
   }
 
   private synchronized void queueChildRequests(final NodeDataRequest request) {
-    if (status == Status.RUNNING) {
+    if (isRunning()) {
       request.getChildRequests().forEach(pendingRequests::enqueue);
     }
+  }
+
+  private boolean isRunning() {
+    return future != null && !future.isDone();
   }
 
   private synchronized CompletableFuture<Void> getFuture() {
@@ -279,7 +278,6 @@ public class WorldStateDownloader {
 
   private synchronized void handleCancellation() {
     LOG.info("World state download cancelled");
-    status = Status.CANCELLED;
     pendingRequests.clear();
     for (EthTask<?> outstandingRequest : outstandingRequests) {
       outstandingRequest.cancel();
@@ -290,7 +288,6 @@ public class WorldStateDownloader {
     final boolean completed = getFuture().complete(null);
     if (completed) {
       LOG.info("Finished downloading world state from peers");
-      status = Status.COMPLETED;
     }
   }
 

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
@@ -412,8 +412,6 @@ public class WorldStateDownloaderTest {
     verify(queue, never()).enqueue(any());
     // Target world state should not be available
     assertThat(localStorage.isWorldStateAvailable(header.getStateRoot())).isFalse();
-
-    assertThat(downloader.run(header)).isCancelled();
   }
 
   @Test
@@ -729,6 +727,10 @@ public class WorldStateDownloaderTest {
 
     // Start downloader
     CompletableFuture<?> result = downloader.run(header);
+    // A second run should return an error without impacting the first result
+    CompletableFuture<?> secondResult = downloader.run(header);
+    assertThat(secondResult).isCompletedExceptionally();
+    assertThat(result).isNotCompletedExceptionally();
 
     // Respond to node data requests
     // Send one round of full responses, so that we can get multiple requests queued up

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
@@ -412,6 +412,8 @@ public class WorldStateDownloaderTest {
     verify(queue, never()).enqueue(any());
     // Target world state should not be available
     assertThat(localStorage.isWorldStateAvailable(header.getStateRoot())).isFalse();
+
+    assertThat(downloader.run(header)).isCancelled();
   }
 
   @Test
@@ -727,10 +729,6 @@ public class WorldStateDownloaderTest {
 
     // Start downloader
     CompletableFuture<?> result = downloader.run(header);
-    // A second run should return an error without impacting the first result
-    CompletableFuture<?> secondResult = downloader.run(header);
-    assertThat(secondResult).isCompletedExceptionally();
-    assertThat(result).isNotCompletedExceptionally();
 
     // Respond to node data requests
     // Send one round of full responses, so that we can get multiple requests queued up

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
@@ -13,7 +13,13 @@
 package tech.pegasys.pantheon.ethereum.eth.sync.worldstate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import tech.pegasys.pantheon.ethereum.chain.Blockchain;
 import tech.pegasys.pantheon.ethereum.core.Account;
@@ -322,6 +328,92 @@ public class WorldStateDownloaderTest {
     final WorldState localWorldState = localWorldStateArchive.get(stateRoot).get();
     assertThat(result).isDone();
     assertAccountsMatch(localWorldState, accounts);
+  }
+
+  @Test
+  public void cancelDownloader() {
+    testCancellation(false);
+  }
+
+  @Test
+  public void cancelDownloaderFuture() {
+    testCancellation(true);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void testCancellation(final boolean shouldCancelFuture) {
+    BlockDataGenerator dataGen = new BlockDataGenerator(1);
+    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
+
+    // Setup "remote" state
+    final WorldStateStorage remoteStorage =
+        new KeyValueStorageWorldStateStorage(new InMemoryKeyValueStorage());
+    final WorldStateArchive remoteWorldStateArchive = new WorldStateArchive(remoteStorage);
+    final MutableWorldState remoteWorldState = remoteWorldStateArchive.getMutable();
+
+    // Generate accounts and save corresponding state root
+    dataGen.createRandomContractAccountsWithNonEmptyStorage(remoteWorldState, 20);
+    final Hash stateRoot = remoteWorldState.rootHash();
+    final BlockHeader header =
+        dataGen.block(BlockOptions.create().setStateRoot(stateRoot).setBlockNumber(10)).getHeader();
+
+    // Create some peers
+    List<RespondingEthPeer> peers =
+        Stream.generate(
+                () -> EthProtocolManagerTestUtil.createPeer(ethProtocolManager, header.getNumber()))
+            .limit(5)
+            .collect(Collectors.toList());
+
+    TaskQueue<NodeDataRequest> queue = spy(new InMemoryTaskQueue<>());
+    WorldStateStorage localStorage =
+        new KeyValueStorageWorldStateStorage(new InMemoryKeyValueStorage());
+
+    WorldStateDownloader downloader =
+        new WorldStateDownloader(
+            ethProtocolManager.ethContext(),
+            localStorage,
+            queue,
+            10,
+            10,
+            NoOpMetricsSystem.NO_OP_LABELLED_TIMER,
+            new NoOpMetricsSystem());
+
+    CompletableFuture<Void> result = downloader.run(header);
+
+    // Send a few responses
+    Responder responder =
+        RespondingEthPeer.blockchainResponder(mock(Blockchain.class), remoteWorldStateArchive);
+
+    for (int i = 0; i < 3; i++) {
+      for (RespondingEthPeer peer : peers) {
+        peer.respond(responder);
+      }
+    }
+    assertThat(result.isDone()).isFalse(); // Sanity check
+
+    // Reset queue so we can track interactions after the cancellation
+    reset(queue);
+    if (shouldCancelFuture) {
+      result.cancel(true);
+    } else {
+      downloader.cancel();
+      assertThat(result).isCancelled();
+    }
+
+    // Send some more responses after cancelling
+    for (int i = 0; i < 3; i++) {
+      for (RespondingEthPeer peer : peers) {
+        peer.respond(responder);
+      }
+    }
+
+    verify(queue, times(1)).clear();
+    verify(queue, never()).dequeue();
+    verify(queue, never()).enqueue(any());
+    // Target world state should not be available
+    assertThat(localStorage.isWorldStateAvailable(header.getStateRoot())).isFalse();
+
+    assertThat(downloader.run(header)).isCancelled();
   }
 
   @Test

--- a/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/BytesTaskQueueAdapter.java
+++ b/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/BytesTaskQueueAdapter.java
@@ -59,6 +59,11 @@ public class BytesTaskQueueAdapter<T> implements TaskQueue<T> {
   }
 
   @Override
+  public void clear() {
+    queue.clear();
+  }
+
+  @Override
   public boolean allTasksCompleted() {
     return queue.allTasksCompleted();
   }

--- a/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/RocksDbTaskQueue.java
+++ b/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/RocksDbTaskQueue.java
@@ -126,6 +126,7 @@ public class RocksDbTaskQueue implements BytesTaskQueue {
       db.deleteRange(from, to);
       lastDequeuedKey.set(0);
       lastEnqueuedKey.set(0);
+      oldestKey.set(0);
     } catch (RocksDBException e) {
       throw new StorageException(e);
     }
@@ -144,7 +145,7 @@ public class RocksDbTaskQueue implements BytesTaskQueue {
             .orElse(lastDequeuedKey.get() + 1);
 
     if (oldestKey.get() < oldestOutstandingKey) {
-      // Delete all contiguous completed task keys
+      // Delete all contiguous completed tasks
       byte[] fromKey = Longs.toByteArray(oldestKey.get());
       byte[] toKey = Longs.toByteArray(oldestOutstandingKey);
       try {

--- a/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/RocksDbTaskQueue.java
+++ b/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/RocksDbTaskQueue.java
@@ -112,7 +112,23 @@ public class RocksDbTaskQueue implements BytesTaskQueue {
 
   @Override
   public synchronized boolean isEmpty() {
+    assertNotClosed();
     return size() == 0;
+  }
+
+  @Override
+  public synchronized void clear() {
+    assertNotClosed();
+    outstandingTasks.clear();
+    byte[] from = Longs.toByteArray(oldestKey.get());
+    byte[] to = Longs.toByteArray(lastEnqueuedKey.get() + 1);
+    try {
+      db.deleteRange(from, to);
+      lastDequeuedKey.set(0);
+      lastEnqueuedKey.set(0);
+    } catch (RocksDBException e) {
+      throw new StorageException(e);
+    }
   }
 
   @Override
@@ -154,14 +170,18 @@ public class RocksDbTaskQueue implements BytesTaskQueue {
     }
   }
 
-  private synchronized void markTaskCompleted(final RocksDbTask task) {
-    outstandingTasks.remove(task);
-    deleteCompletedTasks();
+  private synchronized boolean markTaskCompleted(final RocksDbTask task) {
+    if (outstandingTasks.remove(task)) {
+      deleteCompletedTasks();
+      return true;
+    }
+    return false;
   }
 
   private synchronized void handleFailedTask(final RocksDbTask task) {
-    enqueue(task.getData());
-    markTaskCompleted(task);
+    if (markTaskCompleted(task)) {
+      enqueue(task.getData());
+    }
   }
 
   public static class StorageException extends RuntimeException {

--- a/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/TaskQueue.java
+++ b/services/queue/src/main/java/tech/pegasys/pantheon/services/queue/TaskQueue.java
@@ -42,6 +42,9 @@ public interface TaskQueue<T> extends Closeable {
   /** @return True if all tasks have been dequeued. */
   boolean isEmpty();
 
+  /** Clear all data from the queue. */
+  void clear();
+
   /** @return True if all tasks have been dequeued and processed. */
   boolean allTasksCompleted();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Implement world state download cancellation functionality.  On cancellation, the `WorldStateDownloader` will cancel any pending network tasks and clear its task queue.  Also made a few other small changes: 
- ~Removed the `status` tracking from the downloader in favor of using the future as a signal on the status~.  
- Modified the downloader to return an exceptional result if `run` is called on an already running instance.