### PR TITLE
Periodically try to connect to some peers already in our peer table

### DIFF
--- a/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
@@ -171,6 +171,9 @@ public final class MockNetwork {
     public void checkMaintainedConnectionPeers() {}
 
     @Override
+    public void attemptPeerConnections() {}
+
+    @Override
     public void stop() {}
 
     @Override

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/NetworkRunner.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/NetworkRunner.java
@@ -92,6 +92,8 @@ public class NetworkRunner implements AutoCloseable {
       networkExecutor.submit(network);
       networkCheckExecutor.scheduleWithFixedDelay(
           network::checkMaintainedConnectionPeers, 60, 60, TimeUnit.SECONDS);
+      networkCheckExecutor.scheduleWithFixedDelay(
+          network::attemptPeerConnections, 30, 30, TimeUnit.SECONDS);
     } else {
       LOG.error("Attempted to start already running network.");
     }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/NoopP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/NoopP2PNetwork.java
@@ -57,6 +57,9 @@ public class NoopP2PNetwork implements P2PNetwork {
   public void checkMaintainedConnectionPeers() {}
 
   @Override
+  public void attemptPeerConnections() {}
+
+  @Override
   public void stop() {}
 
   @Override

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/P2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/P2PNetwork.java
@@ -81,6 +81,9 @@ public interface P2PNetwork extends Closeable, Runnable {
    */
   void checkMaintainedConnectionPeers();
 
+  /** Attempt to connect to additional peers from the peer table. */
+  void attemptPeerConnections();
+
   /** Stops the P2P network layer. */
   void stop();
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -40,8 +40,6 @@ import tech.pegasys.pantheon.util.Subscribers;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.net.InetSocketAddress;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -49,6 +47,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.InetAddresses;
@@ -219,12 +218,8 @@ public abstract class PeerDiscoveryAgent implements DisconnectCallback {
             });
   }
 
-  @VisibleForTesting
-  public Collection<DiscoveryPeer> getPeers() {
-    return controller
-        .map(PeerDiscoveryController::getPeers)
-        .map(Collections::unmodifiableCollection)
-        .orElse(Collections.emptyList());
+  public Stream<DiscoveryPeer> getPeers() {
+    return controller.map(PeerDiscoveryController::getPeers).orElse(Stream.empty());
   }
 
   public DiscoveryPeer getAdvertisedPeer() {

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
@@ -489,7 +490,7 @@ public class PeerDiscoveryController {
    *
    * @return List of peers.
    */
-  public Collection<DiscoveryPeer> getPeers() {
+  public Stream<DiscoveryPeer> getPeers() {
     return peerTable.getAllPeers();
   }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NetworkingServiceLifecycleTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/NetworkingServiceLifecycleTest.java
@@ -13,6 +13,7 @@
 package tech.pegasys.pantheon.ethereum.p2p;
 
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -249,7 +250,7 @@ public class NetworkingServiceLifecycleTest {
             new PeerBlacklist(),
             new NoOpMetricsSystem(),
             Optional.empty())) {
-      assertTrue(agent.getDiscoveryPeers().isEmpty());
+      assertTrue(agent.getDiscoveryPeers().collect(toList()).isEmpty());
       assertEquals(0, agent.getPeers().size());
     }
   }

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.pantheon.ethereum.p2p.discovery;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import tech.pegasys.pantheon.ethereum.p2p.api.MessageData;
@@ -33,7 +34,6 @@ import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -64,9 +64,7 @@ public class PeerDiscoveryAgentTest {
     final List<MockPeerDiscoveryAgent> otherAgents =
         helper.startDiscoveryAgents(20, Collections.emptyList());
     final List<DiscoveryPeer> otherPeers =
-        otherAgents.stream()
-            .map(MockPeerDiscoveryAgent::getAdvertisedPeer)
-            .collect(Collectors.toList());
+        otherAgents.stream().map(MockPeerDiscoveryAgent::getAdvertisedPeer).collect(toList());
 
     // Start another peer pointing to those 20 agents.
     final MockPeerDiscoveryAgent agent = helper.startDiscoveryAgent(otherPeers);
@@ -92,7 +90,7 @@ public class PeerDiscoveryAgentTest {
     List<IncomingPacket> incomingPackets =
         testAgent.getIncomingPackets().stream()
             .filter(p -> p.packet.getType().equals(PacketType.NEIGHBORS))
-            .collect(Collectors.toList());
+            .collect(toList());
     assertThat(incomingPackets.size()).isEqualTo(1);
     IncomingPacket neighborsPacket = incomingPackets.get(0);
     assertThat(neighborsPacket.fromAgent).isEqualTo(agent);
@@ -121,12 +119,12 @@ public class PeerDiscoveryAgentTest {
     final MockPeerDiscoveryAgent peerDiscoveryAgent2 = helper.startDiscoveryAgent(peer);
     peerDiscoveryAgent2.start().join();
 
-    assertThat(peerDiscoveryAgent2.getPeers().size()).isEqualTo(1);
+    assertThat(peerDiscoveryAgent2.getPeers().collect(toList()).size()).isEqualTo(1);
 
     final PeerConnection peerConnection = createAnonymousPeerConnection(peer.getId());
     peerDiscoveryAgent2.onDisconnect(peerConnection, DisconnectReason.REQUESTED, true);
 
-    assertThat(peerDiscoveryAgent2.getPeers().size()).isEqualTo(0);
+    assertThat(peerDiscoveryAgent2.getPeers().collect(toList()).size()).isEqualTo(0);
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -229,9 +229,7 @@ public class PeerDiscoveryControllerTest {
 
     controller.start();
 
-    assertThat(
-            controller.getPeers().stream()
-                .filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
+    assertThat(controller.getPeers().filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
         .hasSize(3);
 
     // Simulate PONG messages from all peers
@@ -255,12 +253,9 @@ public class PeerDiscoveryControllerTest {
           .send(eq(peers.get(i)), matchPacketOfType(PacketType.FIND_NEIGHBORS));
     }
 
-    assertThat(
-            controller.getPeers().stream()
-                .filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
+    assertThat(controller.getPeers().filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
         .hasSize(0);
-    assertThat(
-            controller.getPeers().stream().filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDED))
+    assertThat(controller.getPeers().filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDED))
         .hasSize(3);
   }
 
@@ -285,9 +280,7 @@ public class PeerDiscoveryControllerTest {
 
     controller.start();
 
-    assertThat(
-            controller.getPeers().stream()
-                .filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
+    assertThat(controller.getPeers().filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
         .hasSize(3);
 
     // Send a PONG packet from peer 1, with an incorrect hash.
@@ -300,9 +293,7 @@ public class PeerDiscoveryControllerTest {
     verify(outboundMessageHandler, never())
         .send(eq(peers.get(1)), matchPacketOfType(PacketType.FIND_NEIGHBORS));
 
-    assertThat(
-            controller.getPeers().stream()
-                .filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
+    assertThat(controller.getPeers().filter(p -> p.getStatus() == PeerDiscoveryStatus.BONDING))
         .hasSize(3);
   }
 
@@ -355,7 +346,7 @@ public class PeerDiscoveryControllerTest {
     assertThat(data.getTarget()).isEqualTo(localPeer.getId());
 
     assertThat(controller.getPeers()).hasSize(1);
-    assertThat(controller.getPeers().stream().findFirst().get().getStatus())
+    assertThat(controller.getPeers().findFirst().get().getStatus())
         .isEqualTo(PeerDiscoveryStatus.BONDED);
   }
 
@@ -895,14 +886,14 @@ public class PeerDiscoveryControllerTest {
     controller.onMessage(pongPacket16, peers.get(16));
 
     assertThat(controller.getPeers()).contains(peers.get(16));
-    assertThat(controller.getPeers().size()).isEqualTo(16);
+    assertThat(controller.getPeers().collect(Collectors.toList())).hasSize(16);
     assertThat(evictedPeerFromBucket(bootstrapPeers, controller)).isTrue();
   }
 
   private boolean evictedPeerFromBucket(
       final List<DiscoveryPeer> peers, final PeerDiscoveryController controller) {
     for (final DiscoveryPeer peer : peers) {
-      if (!controller.getPeers().contains(peer)) {
+      if (controller.getPeers().noneMatch(candidate -> candidate.equals(peer))) {
         return true;
       }
     }

--- a/pantheon/src/main/java/tech/pegasys/pantheon/util/BlockImporter.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/util/BlockImporter.java
@@ -162,7 +162,7 @@ public class BlockImporter {
     final BlockHeaderValidator<C> blockHeaderValidator = protocolSpec.getBlockHeaderValidator();
     final boolean validHeader =
         blockHeaderValidator.validateHeader(
-            header, previousHeader, context, HeaderValidationMode.FULL);
+            header, previousHeader, context, HeaderValidationMode.DETACHED_ONLY);
     if (!validHeader) {
       throw new IllegalStateException("Invalid header at block number " + header.getNumber() + ".");
     }
@@ -177,7 +177,7 @@ public class BlockImporter {
       final tech.pegasys.pantheon.ethereum.core.BlockImporter<C> blockImporter =
           protocolSpec.getBlockImporter();
       final boolean blockImported =
-          blockImporter.importBlock(context, block, HeaderValidationMode.NONE);
+          blockImporter.importBlock(context, block, HeaderValidationMode.SKIP_DETACHED);
       if (!blockImported) {
         throw new IllegalStateException(
             "Invalid block at block number " + header.getNumber() + ".");


### PR DESCRIPTION
## PR description
Periodically select some peers already in our peer table and attempt to connect to them.  Previously we only attempted to connect to newly discovered peers, but if the pending connections exceeded our max peer limit we wouldn't make any attempt to connect.

Apart from needing some tests, before merging we should take some measurements to see if this actually finds more peers or not.  Initial tests are inconclusive.