### PR TITLE
[MINOR] permission config file location and option under docker

### DIFF
--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/DefaultCommandValues.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/DefaultCommandValues.java
@@ -48,6 +48,7 @@ interface DefaultCommandValues {
   String DOCKER_RPC_WS_AUTHENTICATION_CREDENTIALS_FILE_LOCATION =
       "/etc/pantheon/rpc_ws_auth_config.toml";
   String DOCKER_PRIVACY_PUBLIC_KEY_FILE = "/etc/pantheon/privacy_public_key";
+  String DOCKER_PERMISSIONS_CONFIG_FILE_LOCATION = "/etc/pantheon/permissions_config.toml";
   String PERMISSIONING_CONFIG_LOCATION = "permissions_config.toml";
   String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
   String MANDATORY_PORT_FORMAT_HELP = "<PORT>";

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -445,12 +445,6 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
   private final Boolean permissionsAccountsEnabled = false;
 
   @Option(
-      names = {"--permissions-config-file"},
-      description =
-          "Permissions config TOML file (default: a file named \"permissions_config.toml\" in the Pantheon data folder)")
-  private String permissionsConfigFile = null;
-
-  @Option(
       names = {"--privacy-enabled"},
       description = "Set if private transaction should be enabled (default: ${DEFAULT-VALUE})")
   private final Boolean privacyEnabled = false;
@@ -554,10 +548,10 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
               + "or specify the beneficiary of mining (via --miner-coinbase <Address>)");
     }
 
-    if (permissionsConfigFile != null) {
+    if (permissionsConfigFile() != null) {
       if (!permissionsAccountsEnabled && !permissionsNodesEnabled) {
         logger.warn(
-            "Permissions config file set {} but no permissions enabled", permissionsConfigFile);
+            "Permissions config file set {} but no permissions enabled", permissionsConfigFile());
       }
     }
 
@@ -626,8 +620,8 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
 
   private String getPermissionsConfigFile() {
 
-    return permissionsConfigFile != null
-        ? permissionsConfigFile
+    return permissionsConfigFile() != null
+        ? permissionsConfigFile()
         : dataDir().toAbsolutePath()
             + System.getProperty("file.separator")
             + DefaultCommandValues.PERMISSIONING_CONFIG_LOCATION;
@@ -1009,6 +1003,20 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
     if (filename != null) {
       RpcAuthFileValidator.validate(commandLine, filename, "WS");
     }
+    return filename;
+  }
+
+  private String permissionsConfigFile() {
+    String filename = null;
+    if (isFullInstantiation()) {
+      filename = standaloneCommands.rpcWsAuthenticationCredentialsFile;
+    } else if (isDocker) {
+      final File file = new File(DOCKER_PERMISSIONS_CONFIG_FILE_LOCATION);
+      if (file.exists()) {
+        filename = file.getAbsolutePath();
+      }
+    }
+
     return filename;
   }
 

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -1009,7 +1009,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
   private String permissionsConfigFile() {
     String filename = null;
     if (isFullInstantiation()) {
-      filename = standaloneCommands.rpcWsAuthenticationCredentialsFile;
+      filename = standaloneCommands.permissionsConfigFile;
     } else if (isDocker) {
       final File file = new File(DOCKER_PERMISSIONS_CONFIG_FILE_LOCATION);
       if (file.exists()) {

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/StandaloneCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/StandaloneCommand.java
@@ -72,4 +72,10 @@ class StandaloneCommand implements DefaultCommandValues {
       names = {"--privacy-public-key-file"},
       description = "The enclave's public key file")
   final File privacyPublicKeyFile = null;
+
+  @CommandLine.Option(
+      names = {"--permissions-config-file"},
+      description =
+          "Permissions config TOML file (default: a file named \"permissions_config.toml\" in the Pantheon data folder)")
+  String permissionsConfigFile = null;
 }

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
@@ -1989,4 +1989,17 @@ public class PantheonCommandTest extends CommandTestAbstract {
         .startsWith("Unknown options: --rpc-ws-authentication-credentials-file, .");
     assertThat(commandOutput.toString()).isEmpty();
   }
+
+  @Test
+  public void permissionsConfigFileOptionDisabledUnderDocker() {
+    System.setProperty("pantheon.docker", "true");
+
+    assumeFalse(isFullInstantiation());
+
+    final Path path = Paths.get(".");
+    parseCommand("--permissions-config-file", path.toString());
+    assertThat(commandErrorOutput.toString())
+        .startsWith("Unknown options: --permissions-config-file, .");
+    assertThat(commandOutput.toString()).isEmpty();
+  }
 }


### PR DESCRIPTION
Under docker its convention that we default the location to a more root centric location and disable the command line option. --permission-config-file slipped through.