### PR TITLE
Fix for bug in the validation of Round-Change-Certificates

### DIFF
--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeCertificateValidator.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/validation/RoundChangeCertificateValidator.java
@@ -29,6 +29,7 @@ import tech.pegasys.pantheon.ethereum.core.Block;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,7 +59,8 @@ public class RoundChangeCertificateValidator {
     final Collection<SignedData<RoundChangePayload>> roundChangeMsgs =
         roundChangeCert.getRoundChangePayloads();
 
-    if (roundChangeMsgs.size() < quorum) {
+    if (roundChangeMsgs.stream().map(SignedData::getAuthor).collect(Collectors.toSet()).size()
+        < quorum) {
       LOG.info("Invalid RoundChangeCertificate, insufficient RoundChange messages.");
       return false;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
The Round-Change-Certificate must contain at least Quorum(n) Round-Change messages sent by **different** validators
The current code does not verify this condition, but only that the Round-Change-Certificate contains at least Quorum(n) Round-Change messages sent by validators.
This PR fixes the issue.
**Note: Tests must be added**

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
