### PR TITLE
[BUG] remove 127.0.0.1 from default hosts configs

### DIFF
--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcConfiguration.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcConfiguration.java
@@ -13,7 +13,6 @@
 package tech.pegasys.pantheon.ethereum.jsonrpc;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -22,7 +21,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
 public class JsonRpcConfiguration {
-  private static final String DEFAULT_JSON_RPC_HOST = "127.0.0.1";
+  private static final String DEFAULT_JSON_RPC_HOST = "localhost";
   public static final int DEFAULT_JSON_RPC_PORT = 8545;
 
   private boolean enabled;
@@ -30,7 +29,7 @@ public class JsonRpcConfiguration {
   private String host;
   private Collection<String> corsAllowedDomains = Collections.emptyList();
   private Collection<RpcApi> rpcApis;
-  private Collection<String> hostsWhitelist = Arrays.asList("localhost", "127.0.0.1");;
+  private Collection<String> hostsWhitelist = Collections.singletonList("localhost");
   private boolean authenticationEnabled = false;
   private String authenticationCredentialsFile;
 

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/websocket/WebSocketConfiguration.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/websocket/WebSocketConfiguration.java
@@ -25,7 +25,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
 public class WebSocketConfiguration {
-  public static final String DEFAULT_WEBSOCKET_HOST = "127.0.0.1";
+  public static final String DEFAULT_WEBSOCKET_HOST = "localhost";
   public static final int DEFAULT_WEBSOCKET_PORT = 8546;
   public static final Collection<RpcApi> DEFAULT_WEBSOCKET_APIS =
       Arrays.asList(RpcApis.ETH, RpcApis.NET, RpcApis.WEB3);

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcConfigurationTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcConfigurationTest.java
@@ -24,7 +24,7 @@ public class JsonRpcConfigurationTest {
     final JsonRpcConfiguration configuration = JsonRpcConfiguration.createDefault();
 
     assertThat(configuration.isEnabled()).isFalse();
-    assertThat(configuration.getHost()).isEqualTo("127.0.0.1");
+    assertThat(configuration.getHost()).isEqualTo("localhost");
     assertThat(configuration.getPort()).isEqualTo(8545);
     assertThat(configuration.getCorsAllowedDomains()).isEmpty();
     assertThat(configuration.getRpcApis())

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/websocket/WebSocketConfigurationTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/websocket/WebSocketConfigurationTest.java
@@ -25,7 +25,7 @@ public class WebSocketConfigurationTest {
     final WebSocketConfiguration configuration = WebSocketConfiguration.createDefault();
 
     assertThat(configuration.isEnabled()).isFalse();
-    assertThat(configuration.getHost()).isEqualTo("127.0.0.1");
+    assertThat(configuration.getHost()).isEqualTo("localhost");
     assertThat(configuration.getPort()).isEqualTo(8546);
     assertThat(configuration.getRpcApis())
         .containsExactlyInAnyOrder(RpcApis.ETH, RpcApis.NET, RpcApis.WEB3);

--- a/metrics/src/main/java/tech/pegasys/pantheon/metrics/prometheus/MetricsConfiguration.java
+++ b/metrics/src/main/java/tech/pegasys/pantheon/metrics/prometheus/MetricsConfiguration.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.pantheon.metrics.prometheus;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -34,7 +33,7 @@ public class MetricsConfiguration {
   private String pushHost;
   private int pushInterval;
   private String prometheusJob;
-  private Collection<String> hostsWhitelist = Arrays.asList("localhost", "127.0.0.1");
+  private Collection<String> hostsWhitelist = Collections.singletonList("localhost");
 
   public static MetricsConfiguration createDefault() {
     final MetricsConfiguration metricsConfiguration = new MetricsConfiguration();

--- a/metrics/src/main/java/tech/pegasys/pantheon/metrics/prometheus/MetricsConfiguration.java
+++ b/metrics/src/main/java/tech/pegasys/pantheon/metrics/prometheus/MetricsConfiguration.java
@@ -19,10 +19,10 @@ import java.util.Objects;
 import com.google.common.collect.Lists;
 
 public class MetricsConfiguration {
-  private static final String DEFAULT_METRICS_HOST = "127.0.0.1";
+  private static final String DEFAULT_METRICS_HOST = "localhost";
   public static final int DEFAULT_METRICS_PORT = 9545;
 
-  private static final String DEFAULT_METRICS_PUSH_HOST = "127.0.0.1";
+  private static final String DEFAULT_METRICS_PUSH_HOST = "localhost";
   public static final int DEFAULT_METRICS_PUSH_PORT = 9001;
 
   private boolean enabled;

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -393,7 +393,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
       paramLabel = "<hostname>[,<hostname>...]... or * or all",
       description =
           "Comma separated list of hostnames to whitelist for JSON-RPC access, or * or all to accept any host (default: ${DEFAULT-VALUE})",
-      defaultValue = "localhost,127.0.0.1")
+      defaultValue = "localhost")
   private final JsonRPCWhitelistHostsProperty hostsWhitelist = new JsonRPCWhitelistHostsProperty();
 
   @Option(

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -246,7 +246,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
       paramLabel = MANDATORY_HOST_FORMAT_HELP,
       description = "Host for JSON-RPC HTTP to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private String rpcHttpHost = autoDiscoverDefaultIP().getHostAddress();
+  private String rpcHttpHost = autoDiscoverDefaultIP().getHostName();
 
   @Option(
       names = {"--rpc-http-port"},
@@ -288,7 +288,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
       paramLabel = MANDATORY_HOST_FORMAT_HELP,
       description = "Host for JSON-RPC WebSocket service to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private String rpcWsHost = autoDiscoverDefaultIP().getHostAddress();
+  private String rpcWsHost = autoDiscoverDefaultIP().getHostName();
 
   @Option(
       names = {"--rpc-ws-port"},
@@ -346,7 +346,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
       paramLabel = MANDATORY_HOST_FORMAT_HELP,
       description = "Host for the metrics exporter to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private String metricsHost = autoDiscoverDefaultIP().getHostAddress();
+  private String metricsHost = autoDiscoverDefaultIP().getHostName();
 
   @Option(
       names = {"--metrics-port"},
@@ -365,7 +365,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
       paramLabel = MANDATORY_HOST_FORMAT_HELP,
       description = "Host of the Prometheus Push Gateway for push mode (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private String metricsPushHost = autoDiscoverDefaultIP().getHostAddress();
+  private String metricsPushHost = autoDiscoverDefaultIP().getHostName();
 
   @Option(
       names = {"--metrics-push-port"},


### PR DESCRIPTION
in PR #974 it added 127.0.0.1 to the host whitelist to make tests work under more environments. Adding this to the whitelist opens up a security vulnerability. This reverts that then changes the default setup for hosts to use the localhost loopback name.