### PR TITLE
[PAN-2369] RunnerTest fail on Windows due to network startup timing issue

### DIFF
--- a/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
@@ -157,11 +157,11 @@ public final class RunnerTest {
 
       // Wait for network to initialize to get the P2P UDP port
       Awaitility.await()
-          .atMost(5, TimeUnit.SECONDS)
+          .atMost(20, TimeUnit.SECONDS)
           .ignoreExceptions()
           .untilAsserted(() -> assertThat(runnerAhead.getP2pUdpPort()).isNotNull());
       Awaitility.await()
-          .atMost(5, TimeUnit.SECONDS)
+          .atMost(20, TimeUnit.SECONDS)
           .ignoreExceptions()
           .untilAsserted(() -> assertThat(runnerAhead.getP2pTcpPort()).isNotNull());
 

--- a/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
@@ -67,7 +67,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -78,13 +77,11 @@ public final class RunnerTest {
   @Rule public final TemporaryFolder temp = new TemporaryFolder();
 
   @Test
-  @Ignore
   public void fullSyncFromGenesis() throws Exception {
     syncFromGenesis(SyncMode.FULL);
   }
 
   @Test
-  @Ignore
   public void fastSyncFromGenesis() throws Exception {
     syncFromGenesis(SyncMode.FAST);
   }
@@ -157,6 +154,16 @@ public final class RunnerTest {
     try {
 
       executorService.submit(runnerAhead::execute);
+
+      // Wait for network to initialize to get the P2P UDP port
+      Awaitility.await()
+          .atMost(5, TimeUnit.SECONDS)
+          .ignoreExceptions()
+          .untilAsserted(() -> assertThat(runnerAhead.getP2pUdpPort()).isNotNull());
+      Awaitility.await()
+          .atMost(5, TimeUnit.SECONDS)
+          .ignoreExceptions()
+          .untilAsserted(() -> assertThat(runnerAhead.getP2pTcpPort()).isNotNull());
 
       final SynchronizerConfiguration syncConfigBehind =
           SynchronizerConfiguration.builder()


### PR DESCRIPTION
## PR description
[PAN-2369] RunnerTest fail on Windows due to network startup timing issue

- Forces RunnerTest to wait for the P2PNetwork to start and actually configure it's ports before asking for them.
- Re-Enables RunnerTest.fullSyncFromGenesis()
- Re-Enables RunnerTest.fastSyncFromGenesis()

## Fixed Issue(s)
[PAN-2369]

[PAN-2369]: https://pegasys1.atlassian.net/browse/PAN-2369
[PAN-2369]: https://pegasys1.atlassian.net/browse/PAN-2369