### PR TITLE
[minor] add rpc_modules json-rpc

### DIFF
--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
@@ -66,6 +66,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.JsonRpcMethod;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetListening;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetPeerCount;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetVersion;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.RpcModules;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.Web3ClientVersion;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.Web3Sha3;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.miner.MinerSetCoinbase;
@@ -160,7 +161,9 @@ public class JsonRpcMethodsFactory {
       final Collection<RpcApi> rpcApis,
       final PrivacyParameters privacyParameters) {
     final Map<String, JsonRpcMethod> enabledMethods = new HashMap<>();
-    // @formatter:off
+    if (!rpcApis.isEmpty()) {
+      addMethods(enabledMethods, new RpcModules(rpcApis));
+    }
     if (rpcApis.contains(RpcApis.ETH)) {
       addMethods(
           enabledMethods,
@@ -277,7 +280,6 @@ public class JsonRpcMethodsFactory {
           new EeaGetTransactionReceipt(
               blockchainQueries, new Enclave(privacyParameters.getUrl()), parameter));
     }
-    // @formatter:off
     return enabledMethods;
   }
 

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/RpcModules.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/RpcModules.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods;
+
+import tech.pegasys.pantheon.ethereum.jsonrpc.RpcApi;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcResponse;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class RpcModules implements JsonRpcMethod {
+
+  private final Map<String, String> moduleVersions;
+
+  public RpcModules(final Collection<RpcApi> modulesList) {
+    this.moduleVersions =
+        modulesList.stream()
+            .map(RpcApi::getCliValue)
+            .map(String::toLowerCase)
+            .collect(Collectors.toMap(Function.identity(), s -> "1.0"));
+  }
+
+  @Override
+  public String getName() {
+    return "rpc_modules";
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequest req) {
+    // For now, just return an empty list.
+    return new JsonRpcSuccessResponse(req.getId(), moduleVersions);
+  }
+}

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/RpcModules.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/RpcModules.java
@@ -41,7 +41,6 @@ public class RpcModules implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest req) {
-    // For now, just return an empty list.
     return new JsonRpcSuccessResponse(req.getId(), moduleVersions);
   }
 }

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/RpcModulesTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/RpcModulesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.pantheon.ethereum.jsonrpc.RpcApis;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcResponse;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RpcModulesTest {
+
+  private final String JSON_RPC_VERSION = "2.0";
+  private final String RPC_METHOD = "rpc_modules";
+
+  private RpcModules method;
+
+  @Before
+  public void setUp() {
+    method = new RpcModules(ImmutableList.of(RpcApis.DEBUG));
+  }
+
+  @Test
+  public void shouldReturnCorrectMethodName() {
+    assertThat(method.getName()).isEqualTo(RPC_METHOD);
+  }
+
+  @Test
+  public void shouldReturnCorrectResult() {
+    final JsonRpcRequest request =
+        new JsonRpcRequest(JSON_RPC_VERSION, RPC_METHOD, new Object[] {});
+
+    final JsonRpcResponse expected =
+        new JsonRpcSuccessResponse(request.getId(), ImmutableMap.of("debug", "1.0"));
+    final JsonRpcResponse actual = method.response(request);
+
+    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+  }
+}


### PR DESCRIPTION
## PR description

rpc_module enumerates the modules exposed to RPC.  This allows the
`geth attach` geth javascript console to attach to Pantheon and use the
json-rpc APIs that pantheon and geth share.

