### PR TITLE
Timeout long test

### DIFF
--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/worldstate/WorldStateDownloaderTest.java
@@ -86,9 +86,13 @@ import java.util.stream.StreamSupport;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class WorldStateDownloaderTest {
+
+  @Rule public Timeout globalTimeout = Timeout.seconds(60); // 1 minute max per test
 
   private static final Hash EMPTY_TRIE_ROOT = Hash.wrap(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH);
 


### PR DESCRIPTION
## PR description

WorldStateDownloaderTest can get in an infinite loop.  Add a timeout rule.

