### PR TITLE
PAN-2286 - quieter exceptions when network is unreachable

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -41,6 +41,7 @@ import tech.pegasys.pantheon.util.Subscribers;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -204,11 +205,16 @@ public abstract class PeerDiscoveryAgent implements DisconnectCallback {
         .whenComplete(
             (res, err) -> {
               if (err != null) {
-                LOG.warn(
-                    "Sending to peer {} failed, packet: {}",
-                    peer,
-                    wrapBuffer(packet.encode()),
-                    err);
+                if (err instanceof SocketException && err.getMessage().contains("unreachable")) {
+                  LOG.debug(
+                      "Peer {} is unreachable, packet: {}", peer, wrapBuffer(packet.encode()), err);
+                } else {
+                  LOG.warn(
+                      "Sending to peer {} failed, packet: {}",
+                      peer,
+                      wrapBuffer(packet.encode()),
+                      err);
+                }
                 return;
               }
               peer.setLastContacted(System.currentTimeMillis());


### PR DESCRIPTION
## PR description

Lower the log level of discovery connections to unreachable networks,
such as a box without IPv6 enabled connecting to an IPv6 peer.


## Fixed Issue(s)

PAN-2286