### PR TITLE
Fail at load if static nodes not whitelisted

### DIFF
--- a/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
@@ -97,7 +97,7 @@ public class RunnerBuilder {
   private MetricsConfiguration metricsConfiguration;
   private MetricsSystem metricsSystem;
   private Optional<PermissioningConfiguration> permissioningConfiguration = Optional.empty();
-  private Set<EnodeURL> staticNodes;
+  private Collection<EnodeURL> staticNodes;
 
   private EnodeURL getSelfEnode() {
     String nodeId = pantheonController.getLocalNodeKeyPair().getPublicKey().toString();
@@ -180,7 +180,7 @@ public class RunnerBuilder {
     return this;
   }
 
-  public RunnerBuilder staticNodes(final Set<EnodeURL> staticNodes) {
+  public RunnerBuilder staticNodes(final Collection<EnodeURL> staticNodes) {
     this.staticNodes = staticNodes;
     return this;
   }
@@ -300,12 +300,12 @@ public class RunnerBuilder {
     final FilterManager filterManager = createFilterManager(vertx, context, transactionPool);
 
     final P2PNetwork peerNetwork = networkRunner.getNetwork();
-    staticNodes.stream()
-        .forEach(
-            enodeURL -> {
-              final Peer peer = DefaultPeer.fromEnodeURL(enodeURL);
-              peerNetwork.addMaintainConnectionPeer(peer);
-            });
+
+    staticNodes.forEach(
+        enodeURL -> {
+          final Peer peer = DefaultPeer.fromEnodeURL(enodeURL);
+          peerNetwork.addMaintainConnectionPeer(peer);
+        });
 
     Optional<JsonRpcHttpService> jsonRpcHttpService = Optional.empty();
     if (jsonRpcConfiguration.isEnabled()) {

--- a/pantheon/src/main/java/tech/pegasys/pantheon/util/PermissioningConfigurationValidator.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/util/PermissioningConfigurationValidator.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.pantheon.util;
 
-import tech.pegasys.pantheon.cli.EthNetworkConfig;
 import tech.pegasys.pantheon.ethereum.permissioning.LocalPermissioningConfiguration;
 
 import java.net.URI;
@@ -23,21 +22,20 @@ import java.util.stream.Collectors;
 
 public class PermissioningConfigurationValidator {
 
-  public static void areAllBootnodesAreInWhitelist(
-      final EthNetworkConfig ethNetworkConfig,
+  public static void areAllNodesAreInWhitelist(
+      final Collection<URI> nodeURIs,
       final LocalPermissioningConfiguration permissioningConfiguration)
       throws Exception {
-    List<URI> bootnodesNotInWhitelist = new ArrayList<>();
-    final Collection<URI> bootnodes = ethNetworkConfig.getBootNodes();
-    if (permissioningConfiguration.isNodeWhitelistEnabled() && bootnodes != null) {
-      bootnodesNotInWhitelist =
-          bootnodes.stream()
+    List<URI> nodesNotInWhitelist = new ArrayList<>();
+    if (permissioningConfiguration.isNodeWhitelistEnabled() && nodeURIs != null) {
+      nodesNotInWhitelist =
+          nodeURIs.stream()
               .filter(enode -> !permissioningConfiguration.getNodeWhitelist().contains(enode))
               .collect(Collectors.toList());
     }
-    if (!bootnodesNotInWhitelist.isEmpty()) {
+    if (!nodesNotInWhitelist.isEmpty()) {
       throw new Exception(
-          "Bootnode(s) not in nodes-whitelist " + enodesAsStrings(bootnodesNotInWhitelist));
+          "Specified node(s) not in nodes-whitelist " + enodesAsStrings(nodesNotInWhitelist));
     }
   }
 

--- a/pantheon/src/test/java/tech/pegasys/pantheon/util/LocalPermissioningConfigurationValidatorTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/util/LocalPermissioningConfigurationValidatorTest.java
@@ -47,8 +47,8 @@ public class LocalPermissioningConfigurationValidatorTest {
         PermissioningConfigurationBuilder.permissioningConfiguration(
             true, toml.toAbsolutePath().toString(), true, toml.toAbsolutePath().toString());
 
-    PermissioningConfigurationValidator.areAllBootnodesAreInWhitelist(
-        ethNetworkConfig, permissioningConfiguration);
+    PermissioningConfigurationValidator.areAllNodesAreInWhitelist(
+        ethNetworkConfig.getBootNodes(), permissioningConfiguration);
   }
 
   @Test
@@ -66,11 +66,11 @@ public class LocalPermissioningConfigurationValidatorTest {
             true, toml.toAbsolutePath().toString(), true, toml.toAbsolutePath().toString());
 
     try {
-      PermissioningConfigurationValidator.areAllBootnodesAreInWhitelist(
-          ethNetworkConfig, permissioningConfiguration);
+      PermissioningConfigurationValidator.areAllNodesAreInWhitelist(
+          ethNetworkConfig.getBootNodes(), permissioningConfiguration);
       fail("expected exception because ropsten bootnodes are not in node-whitelist");
     } catch (Exception e) {
-      assertThat(e.getMessage()).startsWith("Bootnode(s) not in nodes-whitelist");
+      assertThat(e.getMessage()).startsWith("Specified node(s) not in nodes-whitelist");
       assertThat(e.getMessage())
           .contains(
               "enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@52.232.243.152:30303");


### PR DESCRIPTION
To prevent unexpected behaviour, if a static node is not in the nodes whitelist
(when permissioning is enabled) pantheon will not start (rather than starting
with only whitelisted static nodes).