### PR TITLE
fix azure deploy url

### DIFF
--- a/docs/Tutorials/Azure/Azure-Private-Network-Quickstart.md
+++ b/docs/Tutorials/Azure/Azure-Private-Network-Quickstart.md
@@ -42,7 +42,7 @@ This tutorial contains some optional steps that will increase the duration.
 
 Deploy the Pantheon Quickstart on [Microsoft Azure](https://azure.microsoft.com) by clicking the button below.
 
-[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FNicolasMassart%2Fpantheon-quickstart%2Fazure_deploy_button%2Fazure%2Fazuredeploy.json)
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FPegaSysEng%2Fpantheon-quickstart%2Fmaster%2Fazure%2Fazuredeploy.json)
 
 If prompted to log in to the Azure Portal, log in before being redirected to the deployment form.  
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Url on the tutorial is pointing to my fork, forgot to make the change.
Once merge, we can remove the NicolasMassart:azure_deploy_button branch from my fork. My bad, sorry.
The links works the same for the moment, just using a JSON from the wrong place. So no visible issue for the users.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Quick fix