### PR TITLE
documentation: Fixed the relative links on documentation that weren't working

### DIFF
--- a/docs/community/community-membership.md
+++ b/docs/community/community-membership.md
@@ -163,12 +163,12 @@ This document is adapted from the following sources:
 - Kubernetes community-membership.md, available at [kub community membership].  
 - OSSWatch Benevolent Dictator Governance Model, available at [oss watch benevolent dictator].  
 
-[CLA.md]: /CLA.md
+[CLA.md]: https://github.com/PegaSysEng/pantheon/blob/master/CLA.md
 [oss watch benevolent dictator]: http://oss-watch.ac.uk/resources/benevolentdictatorgovernancemodel
 [kub community membership]: https://raw.githubusercontent.com/kubernetes/community/master/community-membership.md
-[code reviews]: /docs/community/code-reviews.md
-[contributor guide]: /CONTRIBUTING.md
-[New contributors]: /CONTRIBUTING.md
+[code reviews]: code-reviews.md
+[contributor guide]: https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md
+[New contributors]: https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
 [pantheon-dev@pegasys.tech]: mailto:pantheon-dev@pegasys.tech
 [Pantheon Gitter]: https://gitter.im/PegaSysEng/pantheon


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
I've replaced some relative links on the documentation (on Community membership page) that weren't working.
I've replaced them, either by: absolute links for those pointing to root files, or a correct relative link in the case of `code-reviews.md`.

## Fixed Issue(s)
fixes #1162
