### PR TITLE
[PIE-7] Ignore transactions from the network while behind chain head

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/core/TransactionPool.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/core/TransactionPool.java
@@ -49,19 +49,8 @@ public class TransactionPool implements BlockAddedObserver {
   private final ProtocolSchedule<?> protocolSchedule;
   private final ProtocolContext<?> protocolContext;
   private final TransactionBatchAddedListener transactionBatchAddedListener;
+  private final Synchronizer synchronizer;
   private Optional<AccountFilter> accountFilter = Optional.empty();
-  private Synchronizer synchronizer;
-
-  public TransactionPool(
-          final PendingTransactions pendingTransactions,
-          final ProtocolSchedule<?> protocolSchedule,
-          final ProtocolContext<?> protocolContext,
-          final TransactionBatchAddedListener transactionBatchAddedListener) {
-    this.pendingTransactions = pendingTransactions;
-    this.protocolSchedule = protocolSchedule;
-    this.protocolContext = protocolContext;
-    this.transactionBatchAddedListener = transactionBatchAddedListener;
-  }
 
   public TransactionPool(
       final PendingTransactions pendingTransactions,
@@ -93,7 +82,7 @@ public class TransactionPool implements BlockAddedObserver {
 
   public void addRemoteTransactions(final Collection<Transaction> transactions) {
 
-    if(synchronizer.getSyncStatus().isPresent()){
+    if (synchronizer.getSyncStatus().isPresent()) {
       return;
     }
 

--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/core/TransactionPool.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/core/TransactionPool.java
@@ -50,16 +50,30 @@ public class TransactionPool implements BlockAddedObserver {
   private final ProtocolContext<?> protocolContext;
   private final TransactionBatchAddedListener transactionBatchAddedListener;
   private Optional<AccountFilter> accountFilter = Optional.empty();
+  private Synchronizer synchronizer;
+
+  public TransactionPool(
+          final PendingTransactions pendingTransactions,
+          final ProtocolSchedule<?> protocolSchedule,
+          final ProtocolContext<?> protocolContext,
+          final TransactionBatchAddedListener transactionBatchAddedListener) {
+    this.pendingTransactions = pendingTransactions;
+    this.protocolSchedule = protocolSchedule;
+    this.protocolContext = protocolContext;
+    this.transactionBatchAddedListener = transactionBatchAddedListener;
+  }
 
   public TransactionPool(
       final PendingTransactions pendingTransactions,
       final ProtocolSchedule<?> protocolSchedule,
       final ProtocolContext<?> protocolContext,
-      final TransactionBatchAddedListener transactionBatchAddedListener) {
+      final TransactionBatchAddedListener transactionBatchAddedListener,
+      final Synchronizer synchronizer) {
     this.pendingTransactions = pendingTransactions;
     this.protocolSchedule = protocolSchedule;
     this.protocolContext = protocolContext;
     this.transactionBatchAddedListener = transactionBatchAddedListener;
+    this.synchronizer = synchronizer;
   }
 
   public ValidationResult<TransactionInvalidReason> addLocalTransaction(
@@ -78,6 +92,11 @@ public class TransactionPool implements BlockAddedObserver {
   }
 
   public void addRemoteTransactions(final Collection<Transaction> transactions) {
+
+    if(synchronizer.getSyncStatus().isPresent()){
+      return;
+    }
+
     final Set<Transaction> addedTransactions = new HashSet<>();
     for (final Transaction transaction : sortByNonce(transactions)) {
       final ValidationResult<TransactionInvalidReason> validationResult =

--- a/ethereum/core/src/test/java/tech/pegasys/pantheon/ethereum/core/TransactionPoolTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/pantheon/ethereum/core/TransactionPoolTest.java
@@ -39,10 +39,7 @@ import tech.pegasys.pantheon.crypto.SECP256K1.KeyPair;
 import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.chain.MutableBlockchain;
 import tech.pegasys.pantheon.ethereum.core.TransactionPool.TransactionBatchAddedListener;
-import tech.pegasys.pantheon.ethereum.eth.manager.EthProtocolManager;
-import tech.pegasys.pantheon.ethereum.eth.sync.DefaultSynchronizer;
-import tech.pegasys.pantheon.ethereum.eth.sync.SynchronizerConfiguration;
-import tech.pegasys.pantheon.ethereum.eth.sync.state.SyncState;
+
 import tech.pegasys.pantheon.ethereum.mainnet.ProtocolSchedule;
 import tech.pegasys.pantheon.ethereum.mainnet.ProtocolSpec;
 import tech.pegasys.pantheon.ethereum.mainnet.TransactionValidator;
@@ -59,6 +56,18 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+
+
+
+//import tech.pegasys.pantheon.ethereum.eth.manager.EthProtocolManager;
+//import tech.pegasys.pantheon.ethereum.eth.sync.DefaultSynchronizer;
+//import tech.pegasys.pantheon.ethereum.eth.sync.SynchronizerConfiguration;
+//import tech.pegasys.pantheon.ethereum.eth.sync.state.SyncState;
+
+//import tech.pegasys.pantheon.ethereum.eth.sync.SynchronizerConfiguration;
+
+
+
 
 public class TransactionPoolTest {
 
@@ -95,8 +104,7 @@ public class TransactionPoolTest {
     when(protocolSpec.getTransactionValidator()).thenReturn(transactionValidator);
     genesisBlockGasLimit = executionContext.getGenesis().getHeader().getGasLimit();
 
-    SynchronizerConfiguration syncConfig =
-        SynchronizerConfiguration.builder().worldStateMaxRequestsWithoutProgress(10).build();
+    SynchronizerConfiguration syncConfig = SynchronizerConfiguration.builder().worldStateMaxRequestsWithoutProgress(10).build();
 
     boolean fastSyncEnabled = false;
 

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -26,48 +26,13 @@ import java.time.Clock;
 public class TransactionPoolFactory {
 
   public static TransactionPool createTransactionPool(
-          final ProtocolSchedule<?> protocolSchedule,
-          final ProtocolContext<?> protocolContext,
-          final EthContext ethContext,
-          final Clock clock,
-          final int maxPendingTransactions,
-          final MetricsSystem metricsSystem,
-          final Synchronizer synchronizer) {
-    final PendingTransactions pendingTransactions =
-            new PendingTransactions(maxPendingTransactions, clock, metricsSystem);
-
-    final PeerTransactionTracker transactionTracker = new PeerTransactionTracker();
-    final TransactionsMessageSender transactionsMessageSender =
-            new TransactionsMessageSender(transactionTracker);
-
-    final TransactionPool transactionPool =
-            new TransactionPool(
-                    pendingTransactions,
-                    protocolSchedule,
-                    protocolContext,
-                    new TransactionSender(transactionTracker, transactionsMessageSender, ethContext),
-                    synchronizer);
-
-    final TransactionsMessageHandler transactionsMessageHandler =
-            new TransactionsMessageHandler(
-                    ethContext.getScheduler(),
-                    new TransactionsMessageProcessor(transactionTracker, transactionPool));
-
-    ethContext.getEthMessages().subscribe(EthPV62.TRANSACTIONS, transactionsMessageHandler);
-    protocolContext.getBlockchain().observeBlockAdded(transactionPool);
-    ethContext.getEthPeers().subscribeDisconnect(transactionTracker);
-    return transactionPool;
-  }
-
-
-
-  public static TransactionPool createTransactionPool(
       final ProtocolSchedule<?> protocolSchedule,
       final ProtocolContext<?> protocolContext,
       final EthContext ethContext,
       final Clock clock,
       final int maxPendingTransactions,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final Synchronizer synchronizer) {
     final PendingTransactions pendingTransactions =
         new PendingTransactions(maxPendingTransactions, clock, metricsSystem);
 
@@ -80,7 +45,8 @@ public class TransactionPoolFactory {
             pendingTransactions,
             protocolSchedule,
             protocolContext,
-            new TransactionSender(transactionTracker, transactionsMessageSender, ethContext));
+            new TransactionSender(transactionTracker, transactionsMessageSender, ethContext),
+            synchronizer);
 
     final TransactionsMessageHandler transactionsMessageHandler =
         new TransactionsMessageHandler(

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -14,6 +14,7 @@ package tech.pegasys.pantheon.ethereum.eth.transactions;
 
 import tech.pegasys.pantheon.ethereum.ProtocolContext;
 import tech.pegasys.pantheon.ethereum.core.PendingTransactions;
+import tech.pegasys.pantheon.ethereum.core.Synchronizer;
 import tech.pegasys.pantheon.ethereum.core.TransactionPool;
 import tech.pegasys.pantheon.ethereum.eth.manager.EthContext;
 import tech.pegasys.pantheon.ethereum.eth.messages.EthPV62;
@@ -23,6 +24,42 @@ import tech.pegasys.pantheon.metrics.MetricsSystem;
 import java.time.Clock;
 
 public class TransactionPoolFactory {
+
+  public static TransactionPool createTransactionPool(
+          final ProtocolSchedule<?> protocolSchedule,
+          final ProtocolContext<?> protocolContext,
+          final EthContext ethContext,
+          final Clock clock,
+          final int maxPendingTransactions,
+          final MetricsSystem metricsSystem,
+          final Synchronizer synchronizer) {
+    final PendingTransactions pendingTransactions =
+            new PendingTransactions(maxPendingTransactions, clock, metricsSystem);
+
+    final PeerTransactionTracker transactionTracker = new PeerTransactionTracker();
+    final TransactionsMessageSender transactionsMessageSender =
+            new TransactionsMessageSender(transactionTracker);
+
+    final TransactionPool transactionPool =
+            new TransactionPool(
+                    pendingTransactions,
+                    protocolSchedule,
+                    protocolContext,
+                    new TransactionSender(transactionTracker, transactionsMessageSender, ethContext),
+                    synchronizer);
+
+    final TransactionsMessageHandler transactionsMessageHandler =
+            new TransactionsMessageHandler(
+                    ethContext.getScheduler(),
+                    new TransactionsMessageProcessor(transactionTracker, transactionPool));
+
+    ethContext.getEthMessages().subscribe(EthPV62.TRANSACTIONS, transactionsMessageHandler);
+    protocolContext.getBlockchain().observeBlockAdded(transactionPool);
+    ethContext.getEthPeers().subscribeDisconnect(transactionTracker);
+    return transactionPool;
+  }
+
+
 
   public static TransactionPool createTransactionPool(
       final ProtocolSchedule<?> protocolSchedule,

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/CliquePantheonController.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/CliquePantheonController.java
@@ -178,7 +178,8 @@ public class CliquePantheonController implements PantheonController<CliqueContex
             ethProtocolManager.ethContext(),
             clock,
             maxPendingTransactions,
-            metricsSystem);
+            metricsSystem,
+            synchronizer);
 
     final ExecutorService minerThreadPool = Executors.newCachedThreadPool();
     final CliqueMinerExecutor miningExecutor =

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftLegacyPantheonController.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftLegacyPantheonController.java
@@ -182,7 +182,8 @@ public class IbftLegacyPantheonController implements PantheonController<IbftCont
             istanbul64ProtocolManager.ethContext(),
             clock,
             maxPendingTransactions,
-            metricsSystem);
+            metricsSystem,
+            synchronizer);
 
     return new IbftLegacyPantheonController(
         protocolSchedule,

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonController.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonController.java
@@ -207,7 +207,8 @@ public class IbftPantheonController implements PantheonController<IbftContext> {
             ethContext,
             clock,
             maxPendingTransactions,
-            metricsSystem);
+            metricsSystem,
+            synchronizer);
 
     final IbftEventQueue ibftEventQueue = new IbftEventQueue(ibftConfig.getMessageQueueLimit());
 

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/MainnetPantheonController.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/MainnetPantheonController.java
@@ -56,204 +56,204 @@ import org.apache.logging.log4j.Logger;
 
 public class MainnetPantheonController implements PantheonController<Void> {
 
-    private static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
-    private final ProtocolSchedule<Void> protocolSchedule;
-    private final ProtocolContext<Void> protocolContext;
-    private final GenesisConfigOptions genesisConfigOptions;
-    private final ProtocolManager ethProtocolManager;
-    private final KeyPair keyPair;
-    private final Synchronizer synchronizer;
+  private final ProtocolSchedule<Void> protocolSchedule;
+  private final ProtocolContext<Void> protocolContext;
+  private final GenesisConfigOptions genesisConfigOptions;
+  private final ProtocolManager ethProtocolManager;
+  private final KeyPair keyPair;
+  private final Synchronizer synchronizer;
 
-    private final TransactionPool transactionPool;
-    private final MiningCoordinator miningCoordinator;
-    private final PrivacyParameters privacyParameters;
-    private final Runnable close;
+  private final TransactionPool transactionPool;
+  private final MiningCoordinator miningCoordinator;
+  private final PrivacyParameters privacyParameters;
+  private final Runnable close;
 
-    private MainnetPantheonController(
-            final ProtocolSchedule<Void> protocolSchedule,
-            final ProtocolContext<Void> protocolContext,
-            final GenesisConfigOptions genesisConfigOptions,
-            final ProtocolManager ethProtocolManager,
-            final Synchronizer synchronizer,
-            final KeyPair keyPair,
-            final TransactionPool transactionPool,
-            final MiningCoordinator miningCoordinator,
-            final PrivacyParameters privacyParameters,
-            final Runnable close) {
-        this.protocolSchedule = protocolSchedule;
-        this.protocolContext = protocolContext;
-        this.genesisConfigOptions = genesisConfigOptions;
-        this.ethProtocolManager = ethProtocolManager;
-        this.synchronizer = synchronizer;
-        this.keyPair = keyPair;
-        this.transactionPool = transactionPool;
-        this.miningCoordinator = miningCoordinator;
-        this.privacyParameters = privacyParameters;
-        this.close = close;
+  private MainnetPantheonController(
+      final ProtocolSchedule<Void> protocolSchedule,
+      final ProtocolContext<Void> protocolContext,
+      final GenesisConfigOptions genesisConfigOptions,
+      final ProtocolManager ethProtocolManager,
+      final Synchronizer synchronizer,
+      final KeyPair keyPair,
+      final TransactionPool transactionPool,
+      final MiningCoordinator miningCoordinator,
+      final PrivacyParameters privacyParameters,
+      final Runnable close) {
+    this.protocolSchedule = protocolSchedule;
+    this.protocolContext = protocolContext;
+    this.genesisConfigOptions = genesisConfigOptions;
+    this.ethProtocolManager = ethProtocolManager;
+    this.synchronizer = synchronizer;
+    this.keyPair = keyPair;
+    this.transactionPool = transactionPool;
+    this.miningCoordinator = miningCoordinator;
+    this.privacyParameters = privacyParameters;
+    this.close = close;
+  }
+
+  public static PantheonController<Void> init(
+      final StorageProvider storageProvider,
+      final GenesisConfigFile genesisConfig,
+      final ProtocolSchedule<Void> protocolSchedule,
+      final SynchronizerConfiguration syncConfig,
+      final MiningParameters miningParams,
+      final int networkId,
+      final KeyPair nodeKeys,
+      final PrivacyParameters privacyParameters,
+      final Path dataDirectory,
+      final MetricsSystem metricsSystem,
+      final Clock clock,
+      final int maxPendingTransactions) {
+
+    final GenesisState genesisState = GenesisState.fromConfig(genesisConfig, protocolSchedule);
+    final ProtocolContext<Void> protocolContext =
+        ProtocolContext.init(
+            storageProvider, genesisState, protocolSchedule, metricsSystem, (a, b) -> null);
+    final MutableBlockchain blockchain = protocolContext.getBlockchain();
+
+    final boolean fastSyncEnabled = syncConfig.syncMode().equals(SyncMode.FAST);
+    final EthProtocolManager ethProtocolManager =
+        new EthProtocolManager(
+            blockchain,
+            protocolContext.getWorldStateArchive(),
+            networkId,
+            fastSyncEnabled,
+            syncConfig.downloaderParallelism(),
+            syncConfig.transactionsParallelism(),
+            syncConfig.computationParallelism(),
+            metricsSystem);
+    final SyncState syncState =
+        new SyncState(blockchain, ethProtocolManager.ethContext().getEthPeers());
+    final Synchronizer synchronizer =
+        new DefaultSynchronizer<>(
+            syncConfig,
+            protocolSchedule,
+            protocolContext,
+            protocolContext.getWorldStateArchive().getStorage(),
+            ethProtocolManager.ethContext(),
+            syncState,
+            dataDirectory,
+            clock,
+            metricsSystem);
+
+    final OptionalLong daoBlock = genesisConfig.getConfigOptions().getDaoForkBlock();
+    if (daoBlock.isPresent()) {
+      // Setup dao validator
+      final EthContext ethContext = ethProtocolManager.ethContext();
+      final DaoForkPeerValidator daoForkPeerValidator =
+          new DaoForkPeerValidator(
+              ethContext, protocolSchedule, metricsSystem, daoBlock.getAsLong());
+      PeerValidatorRunner.runValidator(ethContext, daoForkPeerValidator);
     }
 
-    public static PantheonController<Void> init(
-            final StorageProvider storageProvider,
-            final GenesisConfigFile genesisConfig,
-            final ProtocolSchedule<Void> protocolSchedule,
-            final SynchronizerConfiguration syncConfig,
-            final MiningParameters miningParams,
-            final int networkId,
-            final KeyPair nodeKeys,
-            final PrivacyParameters privacyParameters,
-            final Path dataDirectory,
-            final MetricsSystem metricsSystem,
-            final Clock clock,
-            final int maxPendingTransactions) {
+    final TransactionPool transactionPool =
+        TransactionPoolFactory.createTransactionPool(
+            protocolSchedule,
+            protocolContext,
+            ethProtocolManager.ethContext(),
+            clock,
+            maxPendingTransactions,
+            metricsSystem,
+            synchronizer);
 
-        final GenesisState genesisState = GenesisState.fromConfig(genesisConfig, protocolSchedule);
-        final ProtocolContext<Void> protocolContext =
-                ProtocolContext.init(
-                        storageProvider, genesisState, protocolSchedule, metricsSystem, (a, b) -> null);
-        final MutableBlockchain blockchain = protocolContext.getBlockchain();
+    final ExecutorService minerThreadPool = Executors.newCachedThreadPool();
+    final EthHashMinerExecutor executor =
+        new EthHashMinerExecutor(
+            protocolContext,
+            minerThreadPool,
+            protocolSchedule,
+            transactionPool.getPendingTransactions(),
+            miningParams,
+            new DefaultBlockScheduler(
+                MainnetBlockHeaderValidator.MINIMUM_SECONDS_SINCE_PARENT,
+                MainnetBlockHeaderValidator.TIMESTAMP_TOLERANCE_S,
+                clock));
 
-        final boolean fastSyncEnabled = syncConfig.syncMode().equals(SyncMode.FAST);
-        final EthProtocolManager ethProtocolManager =
-                new EthProtocolManager(
-                        blockchain,
-                        protocolContext.getWorldStateArchive(),
-                        networkId,
-                        fastSyncEnabled,
-                        syncConfig.downloaderParallelism(),
-                        syncConfig.transactionsParallelism(),
-                        syncConfig.computationParallelism(),
-                        metricsSystem);
-        final SyncState syncState =
-                new SyncState(blockchain, ethProtocolManager.ethContext().getEthPeers());
-        final Synchronizer synchronizer =
-                new DefaultSynchronizer<>(
-                        syncConfig,
-                        protocolSchedule,
-                        protocolContext,
-                        protocolContext.getWorldStateArchive().getStorage(),
-                        ethProtocolManager.ethContext(),
-                        syncState,
-                        dataDirectory,
-                        clock,
-                        metricsSystem);
-
-        final OptionalLong daoBlock = genesisConfig.getConfigOptions().getDaoForkBlock();
-        if (daoBlock.isPresent()) {
-            // Setup dao validator
-            final EthContext ethContext = ethProtocolManager.ethContext();
-            final DaoForkPeerValidator daoForkPeerValidator =
-                    new DaoForkPeerValidator(
-                            ethContext, protocolSchedule, metricsSystem, daoBlock.getAsLong());
-            PeerValidatorRunner.runValidator(ethContext, daoForkPeerValidator);
-        }
-
-        final TransactionPool transactionPool =
-                TransactionPoolFactory.createTransactionPool(
-                        protocolSchedule,
-                        protocolContext,
-                        ethProtocolManager.ethContext(),
-                        clock,
-                        maxPendingTransactions,
-                        metricsSystem,
-                        synchronizer);
-
-        final ExecutorService minerThreadPool = Executors.newCachedThreadPool();
-        final EthHashMinerExecutor executor =
-                new EthHashMinerExecutor(
-                        protocolContext,
-                        minerThreadPool,
-                        protocolSchedule,
-                        transactionPool.getPendingTransactions(),
-                        miningParams,
-                        new DefaultBlockScheduler(
-                                MainnetBlockHeaderValidator.MINIMUM_SECONDS_SINCE_PARENT,
-                                MainnetBlockHeaderValidator.TIMESTAMP_TOLERANCE_S,
-                                clock));
-
-        final EthHashMiningCoordinator miningCoordinator =
-                new EthHashMiningCoordinator(blockchain, executor, syncState);
-        miningCoordinator.addMinedBlockObserver(ethProtocolManager);
-        if (miningParams.isMiningEnabled()) {
-            miningCoordinator.enable();
-        }
-
-        return new MainnetPantheonController(
-                protocolSchedule,
-                protocolContext,
-                genesisConfig.getConfigOptions(),
-                ethProtocolManager,
-                synchronizer,
-                nodeKeys,
-                transactionPool,
-                miningCoordinator,
-                privacyParameters,
-                () -> {
-                    miningCoordinator.disable();
-                    minerThreadPool.shutdownNow();
-                    try {
-                        minerThreadPool.awaitTermination(5, TimeUnit.SECONDS);
-                    } catch (final InterruptedException e) {
-                        LOG.error("Failed to shutdown miner executor");
-                    }
-                    try {
-                        storageProvider.close();
-                        if (privacyParameters.getPrivateStorageProvider() != null) {
-                            privacyParameters.getPrivateStorageProvider().close();
-                        }
-                    } catch (final IOException e) {
-                        LOG.error("Failed to close storage provider", e);
-                    }
-                });
+    final EthHashMiningCoordinator miningCoordinator =
+        new EthHashMiningCoordinator(blockchain, executor, syncState);
+    miningCoordinator.addMinedBlockObserver(ethProtocolManager);
+    if (miningParams.isMiningEnabled()) {
+      miningCoordinator.enable();
     }
 
-    @Override
-    public ProtocolContext<Void> getProtocolContext() {
-        return protocolContext;
-    }
+    return new MainnetPantheonController(
+        protocolSchedule,
+        protocolContext,
+        genesisConfig.getConfigOptions(),
+        ethProtocolManager,
+        synchronizer,
+        nodeKeys,
+        transactionPool,
+        miningCoordinator,
+        privacyParameters,
+        () -> {
+          miningCoordinator.disable();
+          minerThreadPool.shutdownNow();
+          try {
+            minerThreadPool.awaitTermination(5, TimeUnit.SECONDS);
+          } catch (final InterruptedException e) {
+            LOG.error("Failed to shutdown miner executor");
+          }
+          try {
+            storageProvider.close();
+            if (privacyParameters.getPrivateStorageProvider() != null) {
+              privacyParameters.getPrivateStorageProvider().close();
+            }
+          } catch (final IOException e) {
+            LOG.error("Failed to close storage provider", e);
+          }
+        });
+  }
 
-    @Override
-    public ProtocolSchedule<Void> getProtocolSchedule() {
-        return protocolSchedule;
-    }
+  @Override
+  public ProtocolContext<Void> getProtocolContext() {
+    return protocolContext;
+  }
 
-    @Override
-    public GenesisConfigOptions getGenesisConfigOptions() {
-        return genesisConfigOptions;
-    }
+  @Override
+  public ProtocolSchedule<Void> getProtocolSchedule() {
+    return protocolSchedule;
+  }
 
-    @Override
-    public Synchronizer getSynchronizer() {
-        return synchronizer;
-    }
+  @Override
+  public GenesisConfigOptions getGenesisConfigOptions() {
+    return genesisConfigOptions;
+  }
 
-    @Override
-    public SubProtocolConfiguration subProtocolConfiguration() {
-        return new SubProtocolConfiguration().withSubProtocol(EthProtocol.get(), ethProtocolManager);
-    }
+  @Override
+  public Synchronizer getSynchronizer() {
+    return synchronizer;
+  }
 
-    @Override
-    public KeyPair getLocalNodeKeyPair() {
-        return keyPair;
-    }
+  @Override
+  public SubProtocolConfiguration subProtocolConfiguration() {
+    return new SubProtocolConfiguration().withSubProtocol(EthProtocol.get(), ethProtocolManager);
+  }
 
-    @Override
-    public TransactionPool getTransactionPool() {
-        return transactionPool;
-    }
+  @Override
+  public KeyPair getLocalNodeKeyPair() {
+    return keyPair;
+  }
 
-    @Override
-    public MiningCoordinator getMiningCoordinator() {
-        return miningCoordinator;
-    }
+  @Override
+  public TransactionPool getTransactionPool() {
+    return transactionPool;
+  }
 
-    @Override
-    public void close() {
-        close.run();
-    }
+  @Override
+  public MiningCoordinator getMiningCoordinator() {
+    return miningCoordinator;
+  }
 
-    @Override
-    public PrivacyParameters getPrivacyParameters() {
-        return privacyParameters;
-    }
+  @Override
+  public void close() {
+    close.run();
+  }
+
+  @Override
+  public PrivacyParameters getPrivacyParameters() {
+    return privacyParameters;
+  }
 }

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/MainnetPantheonController.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/MainnetPantheonController.java
@@ -56,203 +56,204 @@ import org.apache.logging.log4j.Logger;
 
 public class MainnetPantheonController implements PantheonController<Void> {
 
-  private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger();
 
-  private final ProtocolSchedule<Void> protocolSchedule;
-  private final ProtocolContext<Void> protocolContext;
-  private final GenesisConfigOptions genesisConfigOptions;
-  private final ProtocolManager ethProtocolManager;
-  private final KeyPair keyPair;
-  private final Synchronizer synchronizer;
+    private final ProtocolSchedule<Void> protocolSchedule;
+    private final ProtocolContext<Void> protocolContext;
+    private final GenesisConfigOptions genesisConfigOptions;
+    private final ProtocolManager ethProtocolManager;
+    private final KeyPair keyPair;
+    private final Synchronizer synchronizer;
 
-  private final TransactionPool transactionPool;
-  private final MiningCoordinator miningCoordinator;
-  private final PrivacyParameters privacyParameters;
-  private final Runnable close;
+    private final TransactionPool transactionPool;
+    private final MiningCoordinator miningCoordinator;
+    private final PrivacyParameters privacyParameters;
+    private final Runnable close;
 
-  private MainnetPantheonController(
-      final ProtocolSchedule<Void> protocolSchedule,
-      final ProtocolContext<Void> protocolContext,
-      final GenesisConfigOptions genesisConfigOptions,
-      final ProtocolManager ethProtocolManager,
-      final Synchronizer synchronizer,
-      final KeyPair keyPair,
-      final TransactionPool transactionPool,
-      final MiningCoordinator miningCoordinator,
-      final PrivacyParameters privacyParameters,
-      final Runnable close) {
-    this.protocolSchedule = protocolSchedule;
-    this.protocolContext = protocolContext;
-    this.genesisConfigOptions = genesisConfigOptions;
-    this.ethProtocolManager = ethProtocolManager;
-    this.synchronizer = synchronizer;
-    this.keyPair = keyPair;
-    this.transactionPool = transactionPool;
-    this.miningCoordinator = miningCoordinator;
-    this.privacyParameters = privacyParameters;
-    this.close = close;
-  }
-
-  public static PantheonController<Void> init(
-      final StorageProvider storageProvider,
-      final GenesisConfigFile genesisConfig,
-      final ProtocolSchedule<Void> protocolSchedule,
-      final SynchronizerConfiguration syncConfig,
-      final MiningParameters miningParams,
-      final int networkId,
-      final KeyPair nodeKeys,
-      final PrivacyParameters privacyParameters,
-      final Path dataDirectory,
-      final MetricsSystem metricsSystem,
-      final Clock clock,
-      final int maxPendingTransactions) {
-
-    final GenesisState genesisState = GenesisState.fromConfig(genesisConfig, protocolSchedule);
-    final ProtocolContext<Void> protocolContext =
-        ProtocolContext.init(
-            storageProvider, genesisState, protocolSchedule, metricsSystem, (a, b) -> null);
-    final MutableBlockchain blockchain = protocolContext.getBlockchain();
-
-    final boolean fastSyncEnabled = syncConfig.syncMode().equals(SyncMode.FAST);
-    final EthProtocolManager ethProtocolManager =
-        new EthProtocolManager(
-            blockchain,
-            protocolContext.getWorldStateArchive(),
-            networkId,
-            fastSyncEnabled,
-            syncConfig.downloaderParallelism(),
-            syncConfig.transactionsParallelism(),
-            syncConfig.computationParallelism(),
-            metricsSystem);
-    final SyncState syncState =
-        new SyncState(blockchain, ethProtocolManager.ethContext().getEthPeers());
-    final Synchronizer synchronizer =
-        new DefaultSynchronizer<>(
-            syncConfig,
-            protocolSchedule,
-            protocolContext,
-            protocolContext.getWorldStateArchive().getStorage(),
-            ethProtocolManager.ethContext(),
-            syncState,
-            dataDirectory,
-            clock,
-            metricsSystem);
-
-    final OptionalLong daoBlock = genesisConfig.getConfigOptions().getDaoForkBlock();
-    if (daoBlock.isPresent()) {
-      // Setup dao validator
-      final EthContext ethContext = ethProtocolManager.ethContext();
-      final DaoForkPeerValidator daoForkPeerValidator =
-          new DaoForkPeerValidator(
-              ethContext, protocolSchedule, metricsSystem, daoBlock.getAsLong());
-      PeerValidatorRunner.runValidator(ethContext, daoForkPeerValidator);
+    private MainnetPantheonController(
+            final ProtocolSchedule<Void> protocolSchedule,
+            final ProtocolContext<Void> protocolContext,
+            final GenesisConfigOptions genesisConfigOptions,
+            final ProtocolManager ethProtocolManager,
+            final Synchronizer synchronizer,
+            final KeyPair keyPair,
+            final TransactionPool transactionPool,
+            final MiningCoordinator miningCoordinator,
+            final PrivacyParameters privacyParameters,
+            final Runnable close) {
+        this.protocolSchedule = protocolSchedule;
+        this.protocolContext = protocolContext;
+        this.genesisConfigOptions = genesisConfigOptions;
+        this.ethProtocolManager = ethProtocolManager;
+        this.synchronizer = synchronizer;
+        this.keyPair = keyPair;
+        this.transactionPool = transactionPool;
+        this.miningCoordinator = miningCoordinator;
+        this.privacyParameters = privacyParameters;
+        this.close = close;
     }
 
-    final TransactionPool transactionPool =
-        TransactionPoolFactory.createTransactionPool(
-            protocolSchedule,
-            protocolContext,
-            ethProtocolManager.ethContext(),
-            clock,
-            maxPendingTransactions,
-            metricsSystem);
+    public static PantheonController<Void> init(
+            final StorageProvider storageProvider,
+            final GenesisConfigFile genesisConfig,
+            final ProtocolSchedule<Void> protocolSchedule,
+            final SynchronizerConfiguration syncConfig,
+            final MiningParameters miningParams,
+            final int networkId,
+            final KeyPair nodeKeys,
+            final PrivacyParameters privacyParameters,
+            final Path dataDirectory,
+            final MetricsSystem metricsSystem,
+            final Clock clock,
+            final int maxPendingTransactions) {
 
-    final ExecutorService minerThreadPool = Executors.newCachedThreadPool();
-    final EthHashMinerExecutor executor =
-        new EthHashMinerExecutor(
-            protocolContext,
-            minerThreadPool,
-            protocolSchedule,
-            transactionPool.getPendingTransactions(),
-            miningParams,
-            new DefaultBlockScheduler(
-                MainnetBlockHeaderValidator.MINIMUM_SECONDS_SINCE_PARENT,
-                MainnetBlockHeaderValidator.TIMESTAMP_TOLERANCE_S,
-                clock));
+        final GenesisState genesisState = GenesisState.fromConfig(genesisConfig, protocolSchedule);
+        final ProtocolContext<Void> protocolContext =
+                ProtocolContext.init(
+                        storageProvider, genesisState, protocolSchedule, metricsSystem, (a, b) -> null);
+        final MutableBlockchain blockchain = protocolContext.getBlockchain();
 
-    final EthHashMiningCoordinator miningCoordinator =
-        new EthHashMiningCoordinator(blockchain, executor, syncState);
-    miningCoordinator.addMinedBlockObserver(ethProtocolManager);
-    if (miningParams.isMiningEnabled()) {
-      miningCoordinator.enable();
+        final boolean fastSyncEnabled = syncConfig.syncMode().equals(SyncMode.FAST);
+        final EthProtocolManager ethProtocolManager =
+                new EthProtocolManager(
+                        blockchain,
+                        protocolContext.getWorldStateArchive(),
+                        networkId,
+                        fastSyncEnabled,
+                        syncConfig.downloaderParallelism(),
+                        syncConfig.transactionsParallelism(),
+                        syncConfig.computationParallelism(),
+                        metricsSystem);
+        final SyncState syncState =
+                new SyncState(blockchain, ethProtocolManager.ethContext().getEthPeers());
+        final Synchronizer synchronizer =
+                new DefaultSynchronizer<>(
+                        syncConfig,
+                        protocolSchedule,
+                        protocolContext,
+                        protocolContext.getWorldStateArchive().getStorage(),
+                        ethProtocolManager.ethContext(),
+                        syncState,
+                        dataDirectory,
+                        clock,
+                        metricsSystem);
+
+        final OptionalLong daoBlock = genesisConfig.getConfigOptions().getDaoForkBlock();
+        if (daoBlock.isPresent()) {
+            // Setup dao validator
+            final EthContext ethContext = ethProtocolManager.ethContext();
+            final DaoForkPeerValidator daoForkPeerValidator =
+                    new DaoForkPeerValidator(
+                            ethContext, protocolSchedule, metricsSystem, daoBlock.getAsLong());
+            PeerValidatorRunner.runValidator(ethContext, daoForkPeerValidator);
+        }
+
+        final TransactionPool transactionPool =
+                TransactionPoolFactory.createTransactionPool(
+                        protocolSchedule,
+                        protocolContext,
+                        ethProtocolManager.ethContext(),
+                        clock,
+                        maxPendingTransactions,
+                        metricsSystem,
+                        synchronizer);
+
+        final ExecutorService minerThreadPool = Executors.newCachedThreadPool();
+        final EthHashMinerExecutor executor =
+                new EthHashMinerExecutor(
+                        protocolContext,
+                        minerThreadPool,
+                        protocolSchedule,
+                        transactionPool.getPendingTransactions(),
+                        miningParams,
+                        new DefaultBlockScheduler(
+                                MainnetBlockHeaderValidator.MINIMUM_SECONDS_SINCE_PARENT,
+                                MainnetBlockHeaderValidator.TIMESTAMP_TOLERANCE_S,
+                                clock));
+
+        final EthHashMiningCoordinator miningCoordinator =
+                new EthHashMiningCoordinator(blockchain, executor, syncState);
+        miningCoordinator.addMinedBlockObserver(ethProtocolManager);
+        if (miningParams.isMiningEnabled()) {
+            miningCoordinator.enable();
+        }
+
+        return new MainnetPantheonController(
+                protocolSchedule,
+                protocolContext,
+                genesisConfig.getConfigOptions(),
+                ethProtocolManager,
+                synchronizer,
+                nodeKeys,
+                transactionPool,
+                miningCoordinator,
+                privacyParameters,
+                () -> {
+                    miningCoordinator.disable();
+                    minerThreadPool.shutdownNow();
+                    try {
+                        minerThreadPool.awaitTermination(5, TimeUnit.SECONDS);
+                    } catch (final InterruptedException e) {
+                        LOG.error("Failed to shutdown miner executor");
+                    }
+                    try {
+                        storageProvider.close();
+                        if (privacyParameters.getPrivateStorageProvider() != null) {
+                            privacyParameters.getPrivateStorageProvider().close();
+                        }
+                    } catch (final IOException e) {
+                        LOG.error("Failed to close storage provider", e);
+                    }
+                });
     }
 
-    return new MainnetPantheonController(
-        protocolSchedule,
-        protocolContext,
-        genesisConfig.getConfigOptions(),
-        ethProtocolManager,
-        synchronizer,
-        nodeKeys,
-        transactionPool,
-        miningCoordinator,
-        privacyParameters,
-        () -> {
-          miningCoordinator.disable();
-          minerThreadPool.shutdownNow();
-          try {
-            minerThreadPool.awaitTermination(5, TimeUnit.SECONDS);
-          } catch (final InterruptedException e) {
-            LOG.error("Failed to shutdown miner executor");
-          }
-          try {
-            storageProvider.close();
-            if (privacyParameters.getPrivateStorageProvider() != null) {
-              privacyParameters.getPrivateStorageProvider().close();
-            }
-          } catch (final IOException e) {
-            LOG.error("Failed to close storage provider", e);
-          }
-        });
-  }
+    @Override
+    public ProtocolContext<Void> getProtocolContext() {
+        return protocolContext;
+    }
 
-  @Override
-  public ProtocolContext<Void> getProtocolContext() {
-    return protocolContext;
-  }
+    @Override
+    public ProtocolSchedule<Void> getProtocolSchedule() {
+        return protocolSchedule;
+    }
 
-  @Override
-  public ProtocolSchedule<Void> getProtocolSchedule() {
-    return protocolSchedule;
-  }
+    @Override
+    public GenesisConfigOptions getGenesisConfigOptions() {
+        return genesisConfigOptions;
+    }
 
-  @Override
-  public GenesisConfigOptions getGenesisConfigOptions() {
-    return genesisConfigOptions;
-  }
+    @Override
+    public Synchronizer getSynchronizer() {
+        return synchronizer;
+    }
 
-  @Override
-  public Synchronizer getSynchronizer() {
-    return synchronizer;
-  }
+    @Override
+    public SubProtocolConfiguration subProtocolConfiguration() {
+        return new SubProtocolConfiguration().withSubProtocol(EthProtocol.get(), ethProtocolManager);
+    }
 
-  @Override
-  public SubProtocolConfiguration subProtocolConfiguration() {
-    return new SubProtocolConfiguration().withSubProtocol(EthProtocol.get(), ethProtocolManager);
-  }
+    @Override
+    public KeyPair getLocalNodeKeyPair() {
+        return keyPair;
+    }
 
-  @Override
-  public KeyPair getLocalNodeKeyPair() {
-    return keyPair;
-  }
+    @Override
+    public TransactionPool getTransactionPool() {
+        return transactionPool;
+    }
 
-  @Override
-  public TransactionPool getTransactionPool() {
-    return transactionPool;
-  }
+    @Override
+    public MiningCoordinator getMiningCoordinator() {
+        return miningCoordinator;
+    }
 
-  @Override
-  public MiningCoordinator getMiningCoordinator() {
-    return miningCoordinator;
-  }
+    @Override
+    public void close() {
+        close.run();
+    }
 
-  @Override
-  public void close() {
-    close.run();
-  }
-
-  @Override
-  public PrivacyParameters getPrivacyParameters() {
-    return privacyParameters;
-  }
+    @Override
+    public PrivacyParameters getPrivacyParameters() {
+        return privacyParameters;
+    }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Pantheon skips validation and storage of transactions from the network until 100 blocks from head (when SyncState.isInSync returns true)

Pantheon continues to track which peers have seen specific transactions while syncing (to avoid resending transactions they've seen and being disconnected once we are in sync)