### PR TITLE
Make contract size limit configurable.

### DIFF
--- a/config/src/main/java/tech/pegasys/pantheon/config/GenesisConfigOptions.java
+++ b/config/src/main/java/tech/pegasys/pantheon/config/GenesisConfigOptions.java
@@ -50,5 +50,7 @@ public interface GenesisConfigOptions {
 
   OptionalInt getChainId();
 
+  OptionalInt getContractSizeLimit();
+
   Map<String, Object> asMap();
 }

--- a/config/src/main/java/tech/pegasys/pantheon/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/tech/pegasys/pantheon/config/JsonGenesisConfigOptions.java
@@ -126,6 +126,13 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
   }
 
   @Override
+  public OptionalInt getContractSizeLimit() {
+    return configRoot.containsKey("contractsizelimit")
+        ? OptionalInt.of(configRoot.getInteger("contractsizelimit"))
+        : OptionalInt.empty();
+  }
+
+  @Override
   public Map<String, Object> asMap() {
     final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
     builder.put("chainId", getChainId().getAsInt());
@@ -153,6 +160,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     getByzantiumBlockNumber().ifPresent(l -> builder.put("byzantiumBlock", l));
     getConstantinopleBlockNumber().ifPresent(l -> builder.put("constantinopleBlock", l));
     getConstantinopleFixBlockNumber().ifPresent(l -> builder.put("constantinopleFixBlock", l));
+    getContractSizeLimit().ifPresent(l -> builder.put("contractSizeLimit", l));
     if (isClique()) {
       builder.put("clique", getCliqueConfigOptions().asMap());
     }

--- a/config/src/main/resources/dev.json
+++ b/config/src/main/resources/dev.json
@@ -9,6 +9,7 @@
     "byzantiumBlock": 0,
     "constantinopleBlock": 0,
     "constantinopleFixBlock": 0,
+    "contractSizeLimit": 2147483647,
     "ethash": {
       "fixeddifficulty": 100
     }
@@ -16,7 +17,7 @@
   "nonce": "0x42",
   "timestamp": "0x0",
   "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
-  "gasLimit": "0x1000000",
+  "gasLimit": "0x1fffffffffffff",
   "difficulty": "0x10000",
   "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "coinbase": "0x0000000000000000000000000000000000000000",

--- a/config/src/test-support/java/tech/pegasys/pantheon/config/StubGenesisConfigOptions.java
+++ b/config/src/test-support/java/tech/pegasys/pantheon/config/StubGenesisConfigOptions.java
@@ -28,6 +28,7 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions {
   private OptionalLong constantinopleBlockNumber = OptionalLong.empty();
   private OptionalLong constantinopleFixBlockNumber = OptionalLong.empty();
   private OptionalInt chainId = OptionalInt.empty();
+  private OptionalInt contractSizeLimit = OptionalInt.empty();
 
   @Override
   public boolean isEthHash() {
@@ -105,6 +106,11 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions {
   }
 
   @Override
+  public OptionalInt getContractSizeLimit() {
+    return contractSizeLimit;
+  }
+
+  @Override
   public OptionalInt getChainId() {
     return chainId;
   }
@@ -130,6 +136,7 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions {
     getByzantiumBlockNumber().ifPresent(l -> builder.put("byzantiumBlock", l));
     getConstantinopleBlockNumber().ifPresent(l -> builder.put("constantinopleBlock", l));
     getConstantinopleFixBlockNumber().ifPresent(l -> builder.put("constantinopleFixBlock", l));
+    getContractSizeLimit().ifPresent(l -> builder.put("contractSizeLimit", l));
     if (isClique()) {
       builder.put("clique", getCliqueConfigOptions().asMap());
     }
@@ -182,6 +189,11 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions {
 
   public StubGenesisConfigOptions chainId(final int chainId) {
     this.chainId = OptionalInt.of(chainId);
+    return this;
+  }
+
+  public StubGenesisConfigOptions contractSizeLimit(final int contractSizeLimit) {
+    this.contractSizeLimit = OptionalInt.of(contractSizeLimit);
     return this;
   }
 }

--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -60,8 +60,9 @@ public abstract class MainnetProtocolSpecs {
 
   private MainnetProtocolSpecs() {}
 
-  public static ProtocolSpecBuilder<Void> frontierDefinition(final OptionalInt contractSizeLimit) {
-    int frontierContractSizeLimit = contractSizeLimit.orElse(FRONTIER_CONTRACT_SIZE_LIMIT);
+  public static ProtocolSpecBuilder<Void> frontierDefinition(
+      final OptionalInt configContractSizeLimit) {
+    int contractSizeLimit = configContractSizeLimit.orElse(FRONTIER_CONTRACT_SIZE_LIMIT);
     return new ProtocolSpecBuilder<Void>()
         .gasCalculator(FrontierGasCalculator::new)
         .evmBuilder(MainnetEvmRegistries::frontier)
@@ -70,7 +71,7 @@ public abstract class MainnetProtocolSpecs {
         .contractCreationProcessorBuilder(
             (gasCalculator, evm) ->
                 new MainnetContractCreationProcessor(
-                    gasCalculator, evm, false, frontierContractSizeLimit, 0))
+                    gasCalculator, evm, false, contractSizeLimit, 0))
         .transactionValidatorBuilder(
             gasCalculator -> new MainnetTransactionValidator(gasCalculator, false))
         .transactionProcessorBuilder(
@@ -110,15 +111,16 @@ public abstract class MainnetProtocolSpecs {
         .name("Frontier");
   }
 
-  public static ProtocolSpecBuilder<Void> homesteadDefinition(final OptionalInt contractSizeLimit) {
-    int frontierContractSizeLimit = contractSizeLimit.orElse(FRONTIER_CONTRACT_SIZE_LIMIT);
-    return frontierDefinition(contractSizeLimit)
+  public static ProtocolSpecBuilder<Void> homesteadDefinition(
+      final OptionalInt configContractSizeLimit) {
+    int contractSizeLimit = configContractSizeLimit.orElse(FRONTIER_CONTRACT_SIZE_LIMIT);
+    return frontierDefinition(configContractSizeLimit)
         .gasCalculator(HomesteadGasCalculator::new)
         .evmBuilder(MainnetEvmRegistries::homestead)
         .contractCreationProcessorBuilder(
             (gasCalculator, evm) ->
                 new MainnetContractCreationProcessor(
-                    gasCalculator, evm, true, frontierContractSizeLimit, 0))
+                    gasCalculator, evm, true, contractSizeLimit, 0))
         .transactionValidatorBuilder(
             gasCalculator -> new MainnetTransactionValidator(gasCalculator, true))
         .difficultyCalculator(MainnetDifficultyCalculators.HOMESTEAD)
@@ -158,9 +160,9 @@ public abstract class MainnetProtocolSpecs {
   }
 
   public static ProtocolSpecBuilder<Void> spuriousDragonDefinition(
-      final int chainId, final OptionalInt contractSizeLimit) {
-    final int spuriousDragonContractSizeLimit =
-        contractSizeLimit.orElse(SPURIOUS_DRAGON_CONTRACT_SIZE_LIMIT);
+      final int chainId, final OptionalInt configContractSizeLimit) {
+    final int contractSizeLimit =
+        configContractSizeLimit.orElse(SPURIOUS_DRAGON_CONTRACT_SIZE_LIMIT);
     return tangerineWhistleDefinition(OptionalInt.empty())
         .gasCalculator(SpuriousDragonGasCalculator::new)
         .messageCallProcessorBuilder(
@@ -175,7 +177,7 @@ public abstract class MainnetProtocolSpecs {
                     gasCalculator,
                     evm,
                     true,
-                    spuriousDragonContractSizeLimit,
+                    contractSizeLimit,
                     1,
                     SPURIOUS_DRAGON_FORCE_DELETE_WHEN_EMPTY_ADDRESSES))
         .transactionValidatorBuilder(

--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/mainnet/ProtocolScheduleBuilder.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/mainnet/ProtocolScheduleBuilder.java
@@ -46,11 +46,13 @@ public class ProtocolScheduleBuilder<C> {
     validateForkOrdering();
 
     addProtocolSpec(
-        protocolSchedule, OptionalLong.of(0), MainnetProtocolSpecs.frontierDefinition());
+        protocolSchedule,
+        OptionalLong.of(0),
+        MainnetProtocolSpecs.frontierDefinition(config.getContractSizeLimit()));
     addProtocolSpec(
         protocolSchedule,
         config.getHomesteadBlockNumber(),
-        MainnetProtocolSpecs.homesteadDefinition());
+        MainnetProtocolSpecs.homesteadDefinition(config.getContractSizeLimit()));
 
     config
         .getDaoForkBlock()
@@ -61,11 +63,12 @@ public class ProtocolScheduleBuilder<C> {
               addProtocolSpec(
                   protocolSchedule,
                   OptionalLong.of(daoBlockNumber),
-                  MainnetProtocolSpecs.daoRecoveryInitDefinition());
+                  MainnetProtocolSpecs.daoRecoveryInitDefinition(config.getContractSizeLimit()));
               addProtocolSpec(
                   protocolSchedule,
                   OptionalLong.of(daoBlockNumber + 1),
-                  MainnetProtocolSpecs.daoRecoveryTransitionDefinition());
+                  MainnetProtocolSpecs.daoRecoveryTransitionDefinition(
+                      config.getContractSizeLimit()));
 
               // Return to the previous protocol spec after the dao fork has completed.
               protocolSchedule.putMilestone(daoBlockNumber + 10, originalProtocolSpec);
@@ -74,23 +77,23 @@ public class ProtocolScheduleBuilder<C> {
     addProtocolSpec(
         protocolSchedule,
         config.getTangerineWhistleBlockNumber(),
-        MainnetProtocolSpecs.tangerineWhistleDefinition());
+        MainnetProtocolSpecs.tangerineWhistleDefinition(config.getContractSizeLimit()));
     addProtocolSpec(
         protocolSchedule,
         config.getSpuriousDragonBlockNumber(),
-        MainnetProtocolSpecs.spuriousDragonDefinition(chainId));
+        MainnetProtocolSpecs.spuriousDragonDefinition(chainId, config.getContractSizeLimit()));
     addProtocolSpec(
         protocolSchedule,
         config.getByzantiumBlockNumber(),
-        MainnetProtocolSpecs.byzantiumDefinition(chainId));
+        MainnetProtocolSpecs.byzantiumDefinition(chainId, config.getContractSizeLimit()));
     addProtocolSpec(
         protocolSchedule,
         config.getConstantinopleBlockNumber(),
-        MainnetProtocolSpecs.constantinopleDefinition(chainId));
+        MainnetProtocolSpecs.constantinopleDefinition(chainId, config.getContractSizeLimit()));
     addProtocolSpec(
         protocolSchedule,
         config.getConstantinopleFixBlockNumber(),
-        MainnetProtocolSpecs.constantinopleFixDefinition(chainId));
+        MainnetProtocolSpecs.constantinopleFixDefinition(chainId, config.getContractSizeLimit()));
 
     LOG.info("Protocol schedule created with milestones: {}", protocolSchedule.listMilestones());
     return protocolSchedule;

--- a/ethereum/core/src/test/java/tech/pegasys/pantheon/ethereum/vm/VMReferenceTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/pantheon/ethereum/vm/VMReferenceTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.pantheon.testutil.JsonTestParameters;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.OptionalInt;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -116,7 +117,7 @@ public class VMReferenceTest extends AbstractRetryingTest {
     final EnvironmentInformation execEnv = spec.getExec();
 
     final ProtocolSpec<Void> protocolSpec =
-        MainnetProtocolSpecs.frontierDefinition()
+        MainnetProtocolSpecs.frontierDefinition(OptionalInt.empty())
             .privacyParameters(PrivacyParameters.noPrivacy())
             .build(new MutableProtocolSchedule<>(CHAIN_ID));
 


### PR DESCRIPTION
Make the contract size limit configurable in the genesis config, making it possible to override milestone based configurations in a private network.

