### PR TITLE
[PAN-1339] Send local transactions to new peers

### DIFF
--- a/ethereum/core/src/test/java/tech/pegasys/pantheon/ethereum/core/TransactionPoolTest.java
+++ b/ethereum/core/src/test/java/tech/pegasys/pantheon/ethereum/core/TransactionPoolTest.java
@@ -451,4 +451,18 @@ public class TransactionPoolTest {
             eq(transaction), nullable(Account.class), anyBoolean()))
         .thenReturn(valid());
   }
+
+  @Test
+  public void shouldSendLocalTransactionsToNewPeers() {
+    transactionPool.setAccountFilter(accountFilter);
+    givenTransactionIsValid(transaction1);
+
+    when(accountFilter.permitted(transaction1.getSender().toString())).thenReturn(false);
+
+    assertThat(transactionPool.addLocalTransaction(transaction1))
+            .isEqualTo(ValidationResult.invalid(TX_SENDER_NOT_AUTHORIZED));
+
+    assertTransactionNotPending(transaction1);
+    verifyZeroInteractions(batchAddedListener);
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description

* When a new peer connects, local transactions are sent to it

* Remote transactions are not sent to newly connected peers

* Event loop threads are not blocked while sending transactions

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
