### PR TITLE
[MINOR / PAN-1339 (A)] Fetch local transactions in isolation

### DIFF
--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/PendingTransactions.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/PendingTransactions.java
@@ -92,6 +92,18 @@ public class PendingTransactions {
             "operation");
   }
 
+  List<Transaction> getLocalTransactions() {
+    synchronized (pendingTransactions) {
+      List<Transaction> localTransactions = new ArrayList<>();
+      for (Map.Entry<Hash, TransactionInfo> transaction : pendingTransactions.entrySet()) {
+        if (transaction.getValue().isReceivedFromLocalSource()) {
+          localTransactions.add(transaction.getValue().getTransaction());
+        }
+      }
+      return localTransactions;
+    }
+  }
+
   public boolean addRemoteTransaction(final Transaction transaction) {
     final TransactionInfo transactionInfo =
         new TransactionInfo(transaction, false, clock.instant());

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPool.java
@@ -66,6 +66,10 @@ public class TransactionPool implements BlockAddedObserver {
     this.transactionBatchAddedListener = transactionBatchAddedListener;
   }
 
+  public List<Transaction> getLocalTransactions() {
+    return pendingTransactions.getLocalTransactions();
+  }
+
   public ValidationResult<TransactionInvalidReason> addLocalTransaction(
       final Transaction transaction) {
     final ValidationResult<TransactionInvalidReason> validationResult =

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/PendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/PendingTransactionsTest.java
@@ -55,6 +55,22 @@ public class PendingTransactionsTest {
   private static final Address SENDER2 = Util.publicKeyToAddress(KEYS2.getPublicKey());
 
   @Test
+  public void shouldReturnExclusivelyLocalTransactionsWhenAppropriate() {
+    final Transaction localTransaction0 = createTransaction(0);
+    transactions.addLocalTransaction(localTransaction0);
+    assertThat(transactions.size()).isEqualTo(1);
+
+    transactions.addRemoteTransaction(transaction1);
+    assertThat(transactions.size()).isEqualTo(2);
+
+    transactions.addRemoteTransaction(transaction2);
+    assertThat(transactions.size()).isEqualTo(3);
+
+    List<Transaction> localTransactions = transactions.getLocalTransactions();
+    assertThat(localTransactions.size()).isEqualTo(1);
+  }
+
+  @Test
   public void shouldAddATransaction() {
     transactions.addRemoteTransaction(transaction1);
     assertThat(transactions.size()).isEqualTo(1);

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPoolTest.java
@@ -104,6 +104,22 @@ public class TransactionPoolTest {
   }
 
   @Test
+  public void shouldReturnExclusivelyLocalTransactionsWhenAppropriate() {
+    final Transaction localTransaction0 = createTransaction(0);
+    transactions.addLocalTransaction(localTransaction0);
+    assertThat(transactions.size()).isEqualTo(1);
+
+    transactions.addRemoteTransaction(transaction1);
+    assertThat(transactions.size()).isEqualTo(2);
+
+    transactions.addRemoteTransaction(transaction2);
+    assertThat(transactions.size()).isEqualTo(3);
+
+    List<Transaction> localTransactions = transactions.getLocalTransactions();
+    assertThat(localTransactions.size()).isEqualTo(1);
+  }
+
+  @Test
   public void shouldRemoveTransactionsFromPendingListWhenIncludedInBlockOnChain() {
     transactions.addRemoteTransaction(transaction1);
     assertTransactionPending(transaction1);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description

In an effort to make the change set inevitably necessitated by the acceptance criteria of `PAN-1339` less onerous, and consequently the review more palatable, I've decided to serialize it into constituent elements -- each of which constituting a relatively discrete semantic chunk.  

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

In order to disseminate local transactions to new peers we'll require a mechanism to fetch local transactions in isolation -- this is that mechanism (_along with associated test infrastructure_).
