### PR TITLE
PIE-1505 - Build broken in Java 12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,11 @@ allprojects {
       // Lazy impl causes excess CPU usage O(n) of non-final fiield when it should be O(1).
       check('FieldCanBeFinal', CheckSeverity.OFF)
 
+      // This check is broken in Java 12.  See https://github.com/google/error-prone/issues/1257
+      if ((JavaVersion.current().majorVersion as Integer) > 11) {
+        check('Finally', CheckSeverity.OFF)
+      }
+
       check('InsecureCryptoUsage', CheckSeverity.WARN)
       check('WildcardImport', CheckSeverity.WARN)
     }


### PR DESCRIPTION
## PR description

There is one check that has issues in Java 12 and has yet to be fixed.
Disable it when we detect we are being built on Java 12.

## Fixed Issue(s)

PIE-1505