### PR TITLE
Allow use of / in branch name when using the branch from tag release job

### DIFF
--- a/branch-from-tag.sh
+++ b/branch-from-tag.sh
@@ -45,7 +45,7 @@ branch_version="${major_version}.${minor_version}.${branch_bugfix_version}-SNAPS
 sed -i "s/${tag_version}/${branch_version}/g" gradle.properties
 
 # Update the Jenkins job default branch name
-sed -i "s/defaultValue: 'master'/defaultValue: '${branch_name}'/g" Jenkinsfile.release
+sed -i "s#defaultValue: 'master'#defaultValue: '${branch_name}'#g" Jenkinsfile.release
 
 git commit -am"[Release Script] Updating version to ${branch_version}"
 git push --set-upstream origin ${branch_name}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
I found this issue when testing the "Release: Branch from Tag" for EthSigner (formerly EthFirewall).

This allows the release from branch release job have a / in the branch name being used e.g. release/1.1

Due the use of / as separators in the regular expression to update the job name in the Jenkins.release currently it fails with error "number option to `s' command may not be zero" when using a branch name with a / in it. I've just changed the separator to be # instead of /.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
