### PR TITLE
Keep enode nodeId stored as a BytesValue

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
@@ -102,7 +102,7 @@ public interface PeerConnection {
   }
 
   default boolean isRemoteEnode(final EnodeURL remoteEnodeUrl) {
-    return ((remoteEnodeUrl.getNodeId().equals(this.getPeer().getAddress().toString()))
+    return ((remoteEnodeUrl.getNodeId().equals(this.getPeer().getAddress()))
         && (remoteEnodeUrl.getListeningPort() == this.getPeer().getPort())
         && (remoteEnodeUrl
             .getInetAddress()

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/DefaultPeer.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/DefaultPeer.java
@@ -52,7 +52,7 @@ public class DefaultPeer extends DefaultPeerId implements Peer {
             udpPort,
             OptionalInt.of(enodeURL.getListeningPort()));
 
-    return new DefaultPeer(BytesValue.fromHexString(enodeURL.getNodeId()), endpoint);
+    return new DefaultPeer(enodeURL.getNodeId(), endpoint);
   }
 
   /**

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/StaticNodesParserTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/StaticNodesParserTest.java
@@ -67,7 +67,7 @@ public class StaticNodesParserTest {
     final File validFile = new File(resource.getFile());
     final Set<EnodeURL> enodes = StaticNodesParser.fromPath(validFile.toPath());
 
-    assertThat(enodes).containsExactly(validFileItems.toArray(new EnodeURL[validFileItems.size()]));
+    assertThat(enodes).containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURL[validFileItems.size()]));
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/StaticNodesParserTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/StaticNodesParserTest.java
@@ -67,7 +67,8 @@ public class StaticNodesParserTest {
     final File validFile = new File(resource.getFile());
     final Set<EnodeURL> enodes = StaticNodesParser.fromPath(validFile.toPath());
 
-    assertThat(enodes).containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURL[validFileItems.size()]));
+    assertThat(enodes)
+        .containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURL[validFileItems.size()]));
   }
 
   @Test

--- a/ethereum/permissioning/src/main/java/tech/pegasys/pantheon/ethereum/permissioning/SmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/tech/pegasys/pantheon/ethereum/permissioning/SmartContractPermissioningController.java
@@ -125,9 +125,7 @@ public class SmartContractPermissioningController implements NodePermissioningPr
 
   private static BytesValue encodeEnodeUrl(final EnodeURL enode) {
     return BytesValues.concatenate(
-        enode.getNodeId(),
-        encodeIp(enode.getInetAddress()),
-        encodePort(enode.getListeningPort()));
+        enode.getNodeId(), encodeIp(enode.getInetAddress()), encodePort(enode.getListeningPort()));
   }
 
   // As a function parameter an ip needs to be the appropriate number of bytes, big endian, and

--- a/ethereum/permissioning/src/main/java/tech/pegasys/pantheon/ethereum/permissioning/SmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/tech/pegasys/pantheon/ethereum/permissioning/SmartContractPermissioningController.java
@@ -125,7 +125,7 @@ public class SmartContractPermissioningController implements NodePermissioningPr
 
   private static BytesValue encodeEnodeUrl(final EnodeURL enode) {
     return BytesValues.concatenate(
-        encodeEnodeId(enode.getNodeId()),
+        enode.getNodeId(),
         encodeIp(enode.getInetAddress()),
         encodePort(enode.getListeningPort()));
   }
@@ -155,11 +155,5 @@ public class SmartContractPermissioningController implements NodePermissioningPr
     res[31] = (byte) ((port) & 0xFF);
     res[30] = (byte) ((port >> 8) & 0xFF);
     return BytesValue.wrap(res);
-  }
-
-  // The enode high and low need to be 32 bytes each. They then get concatenated as they are
-  // adjacent parameters
-  private static BytesValue encodeEnodeId(final String id) {
-    return BytesValue.fromHexString(id);
   }
 }

--- a/util/src/main/java/tech/pegasys/pantheon/util/enode/EnodeURL.java
+++ b/util/src/main/java/tech/pegasys/pantheon/util/enode/EnodeURL.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.base.Objects;
 import com.google.common.net.InetAddresses;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class EnodeURL {
 
@@ -38,7 +39,7 @@ public class EnodeURL {
           + "(?<listening>\\d+)"
           + "(\\?discport=(?<discovery>\\d+))?$";
 
-  private final String nodeId;
+  private final BytesValue nodeId;
   private final InetAddress ip;
   private final Integer listeningPort;
   // DiscoveryPort will only be present if it differs from listening port, otherwise
@@ -66,11 +67,7 @@ public class EnodeURL {
       final InetAddress address,
       final Integer listeningPort,
       final OptionalInt discoveryPort) {
-    if (nodeId.startsWith("0x")) {
-      this.nodeId = nodeId.substring(2);
-    } else {
-      this.nodeId = nodeId;
-    }
+    this.nodeId = BytesValue.fromHexString(nodeId);
     this.ip = address;
     this.listeningPort = listeningPort;
     // Only explicitly define a discovery port if it differs from the listening port
@@ -99,7 +96,7 @@ public class EnodeURL {
 
   public URI toURI() {
     final String uri =
-        String.format("enode://%s@%s:%d", nodeId, InetAddresses.toUriString(ip), listeningPort);
+        String.format("enode://%s@%s:%d", nodeId.toUnprefixedString(), InetAddresses.toUriString(ip), listeningPort);
     if (discoveryPort.isPresent()) {
       return URI.create(uri + String.format("?discport=%d", discoveryPort.getAsInt()));
     } else {
@@ -152,7 +149,7 @@ public class EnodeURL {
     }
   }
 
-  public String getNodeId() {
+  public BytesValue getNodeId() {
     return nodeId;
   }
 

--- a/util/src/main/java/tech/pegasys/pantheon/util/enode/EnodeURL.java
+++ b/util/src/main/java/tech/pegasys/pantheon/util/enode/EnodeURL.java
@@ -15,6 +15,7 @@ package tech.pegasys.pantheon.util.enode;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import tech.pegasys.pantheon.util.NetworkUtility;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.net.InetAddress;
 import java.net.URI;
@@ -24,7 +25,6 @@ import java.util.regex.Pattern;
 
 import com.google.common.base.Objects;
 import com.google.common.net.InetAddresses;
-import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class EnodeURL {
 
@@ -96,7 +96,9 @@ public class EnodeURL {
 
   public URI toURI() {
     final String uri =
-        String.format("enode://%s@%s:%d", nodeId.toUnprefixedString(), InetAddresses.toUriString(ip), listeningPort);
+        String.format(
+            "enode://%s@%s:%d",
+            nodeId.toUnprefixedString(), InetAddresses.toUriString(ip), listeningPort);
     if (discoveryPort.isPresent()) {
       return URI.create(uri + String.format("?discport=%d", discoveryPort.getAsInt()));
     } else {


### PR DESCRIPTION
## PR description
Keep `EnodeURL.nodeId` as a `BytesValue`.  Keeping all node ids consistently stored as `BytesValues` makes comparisons simpler and minimizes the need for type conversions.  For example, `Peer.getId()` and `EnodeURL.getNodeId()` can be more easily compared.
