### PR TITLE
Add Labelled Gauges to Metrics System

### DIFF
--- a/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/MetricsSystem.java
+++ b/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/MetricsSystem.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.pantheon.metrics;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -50,6 +51,27 @@ public interface MetricsSystem {
       final String help,
       final Supplier<Long> valueSupplier) {
     createGauge(category, name, help, () -> (double) valueSupplier.get());
+  }
+
+  LabelledMetric<Consumer<Supplier<Double>>> createLabelledGauge(
+      MetricCategory category, String name, String help, String... labelNames);
+
+  default LabelledMetric<Consumer<Supplier<Integer>>> createLabelledIntegerGauge(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labelNames) {
+    return (labels) ->
+        (value) -> createLabelledGauge(category, name, help, labelNames).labels(labels);
+  }
+
+  default LabelledMetric<Consumer<Supplier<Long>>> createLabelledLongGauge(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labelNames) {
+    return (labels) ->
+        (value) -> createLabelledGauge(category, name, help, labelNames).labels(labels);
   }
 
   Stream<Observation> getMetrics(MetricCategory category);

--- a/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/noop/NoOpMetricsSystem.java
+++ b/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/noop/NoOpMetricsSystem.java
@@ -20,6 +20,7 @@ import tech.pegasys.pantheon.metrics.Observation;
 import tech.pegasys.pantheon.metrics.OperationTimer;
 import tech.pegasys.pantheon.metrics.OperationTimer.TimingContext;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -86,6 +87,19 @@ public class NoOpMetricsSystem implements MetricsSystem {
       final String name,
       final String help,
       final Supplier<Double> valueSupplier) {}
+
+  @Override
+  public LabelledMetric<Consumer<Supplier<Double>>> createLabelledGauge(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labelNames) {
+    return getLabelledGauge(labelNames.length);
+  }
+
+  public static LabelledMetric<Consumer<Supplier<Double>>> getLabelledGauge(final int labelCount) {
+    return new LabelCountingNoOpMetric<>(labelCount, gauge -> {});
+  }
 
   @Override
   public Stream<Observation> getMetrics(final MetricCategory category) {

--- a/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/prometheus/CurrentValueCollector.java
+++ b/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/prometheus/CurrentValueCollector.java
@@ -27,7 +27,7 @@ class CurrentValueCollector extends Collector {
   private final String help;
   private final Supplier<Double> valueSupplier;
 
-  public CurrentValueCollector(
+  CurrentValueCollector(
       final String metricName, final String help, final Supplier<Double> valueSupplier) {
     this.metricName = metricName;
     this.help = help;

--- a/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/prometheus/LabelledCurrentValueCollector.java
+++ b/metrics/core/src/main/java/tech/pegasys/pantheon/metrics/prometheus/LabelledCurrentValueCollector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.metrics.prometheus;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Collections.singletonList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+
+class LabelledCurrentValueCollector extends Collector {
+
+  private final String metricName;
+  private final String help;
+  private final List<String> labelNames;
+  private final Map<List<String>, Supplier<Double>> labeledGauges;
+
+  LabelledCurrentValueCollector(
+      final String metricName, final String help, final List<String> labelNames) {
+    this.metricName = metricName;
+    this.help = help;
+    this.labelNames = labelNames;
+    labeledGauges = new HashMap<>();
+  }
+
+  void addGauge(final List<String> labels, final Supplier<Double> gauge) {
+    checkArgument(
+        labels.size() == labelNames.size(), "Count of Label names and provided labels must match");
+    labeledGauges.put(labels, gauge);
+  }
+
+  @Override
+  public List<MetricFamilySamples> collect() {
+    return singletonList(
+        new MetricFamilySamples(
+            metricName,
+            Type.GAUGE,
+            help,
+            labeledGauges.entrySet().stream()
+                .map(
+                    entry ->
+                        new Sample(metricName, labelNames, entry.getKey(), entry.getValue().get()))
+                .collect(Collectors.toList())));
+  }
+}


### PR DESCRIPTION
## PR description

For rocks DB we need to use gauges to track native stats.  We are also
moving to use multiple databases for the privacy work.  To keep metrics
separate we need to label the databases on the gauges.

This PR adds labeling to the gauges.  Because gauges do not leave
counters or timers behind this approach returns a consumer that
consumes the lambda that represents the metric.

