### PR TITLE
[PAN-2560] Cleanup PeerConnection interface

### DIFF
--- a/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/StubbedPeerConnection.java
+++ b/consensus/ibft/src/integration-test/java/tech/pegasys/pantheon/consensus/ibft/support/StubbedPeerConnection.java
@@ -25,7 +25,7 @@ public class StubbedPeerConnection {
   public static PeerConnection create(final BytesValue nodeId) {
     PeerConnection peerConnection = mock(PeerConnection.class);
     PeerInfo peerInfo = new PeerInfo(0, "IbftIntTestPeer", emptyList(), 0, nodeId);
-    when(peerConnection.getPeer()).thenReturn(peerInfo);
+    when(peerConnection.getPeerInfo()).thenReturn(peerInfo);
     return peerConnection;
   }
 }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftGossip.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/IbftGossip.java
@@ -69,7 +69,7 @@ public class IbftGossip implements Gossiper {
     }
     final List<Address> excludeAddressesList =
         Lists.newArrayList(
-            message.getConnection().getPeer().getAddress(), decodedMessage.getAuthor());
+            message.getConnection().getPeerInfo().getAddress(), decodedMessage.getAuthor());
 
     multicaster.send(messageData, excludeAddressesList);
   }

--- a/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/ValidatorPeers.java
+++ b/consensus/ibft/src/main/java/tech/pegasys/pantheon/consensus/ibft/network/ValidatorPeers.java
@@ -46,13 +46,13 @@ public class ValidatorPeers implements ValidatorMulticaster, PeerConnectionTrack
 
   @Override
   public void add(final PeerConnection newConnection) {
-    final Address peerAddress = newConnection.getPeer().getAddress();
+    final Address peerAddress = newConnection.getPeerInfo().getAddress();
     peerConnections.put(peerAddress, newConnection);
   }
 
   @Override
   public void remove(final PeerConnection removedConnection) {
-    final Address peerAddress = removedConnection.getPeer().getAddress();
+    final Address peerAddress = removedConnection.getPeerInfo().getAddress();
     peerConnections.remove(peerAddress);
   }
 
@@ -85,7 +85,7 @@ public class ValidatorPeers implements ValidatorMulticaster, PeerConnectionTrack
                 LOG.trace(
                     "Lost connection to a validator. remoteAddress={} peerInfo={}",
                     connection.getRemoteAddress(),
-                    connection.getPeer());
+                    connection.getPeerInfo());
               }
             });
   }

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/network/MockPeerFactory.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/network/MockPeerFactory.java
@@ -24,7 +24,7 @@ public class MockPeerFactory {
   public static PeerConnection create(final Address address) {
     final PeerConnection peerConnection = mock(PeerConnection.class);
     final PeerInfo peerInfo = createPeerInfo(address);
-    when(peerConnection.getPeer()).thenReturn(peerInfo);
+    when(peerConnection.getPeerInfo()).thenReturn(peerInfo);
     return peerConnection;
   }
 

--- a/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/network/ValidatorPeersTest.java
+++ b/consensus/ibft/src/test/java/tech/pegasys/pantheon/consensus/ibft/network/ValidatorPeersTest.java
@@ -57,7 +57,7 @@ public class ValidatorPeersTest {
 
       final PeerInfo peerInfo = mock(PeerInfo.class);
       final PeerConnection peerConnection = mock(PeerConnection.class);
-      when(peerConnection.getPeer()).thenReturn(peerInfo);
+      when(peerConnection.getPeerInfo()).thenReturn(peerInfo);
       when(peerInfo.getAddress()).thenReturn(address);
 
       peerConnections.add(peerConnection);

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/manager/EthPeer.java
@@ -329,7 +329,7 @@ public class EthPeer {
   }
 
   public BytesValue nodeId() {
-    return connection.getPeer().getNodeId();
+    return connection.getPeerInfo().getNodeId();
   }
 
   @Override

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
@@ -19,7 +19,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.PeerInfo;
 import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.DisconnectReason;
 import tech.pegasys.pantheon.util.bytes.Bytes32;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -80,12 +80,12 @@ public class MockPeerConnection implements PeerConnection {
   }
 
   @Override
-  public SocketAddress getLocalAddress() {
+  public InetSocketAddress getLocalAddress() {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public SocketAddress getRemoteAddress() {
+  public InetSocketAddress getRemoteAddress() {
     throw new UnsupportedOperationException();
   }
 

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/manager/MockPeerConnection.java
@@ -65,7 +65,7 @@ public class MockPeerConnection implements PeerConnection {
   }
 
   @Override
-  public PeerInfo getPeer() {
+  public PeerInfo getPeerInfo() {
     return new PeerInfo(5, "Mock", new ArrayList<>(caps), 0, nodeId);
   }
 

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNodeList.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNodeList.java
@@ -73,7 +73,8 @@ public class TestNodeList implements Closeable {
         final TestNode destination = nodes.get(j);
         try {
           LOG.info("Attempting to connect source " + source.shortId() + " to dest " + destination);
-          assertThat(source.connect(destination).get(30L, TimeUnit.SECONDS).getPeer().getNodeId())
+          assertThat(
+                  source.connect(destination).get(30L, TimeUnit.SECONDS).getPeerInfo().getNodeId())
               .isEqualTo(destination.id());
           // Wait for the destination node to finish bonding.
           Awaitility.await()
@@ -118,7 +119,7 @@ public class TestNodeList implements Closeable {
 
   private boolean hasConnection(final TestNode node1, final TestNode node2) {
     for (final PeerConnection peer : node1.network.getPeers()) {
-      if (node2.id().equals(peer.getPeer().getNodeId())) {
+      if (node2.id().equals(peer.getPeerInfo().getNodeId())) {
         return true;
       }
     }
@@ -221,7 +222,7 @@ public class TestNodeList implements Closeable {
       for (final Map.Entry<PeerConnection, DisconnectReason> entry :
           node.disconnections.entrySet()) {
         final PeerConnection peer = entry.getKey();
-        final String peerString = peer.getPeer().getNodeId() + "@" + peer.getRemoteAddress();
+        final String peerString = peer.getPeerInfo().getNodeId() + "@" + peer.getRemoteAddress();
         final String unsentTxMsg =
             "Node "
                 + node.shortId()
@@ -245,7 +246,7 @@ public class TestNodeList implements Closeable {
       for (final PeerConnection peer : node.network.getPeers()) {
         final String localString = node.shortId() + "@" + peer.getLocalAddress();
         final String peerString =
-            shortId(peer.getPeer().getNodeId()) + "@" + peer.getRemoteAddress();
+            shortId(peer.getPeerInfo().getNodeId()) + "@" + peer.getRemoteAddress();
         connStr.add("Connection: " + localString + " to " + peerString);
       }
     }

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/results/PeerResult.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/results/PeerResult.java
@@ -34,16 +34,16 @@ public class PeerResult {
   private final String id;
 
   public PeerResult(final PeerConnection peer) {
-    this.version = Quantity.create(peer.getPeer().getVersion());
-    this.name = peer.getPeer().getClientId();
+    this.version = Quantity.create(peer.getPeerInfo().getVersion());
+    this.name = peer.getPeerInfo().getClientId();
     this.caps =
-        peer.getPeer().getCapabilities().stream()
+        peer.getPeerInfo().getCapabilities().stream()
             .map(Capability::toString)
             .map(TextNode::new)
             .collect(Collectors.toList());
     this.network = new NetworkResult(peer.getLocalAddress(), peer.getRemoteAddress());
-    this.port = Quantity.create(peer.getPeer().getPort());
-    this.id = peer.getPeer().getNodeId().toString();
+    this.port = Quantity.create(peer.getPeerInfo().getPort());
+    this.id = peer.getPeerInfo().getNodeId().toString();
   }
 
   @JsonGetter(value = "version")

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/AdminJsonRpcHttpServiceTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/AdminJsonRpcHttpServiceTest.java
@@ -97,7 +97,7 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTest {
       final BytesValue jsonNodeId = BytesValue.fromHexString(peerJson.getString("id"));
 
       final PeerInfo jsonPeer = new PeerInfo(jsonVersion, jsonClient, caps, jsonPort, jsonNodeId);
-      assertThat(peerConn.getPeer()).isEqualTo(jsonPeer);
+      assertThat(peerConn.getPeerInfo()).isEqualTo(jsonPeer);
     }
   }
 

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/MockPeerConnection.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/MockPeerConnection.java
@@ -30,7 +30,7 @@ public class MockPeerConnection {
       final InetSocketAddress localAddress,
       final InetSocketAddress remoteAddress) {
     PeerConnection peerConnection = mock(PeerConnection.class);
-    when(peerConnection.getPeer()).thenReturn(peerInfo);
+    when(peerConnection.getPeerInfo()).thenReturn(peerInfo);
     when(peerConnection.getLocalAddress()).thenReturn(localAddress);
     when(peerConnection.getRemoteAddress()).thenReturn(remoteAddress);
 

--- a/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
@@ -26,7 +26,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.DisconnectMessage.Discon
 import tech.pegasys.pantheon.util.Subscribers;
 import tech.pegasys.pantheon.util.enode.EnodeURL;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -287,12 +287,12 @@ public final class MockNetwork {
     }
 
     @Override
-    public SocketAddress getLocalAddress() {
+    public InetSocketAddress getLocalAddress() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public SocketAddress getRemoteAddress() {
+    public InetSocketAddress getRemoteAddress() {
       throw new UnsupportedOperationException();
     }
   }

--- a/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetwork.java
@@ -260,7 +260,7 @@ public final class MockNetwork {
     }
 
     @Override
-    public PeerInfo getPeer() {
+    public PeerInfo getPeerInfo() {
       return new PeerInfo(
           5,
           "mock-network-client",

--- a/ethereum/mock-p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetworkTest.java
+++ b/ethereum/mock-p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/testing/MockNetworkTest.java
@@ -46,9 +46,9 @@ public final class MockNetworkTest {
       final CompletableFuture<Message> messageFuture = new CompletableFuture<>();
       network1.subscribe(cap, messageFuture::complete);
       final Predicate<PeerConnection> isPeerOne =
-          peerConnection -> peerConnection.getPeer().getNodeId().equals(one.getId());
+          peerConnection -> peerConnection.getPeerInfo().getNodeId().equals(one.getId());
       final Predicate<PeerConnection> isPeerTwo =
-          peerConnection -> peerConnection.getPeer().getNodeId().equals(two.getId());
+          peerConnection -> peerConnection.getPeerInfo().getNodeId().equals(two.getId());
       Assertions.assertThat(network1.getPeers().stream().filter(isPeerTwo).findFirst())
           .isNotPresent();
       Assertions.assertThat(network2.getPeers().stream().filter(isPeerOne).findFirst())
@@ -60,8 +60,8 @@ public final class MockNetworkTest {
       final CompletableFuture<PeerConnection> peer1Future = new CompletableFuture<>();
       network2.subscribeConnect(peer1Future::complete);
       network1.connect(two).get();
-      Assertions.assertThat(peer1Future.get().getPeer().getNodeId()).isEqualTo(one.getId());
-      Assertions.assertThat(peer2Future.get().getPeer().getNodeId()).isEqualTo(two.getId());
+      Assertions.assertThat(peer1Future.get().getPeerInfo().getNodeId()).isEqualTo(one.getId());
+      Assertions.assertThat(peer2Future.get().getPeerInfo().getNodeId()).isEqualTo(two.getId());
       Assertions.assertThat(network1.getPeers().stream().filter(isPeerTwo).findFirst()).isPresent();
       final Optional<PeerConnection> optionalConnection =
           network2.getPeers().stream().filter(isPeerOne).findFirst();
@@ -78,7 +78,7 @@ public final class MockNetworkTest {
       final MessageData receivedMessageData = receivedMessage.getData();
       Assertions.assertThat(receivedMessageData.getData().compareTo(BytesValue.wrap(data)))
           .isEqualTo(0);
-      Assertions.assertThat(receivedMessage.getConnection().getPeer().getNodeId())
+      Assertions.assertThat(receivedMessage.getConnection().getPeerInfo().getNodeId())
           .isEqualTo(two.getId());
       Assertions.assertThat(receivedMessageData.getSize()).isEqualTo(size);
       Assertions.assertThat(receivedMessageData.getCode()).isEqualTo(code);

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/InsufficientPeersPermissioningProvider.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/InsufficientPeersPermissioningProvider.java
@@ -53,7 +53,8 @@ public class InsufficientPeersPermissioningProvider implements ContextualNodePer
   }
 
   private boolean isNotABootnode(final PeerConnection peerConnection) {
-    return bootnodeEnodes.stream().noneMatch(peerConnection::isRemoteEnode);
+    return bootnodeEnodes.stream()
+        .noneMatch((bootNode) -> peerConnection.getRemoteEnode().sameEndpoint(bootNode));
   }
 
   private long countP2PNetworkNonBootnodeConnections() {

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
@@ -90,9 +90,9 @@ public interface PeerConnection {
   /** @return True if the peer is disconnected */
   boolean isDisconnected();
 
-  SocketAddress getLocalAddress();
+  InetSocketAddress getLocalAddress();
 
-  SocketAddress getRemoteAddress();
+  InetSocketAddress getRemoteAddress();
 
   class PeerNotConnected extends IOException {
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
@@ -19,7 +19,6 @@ import tech.pegasys.pantheon.util.enode.EnodeURL;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Set;
 
 /** A P2P connection to another node. */
@@ -101,11 +100,11 @@ public interface PeerConnection {
     }
   }
 
-  default boolean isRemoteEnode(final EnodeURL remoteEnodeUrl) {
-    return ((remoteEnodeUrl.getNodeId().equals(this.getPeer().getAddress()))
-        && (remoteEnodeUrl.getListeningPort() == this.getPeer().getPort())
-        && (remoteEnodeUrl
-            .getInetAddress()
-            .equals(((InetSocketAddress) this.getRemoteAddress()).getAddress())));
+  default EnodeURL getRemoteEnode() {
+    return EnodeURL.builder()
+        .nodeId(getPeer().getNodeId())
+        .listeningPort(getPeer().getPort())
+        .ipAddress(getRemoteAddress().getAddress())
+        .build();
   }
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/api/PeerConnection.java
@@ -69,7 +69,7 @@ public interface PeerConnection {
    *
    * @return Peer Description
    */
-  PeerInfo getPeer();
+  PeerInfo getPeerInfo();
 
   /**
    * Immediately terminate the connection without sending a disconnect message.
@@ -102,8 +102,8 @@ public interface PeerConnection {
 
   default EnodeURL getRemoteEnode() {
     return EnodeURL.builder()
-        .nodeId(getPeer().getNodeId())
-        .listeningPort(getPeer().getPort())
+        .nodeId(getPeerInfo().getNodeId())
+        .listeningPort(getPeerInfo().getPort())
         .ipAddress(getRemoteAddress().getAddress())
         .build();
   }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -314,7 +314,7 @@ public abstract class PeerDiscoveryAgent implements DisconnectCallback {
       final PeerConnection connection,
       final DisconnectMessage.DisconnectReason reason,
       final boolean initiatedByPeer) {
-    final BytesValue nodeId = connection.getPeer().getNodeId();
+    final BytesValue nodeId = connection.getPeerInfo().getNodeId();
     peerTable.tryEvict(new DefaultPeerId(nodeId));
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/ApiHandler.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/ApiHandler.java
@@ -80,15 +80,15 @@ final class ApiHandler extends SimpleChannelInboundHandler<MessageData> {
             LOG.debug(
                 "Received Wire DISCONNECT ({}) from peer: {}",
                 reason.name(),
-                connection.getPeer().getClientId());
+                connection.getPeerInfo().getClientId());
           } catch (final RLPException e) {
             LOG.debug(
                 "Received Wire DISCONNECT with invalid RLP. Peer: {}",
-                connection.getPeer().getClientId());
+                connection.getPeerInfo().getClientId());
           } catch (final Exception e) {
             LOG.error(
                 "Received Wire DISCONNECT, but unable to parse reason. Peer: {}",
-                connection.getPeer().getClientId(),
+                connection.getPeerInfo().getClientId(),
                 e);
           }
           connection.terminateConnection(reason, true);

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
@@ -365,7 +365,7 @@ public class NettyP2PNetwork implements P2PNetwork {
                 LOG.debug(
                     "Disconnecting incoming connection because connection limit of {} has been reached: {}",
                     maxPeers,
-                    connection.getPeer().getNodeId());
+                    connection.getPeerInfo().getNodeId());
                 connection.disconnect(DisconnectReason.TOO_MANY_PEERS);
                 return;
               }
@@ -377,7 +377,7 @@ public class NettyP2PNetwork implements P2PNetwork {
 
               onConnectionEstablished(connection);
               LOG.debug(
-                  "Successfully accepted connection from {}", connection.getPeer().getNodeId());
+                  "Successfully accepted connection from {}", connection.getPeerInfo().getNodeId());
               logConnections();
             });
       }
@@ -591,7 +591,7 @@ public class NettyP2PNetwork implements P2PNetwork {
     return event -> {
       final Peer peer = event.getPeer();
       getPeers().stream()
-          .filter(p -> p.getPeer().getNodeId().equals(peer.getId()))
+          .filter(p -> p.getPeerInfo().getNodeId().equals(peer.getId()))
           .findFirst()
           .ifPresent(p -> p.disconnect(DisconnectReason.REQUESTED));
     };
@@ -626,7 +626,8 @@ public class NettyP2PNetwork implements P2PNetwork {
     }
 
     LOG.trace(
-        "Checking if connection with peer {} is permitted", peerConnection.getPeer().getNodeId());
+        "Checking if connection with peer {} is permitted",
+        peerConnection.getPeerInfo().getNodeId());
 
     return nodePermissioningController
         .map(
@@ -634,7 +635,8 @@ public class NettyP2PNetwork implements P2PNetwork {
               final EnodeURL localPeerEnodeURL =
                   peerInfoToEnodeURL(ourPeerInfo, peerConnection.getLocalAddress());
               final EnodeURL remotePeerEnodeURL =
-                  peerInfoToEnodeURL(peerConnection.getPeer(), peerConnection.getRemoteAddress());
+                  peerInfoToEnodeURL(
+                      peerConnection.getPeerInfo(), peerConnection.getRemoteAddress());
               return c.isPermitted(localPeerEnodeURL, remotePeerEnodeURL);
             })
         .orElse(true);

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetwork.java
@@ -632,12 +632,9 @@ public class NettyP2PNetwork implements P2PNetwork {
         .map(
             c -> {
               final EnodeURL localPeerEnodeURL =
-                  peerInfoToEnodeURL(
-                      ourPeerInfo, (InetSocketAddress) peerConnection.getLocalAddress());
+                  peerInfoToEnodeURL(ourPeerInfo, peerConnection.getLocalAddress());
               final EnodeURL remotePeerEnodeURL =
-                  peerInfoToEnodeURL(
-                      peerConnection.getPeer(),
-                      (InetSocketAddress) peerConnection.getRemoteAddress());
+                  peerInfoToEnodeURL(peerConnection.getPeer(), peerConnection.getRemoteAddress());
               return c.isPermitted(localPeerEnodeURL, remotePeerEnodeURL);
             })
         .orElse(true);

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
@@ -26,7 +26,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.messages.WireMessageCodes;
 import tech.pegasys.pantheon.metrics.Counter;
 import tech.pegasys.pantheon.metrics.LabelledMetric;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -156,13 +156,13 @@ final class NettyPeerConnection implements PeerConnection {
   }
 
   @Override
-  public SocketAddress getLocalAddress() {
-    return ctx.channel().localAddress();
+  public InetSocketAddress getLocalAddress() {
+    return (InetSocketAddress) ctx.channel().localAddress();
   }
 
   @Override
-  public SocketAddress getRemoteAddress() {
-    return ctx.channel().remoteAddress();
+  public InetSocketAddress getRemoteAddress() {
+    return (InetSocketAddress) ctx.channel().remoteAddress();
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyPeerConnection.java
@@ -108,7 +108,7 @@ final class NettyPeerConnection implements PeerConnection {
   }
 
   @Override
-  public PeerInfo getPeer() {
+  public PeerInfo getPeerInfo() {
     return peerInfo;
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistry.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistry.java
@@ -54,7 +54,7 @@ public class PeerConnectionRegistry implements DisconnectCallback {
   }
 
   public void registerConnection(final PeerConnection connection) {
-    connections.put(connection.getPeer().getNodeId(), connection);
+    connections.put(connection.getPeerInfo().getNodeId(), connection);
     connectedPeersCounter.inc();
   }
 
@@ -79,7 +79,7 @@ public class PeerConnectionRegistry implements DisconnectCallback {
       final PeerConnection connection,
       final DisconnectReason reason,
       final boolean initiatedByPeer) {
-    connections.remove(connection.getPeer().getNodeId());
+    connections.remove(connection.getPeerInfo().getNodeId());
     disconnectCounter.labels(initiatedByPeer ? "remote" : "local", reason.name()).inc();
   }
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklist.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklist.java
@@ -84,7 +84,7 @@ public class PeerBlacklist implements DisconnectCallback {
   }
 
   public boolean contains(final PeerConnection peer) {
-    return contains(peer.getPeer().getNodeId());
+    return contains(peer.getPeerInfo().getNodeId());
   }
 
   public boolean contains(final Peer peer) {
@@ -105,7 +105,7 @@ public class PeerBlacklist implements DisconnectCallback {
       final DisconnectReason reason,
       final boolean initiatedByPeer) {
     if (shouldBlacklistForDisconnect(reason, initiatedByPeer)) {
-      add(connection.getPeer().getNodeId());
+      add(connection.getPeerInfo().getNodeId());
     }
   }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/InsufficientPeersPermissioningProviderTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/InsufficientPeersPermissioningProviderTest.java
@@ -13,9 +13,6 @@
 package tech.pegasys.pantheon.ethereum.p2p;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.AdditionalMatchers.not;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -71,7 +68,7 @@ public class InsufficientPeersPermissioningProviderTest {
   @Test
   public void noResultWhenOtherConnections() {
     final PeerConnection neverMatchPeerConnection = mock(PeerConnection.class);
-    when(neverMatchPeerConnection.isRemoteEnode(any())).thenReturn(false);
+    when(neverMatchPeerConnection.getRemoteEnode()).thenReturn(ENODE_5);
     when(p2pNetwork.getPeers()).thenReturn(Collections.singletonList(neverMatchPeerConnection));
 
     final Collection<EnodeURL> bootnodes = Collections.singletonList(ENODE_2);
@@ -101,7 +98,7 @@ public class InsufficientPeersPermissioningProviderTest {
     final Collection<EnodeURL> bootnodes = Collections.singletonList(ENODE_2);
 
     final PeerConnection bootnodeMatchPeerConnection = mock(PeerConnection.class);
-    when(bootnodeMatchPeerConnection.isRemoteEnode(ENODE_2)).thenReturn(true);
+    when(bootnodeMatchPeerConnection.getRemoteEnode()).thenReturn(ENODE_2);
     when(p2pNetwork.getPeers()).thenReturn(Collections.singletonList(bootnodeMatchPeerConnection));
 
     final InsufficientPeersPermissioningProvider provider =
@@ -113,8 +110,7 @@ public class InsufficientPeersPermissioningProviderTest {
 
   private PeerConnection peerConnectionMatching(final EnodeURL enode) {
     final PeerConnection pc = mock(PeerConnection.class);
-    when(pc.isRemoteEnode(enode)).thenReturn(true);
-    when(pc.isRemoteEnode(not(eq(enode)))).thenReturn(false);
+    when(pc.getRemoteEnode()).thenReturn(enode);
     return pc;
   }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -296,7 +296,7 @@ public class PeerDiscoveryAgentTest {
   private PeerConnection createAnonymousPeerConnection(final BytesValue id) {
     PeerConnection conn = mock(PeerConnection.class);
     PeerInfo peerInfo = new PeerInfo(0, null, null, 0, id);
-    when(conn.getPeer()).thenReturn(peerInfo);
+    when(conn.getPeerInfo()).thenReturn(peerInfo);
     return conn;
   }
 }

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/DeFramerTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/DeFramerTest.java
@@ -156,7 +156,7 @@ public class DeFramerTest {
     assertThat(connectFuture).isDone();
     assertThat(connectFuture).isNotCompletedExceptionally();
     PeerConnection peerConnection = connectFuture.get();
-    assertThat(peerConnection.getPeer()).isEqualTo(remotePeerInfo);
+    assertThat(peerConnection.getPeerInfo()).isEqualTo(remotePeerInfo);
     assertThat(out).isEmpty();
 
     // Next phase of pipeline should be setup

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/NettyP2PNetworkTest.java
@@ -156,7 +156,7 @@ public final class NettyP2PNetworkTest {
                               listenPort,
                               OptionalInt.of(listenPort))))
                   .get(30L, TimeUnit.SECONDS)
-                  .getPeer()
+                  .getPeerInfo()
                   .getNodeId())
           .isEqualTo(listenId);
     }
@@ -209,7 +209,7 @@ public final class NettyP2PNetworkTest {
                               listenPort,
                               OptionalInt.of(listenPort))))
                   .get(30L, TimeUnit.SECONDS)
-                  .getPeer()
+                  .getPeerInfo()
                   .getNodeId())
           .isEqualTo(listenId);
       final CompletableFuture<PeerConnection> secondConnectionFuture =
@@ -290,7 +290,12 @@ public final class NettyP2PNetworkTest {
                   InetAddress.getLoopbackAddress().getHostAddress(),
                   listenPort,
                   OptionalInt.of(listenPort)));
-      assertThat(connector1.connect(listeningPeer).get(30L, TimeUnit.SECONDS).getPeer().getNodeId())
+      assertThat(
+              connector1
+                  .connect(listeningPeer)
+                  .get(30L, TimeUnit.SECONDS)
+                  .getPeerInfo()
+                  .getNodeId())
           .isEqualTo(listenId);
 
       // Setup second connection and check that connection is not accepted
@@ -302,9 +307,15 @@ public final class NettyP2PNetworkTest {
             reasonFuture.complete(reason);
           });
       connector2.start();
-      assertThat(connector2.connect(listeningPeer).get(30L, TimeUnit.SECONDS).getPeer().getNodeId())
+      assertThat(
+              connector2
+                  .connect(listeningPeer)
+                  .get(30L, TimeUnit.SECONDS)
+                  .getPeerInfo()
+                  .getNodeId())
           .isEqualTo(listenId);
-      assertThat(peerFuture.get(30L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(listenId);
+      assertThat(peerFuture.get(30L, TimeUnit.SECONDS).getPeerInfo().getNodeId())
+          .isEqualTo(listenId);
       assertThat(reasonFuture.get(30L, TimeUnit.SECONDS))
           .isEqualByComparingTo(DisconnectReason.TOO_MANY_PEERS);
     }
@@ -437,8 +448,9 @@ public final class NettyP2PNetworkTest {
       final CompletableFuture<PeerConnection> connectFuture = remoteNetwork.connect(localPeer);
 
       // Check connection is made, and then a disconnect is registered at remote
-      assertThat(connectFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
-      assertThat(peerFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
+      assertThat(connectFuture.get(5L, TimeUnit.SECONDS).getPeerInfo().getNodeId())
+          .isEqualTo(localId);
+      assertThat(peerFuture.get(5L, TimeUnit.SECONDS).getPeerInfo().getNodeId()).isEqualTo(localId);
       assertThat(reasonFuture.get(5L, TimeUnit.SECONDS))
           .isEqualByComparingTo(DisconnectReason.UNKNOWN);
     }
@@ -519,8 +531,9 @@ public final class NettyP2PNetworkTest {
       final CompletableFuture<PeerConnection> connectFuture = remoteNetwork.connect(localPeer);
 
       // Check connection is made, and then a disconnect is registered at remote
-      assertThat(connectFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
-      assertThat(peerFuture.get(5L, TimeUnit.SECONDS).getPeer().getNodeId()).isEqualTo(localId);
+      assertThat(connectFuture.get(5L, TimeUnit.SECONDS).getPeerInfo().getNodeId())
+          .isEqualTo(localId);
+      assertThat(peerFuture.get(5L, TimeUnit.SECONDS).getPeerInfo().getNodeId()).isEqualTo(localId);
       assertThat(reasonFuture.get(5L, TimeUnit.SECONDS))
           .isEqualByComparingTo(DisconnectReason.UNKNOWN);
     }
@@ -958,7 +971,7 @@ public final class NettyP2PNetworkTest {
     final PeerInfo peerInfo = mock(PeerInfo.class);
     when(peerInfo.getNodeId()).thenReturn(id);
     final PeerConnection peerConnection = mock(PeerConnection.class);
-    when(peerConnection.getPeer()).thenReturn(peerInfo);
+    when(peerConnection.getPeerInfo()).thenReturn(peerInfo);
     return peerConnection;
   }
 
@@ -972,7 +985,7 @@ public final class NettyP2PNetworkTest {
     doReturn(remotePeer.getEndpoint().getTcpPort().getAsInt()).when(peerInfo).getPort();
 
     final PeerConnection peerConnection = mock(PeerConnection.class);
-    when(peerConnection.getPeer()).thenReturn(peerInfo);
+    when(peerConnection.getPeerInfo()).thenReturn(peerInfo);
 
     Endpoint localEndpoint = localPeer.getEndpoint();
     InetSocketAddress localSocketAddress =

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistryTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/netty/PeerConnectionRegistryTest.java
@@ -38,8 +38,10 @@ public class PeerConnectionRegistryTest {
 
   @Before
   public void setUp() {
-    when(connection1.getPeer()).thenReturn(new PeerInfo(5, "client1", emptyList(), 10, PEER1_ID));
-    when(connection2.getPeer()).thenReturn(new PeerInfo(5, "client2", emptyList(), 10, PEER2_ID));
+    when(connection1.getPeerInfo())
+        .thenReturn(new PeerInfo(5, "client1", emptyList(), 10, PEER1_ID));
+    when(connection2.getPeerInfo())
+        .thenReturn(new PeerInfo(5, "client2", emptyList(), 10, PEER2_ID));
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklistTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerBlacklistTest.java
@@ -199,7 +199,7 @@ public class PeerBlacklistTest {
     final PeerInfo peerInfo = mock(PeerInfo.class);
 
     when(peerInfo.getNodeId()).thenReturn(nodeId);
-    when(peer.getPeer()).thenReturn(peerInfo);
+    when(peer.getPeerInfo()).thenReturn(peerInfo);
 
     return peer;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Small cleanup to the PeerConnection interface:
- Keep local / remote addresses as `InetSocketAddress` values
- Add `getEnode` method, remove `isRemoteEnode` since this can be checked directly now
- Rename `getPeer` to `getPeerInfo` 
