### PR TITLE
PAN-2485#Add net_services json rpc endpoint

### DIFF
--- a/ethereum/jsonrpc/src/integration-test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/jsonrpc/src/integration-test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -30,6 +30,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.filter.FilterManager;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.filter.FilterRepository;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.JsonRpcMethod;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockchainQueries;
+import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
 import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
 import tech.pegasys.pantheon.ethereum.mainnet.MainnetProtocolSchedule;
 import tech.pegasys.pantheon.ethereum.mainnet.ProtocolSchedule;
@@ -40,6 +41,7 @@ import tech.pegasys.pantheon.ethereum.permissioning.NodeLocalConfigPermissioning
 import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
 import tech.pegasys.pantheon.metrics.MetricsSystem;
 import tech.pegasys.pantheon.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -88,6 +90,9 @@ public class JsonRpcTestMethodsFactory {
     final Optional<NodeLocalConfigPermissioningController> nodeWhitelistController =
         Optional.of(mock(NodeLocalConfigPermissioningController.class));
     final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
+    final JsonRpcConfiguration jsonRpcConfiguration = mock(JsonRpcConfiguration.class);
+    final WebSocketConfiguration webSocketConfiguration = mock(WebSocketConfiguration.class);
+    final MetricsConfiguration metricsConfiguration = mock(MetricsConfiguration.class);
 
     return new JsonRpcMethodsFactory()
         .methods(
@@ -106,6 +111,9 @@ public class JsonRpcTestMethodsFactory {
             accountWhitelistController,
             nodeWhitelistController,
             RpcApis.DEFAULT_JSON_RPC_APIS,
-            privacyParameters);
+            privacyParameters,
+            jsonRpcConfiguration,
+            webSocketConfiguration,
+            metricsConfiguration);
   }
 }

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
@@ -70,6 +70,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.JsonRpcMethod;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetEnode;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetListening;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetPeerCount;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetServices;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetVersion;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.RpcModules;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.TxPoolPantheonTransactions;
@@ -94,6 +95,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.processor.BlockTracer;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.processor.TransactionTracer;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockchainQueries;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.results.BlockResultFactory;
+import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
 import tech.pegasys.pantheon.ethereum.mainnet.ProtocolSchedule;
 import tech.pegasys.pantheon.ethereum.mainnet.ScheduleBasedBlockHashFunction;
 import tech.pegasys.pantheon.ethereum.p2p.api.P2PNetwork;
@@ -104,6 +106,7 @@ import tech.pegasys.pantheon.ethereum.privacy.PrivateTransactionHandler;
 import tech.pegasys.pantheon.ethereum.transaction.TransactionSimulator;
 import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
 import tech.pegasys.pantheon.metrics.MetricsSystem;
+import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -133,7 +136,10 @@ public class JsonRpcMethodsFactory {
       final FilterManager filterManager,
       final Optional<AccountWhitelistController> accountsWhitelistController,
       final Optional<NodeLocalConfigPermissioningController> nodeWhitelistController,
-      final PrivacyParameters privacyParameters) {
+      final PrivacyParameters privacyParameters,
+      final JsonRpcConfiguration jsonRpcConfiguration,
+      final WebSocketConfiguration webSocketConfiguration,
+      final MetricsConfiguration metricsConfiguration) {
     final BlockchainQueries blockchainQueries =
         new BlockchainQueries(blockchain, worldStateArchive);
     return methods(
@@ -152,7 +158,10 @@ public class JsonRpcMethodsFactory {
         accountsWhitelistController,
         nodeWhitelistController,
         rpcApis,
-        privacyParameters);
+        privacyParameters,
+        jsonRpcConfiguration,
+        webSocketConfiguration,
+        metricsConfiguration);
   }
 
   public Map<String, JsonRpcMethod> methods(
@@ -171,7 +180,10 @@ public class JsonRpcMethodsFactory {
       final Optional<AccountWhitelistController> accountsWhitelistController,
       final Optional<NodeLocalConfigPermissioningController> nodeWhitelistController,
       final Collection<RpcApi> rpcApis,
-      final PrivacyParameters privacyParameters) {
+      final PrivacyParameters privacyParameters,
+      final JsonRpcConfiguration jsonRpcConfiguration,
+      final WebSocketConfiguration webSocketConfiguration,
+      final MetricsConfiguration metricsConfiguration) {
     final Map<String, JsonRpcMethod> enabledMethods = new HashMap<>();
     if (!rpcApis.isEmpty()) {
       addMethods(enabledMethods, new RpcModules(rpcApis));
@@ -256,7 +268,9 @@ public class JsonRpcMethodsFactory {
           new NetVersion(protocolSchedule.getChainId()),
           new NetListening(p2pNetwork),
           new NetPeerCount(p2pNetwork),
-          new NetEnode(p2pNetwork));
+          new NetEnode(p2pNetwork),
+          new NetServices(
+              jsonRpcConfiguration, webSocketConfiguration, p2pNetwork, metricsConfiguration));
     }
     if (rpcApis.contains(RpcApis.WEB3)) {
       addMethods(enabledMethods, new Web3ClientVersion(clientVersion), new Web3Sha3());

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/NetServices.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/NetServices.java
@@ -21,7 +21,6 @@ import tech.pegasys.pantheon.ethereum.p2p.api.P2PNetwork;
 import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 public class NetServices implements JsonRpcMethod {
 
@@ -33,7 +32,8 @@ public class NetServices implements JsonRpcMethod {
       final P2PNetwork p2pNetwork,
       final MetricsConfiguration metricsConfiguration) {
 
-    Builder<String, ImmutableMap<String, String>> servicesMapBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<String, ImmutableMap<String, String>> servicesMapBuilder =
+        ImmutableMap.builder();
 
     if (jsonRpcConfiguration.isEnabled()) {
       servicesMapBuilder.put(

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/NetServices.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/NetServices.java
@@ -20,10 +20,8 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
 import tech.pegasys.pantheon.ethereum.p2p.api.P2PNetwork;
 import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 
 public class NetServices implements JsonRpcMethod {
 
@@ -35,16 +33,15 @@ public class NetServices implements JsonRpcMethod {
       final P2PNetwork p2pNetwork,
       final MetricsConfiguration metricsConfiguration) {
 
-    Map<String, ImmutableMap<String, String>> activeServices =
-        new LinkedHashMap<String, ImmutableMap<String, String>>();
+    Builder<String, ImmutableMap<String, String>> servicesMapBuilder = ImmutableMap.builder();
 
     if (jsonRpcConfiguration.isEnabled()) {
-      activeServices.put(
+      servicesMapBuilder.put(
           "jsonrpc",
           createServiceDetailsMap(jsonRpcConfiguration.getHost(), jsonRpcConfiguration.getPort()));
     }
     if (webSocketConfiguration.isEnabled()) {
-      activeServices.put(
+      servicesMapBuilder.put(
           "ws",
           createServiceDetailsMap(
               webSocketConfiguration.getHost(), webSocketConfiguration.getPort()));
@@ -55,19 +52,18 @@ public class NetServices implements JsonRpcMethod {
             .getLocalEnode()
             .ifPresent(
                 enode -> {
-                  activeServices.put(
+                  servicesMapBuilder.put(
                       "p2p", createServiceDetailsMap(enode.getIp(), enode.getListeningPort()));
                 });
       }
     }
     if (metricsConfiguration.isEnabled()) {
-      activeServices.put(
+      servicesMapBuilder.put(
           "metrics",
           createServiceDetailsMap(metricsConfiguration.getHost(), metricsConfiguration.getPort()));
     }
 
-    services =
-        ImmutableMap.<String, ImmutableMap<String, String>>builder().putAll(activeServices).build();
+    services = servicesMapBuilder.build();
   }
 
   @Override

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/NetServices.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/NetServices.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods;
+
+import tech.pegasys.pantheon.ethereum.jsonrpc.JsonRpcConfiguration;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcResponse;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
+import tech.pegasys.pantheon.ethereum.p2p.api.P2PNetwork;
+import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+public class NetServices implements JsonRpcMethod {
+
+  private final ImmutableMap<String, ImmutableMap<String, String>> services;
+
+  public NetServices(
+      final JsonRpcConfiguration jsonRpcConfiguration,
+      final WebSocketConfiguration webSocketConfiguration,
+      final P2PNetwork p2pNetwork,
+      final MetricsConfiguration metricsConfiguration) {
+
+    Map<String, ImmutableMap<String, String>> activeServices =
+        new LinkedHashMap<String, ImmutableMap<String, String>>();
+
+    if (jsonRpcConfiguration.isEnabled()) {
+      activeServices.put(
+          "jsonrpc",
+          createServiceDetailsMap(jsonRpcConfiguration.getHost(), jsonRpcConfiguration.getPort()));
+    }
+    if (webSocketConfiguration.isEnabled()) {
+      activeServices.put(
+          "ws",
+          createServiceDetailsMap(
+              webSocketConfiguration.getHost(), webSocketConfiguration.getPort()));
+    }
+    if (p2pNetwork.isP2pEnabled()) {
+      if (p2pNetwork.isP2pEnabled()) {
+        p2pNetwork
+            .getLocalEnode()
+            .ifPresent(
+                enode -> {
+                  activeServices.put(
+                      "p2p", createServiceDetailsMap(enode.getIp(), enode.getListeningPort()));
+                });
+      }
+    }
+    if (metricsConfiguration.isEnabled()) {
+      activeServices.put(
+          "metrics",
+          createServiceDetailsMap(metricsConfiguration.getHost(), metricsConfiguration.getPort()));
+    }
+
+    services =
+        ImmutableMap.<String, ImmutableMap<String, String>>builder().putAll(activeServices).build();
+  }
+
+  @Override
+  public String getName() {
+    return "net_services";
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequest req) {
+    return new JsonRpcSuccessResponse(req.getId(), services);
+  }
+
+  private ImmutableMap<String, String> createServiceDetailsMap(final String host, final int port) {
+    return ImmutableMap.of("host", host, "port", String.valueOf(port));
+  }
+}

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/AbstractEthJsonRpcHttpServiceTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/AbstractEthJsonRpcHttpServiceTest.java
@@ -38,6 +38,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.filter.FilterManager;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.filter.FilterRepository;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.JsonRpcMethod;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockchainQueries;
+import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
 import tech.pegasys.pantheon.ethereum.mainnet.HeaderValidationMode;
 import tech.pegasys.pantheon.ethereum.mainnet.MainnetBlockHashFunction;
 import tech.pegasys.pantheon.ethereum.mainnet.MainnetProtocolSchedule;
@@ -49,6 +50,7 @@ import tech.pegasys.pantheon.ethereum.p2p.wire.Capability;
 import tech.pegasys.pantheon.ethereum.util.RawBlockIterator;
 import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
 import tech.pegasys.pantheon.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -170,6 +172,7 @@ public abstract class AbstractEthJsonRpcHttpServiceTest {
     supportedCapabilities.add(EthProtocol.ETH62);
     supportedCapabilities.add(EthProtocol.ETH63);
 
+    final JsonRpcConfiguration config = JsonRpcConfiguration.createDefault();
     final Map<String, JsonRpcMethod> methods =
         new JsonRpcMethodsFactory()
             .methods(
@@ -188,8 +191,11 @@ public abstract class AbstractEthJsonRpcHttpServiceTest {
                 Optional.empty(),
                 Optional.empty(),
                 JSON_RPC_APIS,
-                privacyParameters);
-    final JsonRpcConfiguration config = JsonRpcConfiguration.createDefault();
+                privacyParameters,
+                config,
+                mock(WebSocketConfiguration.class),
+                mock(MetricsConfiguration.class));
+
     config.setPort(0);
     service =
         new JsonRpcHttpService(

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
@@ -25,12 +25,14 @@ import tech.pegasys.pantheon.ethereum.eth.transactions.TransactionPool;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.filter.FilterManager;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.JsonRpcMethod;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockchainQueries;
+import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
 import tech.pegasys.pantheon.ethereum.mainnet.MainnetProtocolSchedule;
 import tech.pegasys.pantheon.ethereum.p2p.api.P2PNetwork;
 import tech.pegasys.pantheon.ethereum.p2p.wire.Capability;
 import tech.pegasys.pantheon.ethereum.permissioning.AccountWhitelistController;
 import tech.pegasys.pantheon.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import tech.pegasys.pantheon.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -102,7 +104,10 @@ public class JsonRpcHttpServiceHostWhitelistTest {
                     Optional.of(mock(AccountWhitelistController.class)),
                     Optional.of(mock(NodeLocalConfigPermissioningController.class)),
                     JSON_RPC_APIS,
-                    mock(PrivacyParameters.class)));
+                    mock(PrivacyParameters.class),
+                    mock(JsonRpcConfiguration.class),
+                    mock(WebSocketConfiguration.class),
+                    mock(MetricsConfiguration.class)));
     service = createJsonRpcHttpService();
     service.start().join();
 

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -31,10 +31,12 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetVersion;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.Web3ClientVersion;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.Web3Sha3;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockchainQueries;
+import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
 import tech.pegasys.pantheon.ethereum.mainnet.MainnetProtocolSchedule;
 import tech.pegasys.pantheon.ethereum.p2p.api.P2PNetwork;
 import tech.pegasys.pantheon.ethereum.p2p.wire.Capability;
 import tech.pegasys.pantheon.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -132,7 +134,10 @@ public class JsonRpcHttpServiceLoginTest {
                     Optional.empty(),
                     Optional.empty(),
                     JSON_RPC_APIS,
-                    mock(PrivacyParameters.class)));
+                    mock(PrivacyParameters.class),
+                    mock(JsonRpcConfiguration.class),
+                    mock(WebSocketConfiguration.class),
+                    mock(MetricsConfiguration.class)));
     service = createJsonRpcHttpService();
     jwtAuth = service.authenticationService.get().getJwtAuthProvider();
     service.start().join();

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcHttpServiceTest.java
@@ -40,12 +40,14 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockWithMetadata
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.BlockchainQueries;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.queries.TransactionWithMetadata;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcError;
+import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
 import tech.pegasys.pantheon.ethereum.mainnet.MainnetProtocolSchedule;
 import tech.pegasys.pantheon.ethereum.p2p.api.P2PNetwork;
 import tech.pegasys.pantheon.ethereum.p2p.wire.Capability;
 import tech.pegasys.pantheon.ethereum.permissioning.AccountWhitelistController;
 import tech.pegasys.pantheon.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import tech.pegasys.pantheon.metrics.noop.NoOpMetricsSystem;
+import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
 import tech.pegasys.pantheon.util.bytes.BytesValues;
 import tech.pegasys.pantheon.util.uint.UInt256;
@@ -130,7 +132,10 @@ public class JsonRpcHttpServiceTest {
                     Optional.of(mock(AccountWhitelistController.class)),
                     Optional.of(mock(NodeLocalConfigPermissioningController.class)),
                     JSON_RPC_APIS,
-                    mock(PrivacyParameters.class)));
+                    mock(PrivacyParameters.class),
+                    mock(JsonRpcConfiguration.class),
+                    mock(WebSocketConfiguration.class),
+                    mock(MetricsConfiguration.class)));
     service = createJsonRpcHttpService();
     service.start().join();
 

--- a/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
@@ -340,7 +340,10 @@ public class RunnerBuilder {
               filterManager,
               accountWhitelistController,
               nodeWhitelistController,
-              privacyParameters);
+              privacyParameters,
+              jsonRpcConfiguration,
+              webSocketConfiguration,
+              metricsConfiguration);
       jsonRpcHttpService =
           Optional.of(
               new JsonRpcHttpService(
@@ -364,7 +367,10 @@ public class RunnerBuilder {
               filterManager,
               accountWhitelistController,
               nodeWhitelistController,
-              privacyParameters);
+              privacyParameters,
+              jsonRpcConfiguration,
+              webSocketConfiguration,
+              metricsConfiguration);
 
       final SubscriptionManager subscriptionManager =
           createSubscriptionManager(vertx, transactionPool);
@@ -439,7 +445,10 @@ public class RunnerBuilder {
       final FilterManager filterManager,
       final Optional<AccountWhitelistController> accountWhitelistController,
       final Optional<NodeLocalConfigPermissioningController> nodeWhitelistController,
-      final PrivacyParameters privacyParameters) {
+      final PrivacyParameters privacyParameters,
+      final JsonRpcConfiguration jsonRpcConfiguration,
+      final WebSocketConfiguration webSocketConfiguration,
+      final MetricsConfiguration metricsConfiguration) {
     final Map<String, JsonRpcMethod> methods =
         new JsonRpcMethodsFactory()
             .methods(
@@ -459,7 +468,10 @@ public class RunnerBuilder {
                 filterManager,
                 accountWhitelistController,
                 nodeWhitelistController,
-                privacyParameters);
+                privacyParameters,
+                jsonRpcConfiguration,
+                webSocketConfiguration,
+                metricsConfiguration);
     methods.putAll(pantheonController.getAdditionalJsonRpcMethods(jsonRpcApis));
     return methods;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Implemented a JSON RPC method "net_services" that takes no input
parameter and returns an object
containing a list of enabled services (jsonrpc, p2p, ws, metrics) with
"host" and "port", as show below;

{
  "id":1,
  "jsonrpc": "2.0",
  "result": {
    "jsonrpc": {"host": "127.0.0.1", "port":3000},
    "p2p":{"host": "127.0.0.1", "port":3000},
    "ws":{"host": "127.0.0.1", "port":3000},
    "metrics":{"host": "127.0.0.1", "port":3000}
  }
}
In case a service is not enabled, that will not be included in the list;

{
  "id":1,
  "jsonrpc": "2.0",
  "result": {}
}


**This PR includes all the changes requested by reviewer in the PR# 1269 (closed uncommitted)
