### PR TITLE
Stop synchronizer prior to stopping the network

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/core/Synchronizer.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/core/Synchronizer.java
@@ -19,6 +19,8 @@ public interface Synchronizer {
 
   void start();
 
+  void stop();
+
   /**
    * @return the status, based on SyncingResult When actively synchronizing blocks, alternatively
    *     empty

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
@@ -44,7 +44,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
   private static final Logger LOG = LogManager.getLogger();
 
   private final SyncState syncState;
-  private final AtomicBoolean started = new AtomicBoolean(false);
+  private final AtomicBoolean running = new AtomicBoolean(false);
   private final Subscribers<SyncStatusListener> syncStatusListeners = new Subscribers<>();
   private final BlockPropagationManager<C> blockPropagationManager;
   private final Optional<FastSyncDownloader<C>> fastSyncDownloader;
@@ -104,7 +104,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
 
   @Override
   public void start() {
-    if (started.compareAndSet(false, true)) {
+    if (running.compareAndSet(false, true)) {
       syncState.addSyncStatusListener(this::syncStatusCallback);
       if (fastSyncDownloader.isPresent()) {
         fastSyncDownloader.get().start().whenComplete(this::handleFastSyncResult);
@@ -116,7 +116,19 @@ public class DefaultSynchronizer<C> implements Synchronizer {
     }
   }
 
+  @Override
+  public void stop() {
+    LOG.info("Stopping synchronizer");
+    if (running.compareAndSet(true, false)) {
+      fullSyncDownloader.stop();
+    }
+  }
+
   private void handleFastSyncResult(final FastSyncState result, final Throwable error) {
+    if (!running.get()) {
+      // We've been shutdown which will have triggered the fast sync future to complete
+      return;
+    }
     final Throwable rootCause = ExceptionUtils.rootCause(error);
     if (rootCause instanceof FastSyncException) {
       LOG.error(
@@ -142,7 +154,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
 
   @Override
   public Optional<SyncStatus> getSyncStatus() {
-    if (!started.get()) {
+    if (!running.get()) {
       return Optional.empty();
     }
     if (syncState.syncStatus().getCurrentBlock() == syncState.syncStatus().getHighestBlock()) {

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
@@ -120,6 +120,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
   public void stop() {
     LOG.info("Stopping synchronizer");
     if (running.compareAndSet(true, false)) {
+      fastSyncDownloader.ifPresent(FastSyncDownloader::stop);
       fullSyncDownloader.stop();
     }
   }

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/PipelineChainDownloader.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/PipelineChainDownloader.java
@@ -113,12 +113,6 @@ public class PipelineChainDownloader<C> implements ChainDownloader {
   private CompletionStage<Void> handleFailedDownload(final Throwable error) {
     pipelineErrorCounter.inc();
     final Throwable rootCause = ExceptionUtils.rootCause(error);
-    if (!cancelled.get() && rootCause instanceof CancellationException) {
-      // Weird but when Pantheon shuts down we get an unexpected CancellationException
-      // when the scheduler shuts down and to prevent the fast sync state from being deleted have
-      // to ensure we stop doing anything, but never complete.
-      return new CompletableFuture<>();
-    }
     if (!cancelled.get()
         && syncTargetManager.shouldContinueDownloading()
         && !(rootCause instanceof CancellationException)) {

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/fullsync/FullSyncDownloader.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/fullsync/FullSyncDownloader.java
@@ -48,6 +48,10 @@ public class FullSyncDownloader<C> {
     chainDownloader.start();
   }
 
+  public void stop() {
+    chainDownloader.cancel();
+  }
+
   public TrailingPeerRequirements calculateTrailingPeerRequirements() {
     return syncState.isInSync()
         ? TrailingPeerRequirements.UNRESTRICTED

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/PipelineChainDownloaderTest.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/sync/PipelineChainDownloaderTest.java
@@ -128,36 +128,6 @@ public class PipelineChainDownloaderTest {
     verify(syncTargetManager, times(2)).findSyncTarget(Optional.empty());
   }
 
-  @Test // Weird but currently required behaviour to shutdown cleanly
-  public void shouldStopWithoutCompletingFutureWhenTargetSelectionUnexpectedCancelled() {
-    final CompletableFuture<SyncTarget> selectTargetFuture = new CompletableFuture<>();
-    when(syncTargetManager.findSyncTarget(Optional.empty())).thenReturn(selectTargetFuture);
-    final CompletableFuture<Void> result = chainDownloader.start();
-
-    verify(syncTargetManager).findSyncTarget(Optional.empty());
-
-    selectTargetFuture.completeExceptionally(new CancellationException("Shutting down"));
-
-    verifyNoMoreInteractions(syncTargetManager);
-    assertThat(result).isNotDone();
-  }
-
-  @Test // Weird but currently required behaviour to shutdown cleanly
-  public void shouldStopWithoutCompletingFutureWhenPipelineUnexpectedlyCancelled() {
-    when(syncTargetManager.findSyncTarget(Optional.empty()))
-        .thenReturn(completedFuture(syncTarget));
-    final CompletableFuture<Void> pipelineFuture = expectPipelineStarted(syncTarget);
-
-    final CompletableFuture<Void> result = chainDownloader.start();
-
-    verify(syncTargetManager).findSyncTarget(Optional.empty());
-
-    pipelineFuture.completeExceptionally(new CancellationException("Shutting down"));
-
-    verifyNoMoreInteractions(syncTargetManager);
-    assertThat(result).isNotDone();
-  }
-
   @Test
   public void shouldBeCompleteWhenSyncTargetSelectionFailsAndSyncTargetManagerShouldNotContinue() {
     final CompletableFuture<SyncTarget> selectTargetFuture = new CompletableFuture<>();

--- a/pantheon/src/main/java/tech/pegasys/pantheon/Runner.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/Runner.java
@@ -95,10 +95,14 @@ public class Runner implements AutoCloseable {
 
   @Override
   public void close() throws Exception {
-    networkRunner.stop();
-    networkRunner.awaitStop();
-
     try {
+      if (networkRunner.getNetwork().isP2pEnabled()) {
+        pantheonController.getSynchronizer().stop();
+      }
+
+      networkRunner.stop();
+      networkRunner.awaitStop();
+
       jsonRpc.ifPresent(service -> waitForServiceToStop("jsonRpc", service.stop()));
       websocketRpc.ifPresent(service -> waitForServiceToStop("websocketRpc", service.stop()));
       metrics.ifPresent(service -> waitForServiceToStop("metrics", service.stop()));


### PR DESCRIPTION
## PR description
Stop the `Synchronizer` before stopping the `P2PNetwork` - otherwise when the network is stopped, all the tasks performed by `Synchronizer` fail causing it to think fast sync failed and switching to full sync.  The chain downloader had to ignore `CancellationException` to work around this but an explicit stop is much clearer.

## Fixed Issue(s)
https://pegasys1.atlassian.net/browse/PAN-2535