### PR TITLE
Ensured that the transaction statistics endpoint is exposed.

### DIFF
--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
@@ -73,6 +73,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetPeerCount;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetServices;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.NetVersion;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.RpcModules;
+import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.TxPoolPantheonStatistics;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.TxPoolPantheonTransactions;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.Web3ClientVersion;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.Web3Sha3;
@@ -286,7 +287,9 @@ public class JsonRpcMethodsFactory {
     }
     if (rpcApis.contains(RpcApis.TX_POOL)) {
       addMethods(
-          enabledMethods, new TxPoolPantheonTransactions(transactionPool.getPendingTransactions()));
+          enabledMethods,
+          new TxPoolPantheonTransactions(transactionPool.getPendingTransactions()),
+          new TxPoolPantheonStatistics(transactionPool.getPendingTransactions()));
     }
     if (rpcApis.contains(RpcApis.PERM)) {
       addMethods(

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/results/PendingTransactionsStatisticsResult.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/results/PendingTransactionsStatisticsResult.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.ethereum.jsonrpc.internal.results;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonGetter;
 
 public class PendingTransactionsStatisticsResult {
 
@@ -27,17 +27,17 @@ public class PendingTransactionsStatisticsResult {
     this.remoteCount = remoteCount;
   }
 
-  @JsonValue
+  @JsonGetter
   public long getMaxSize() {
     return maxSize;
   }
 
-  @JsonValue
+  @JsonGetter
   public long getLocalCount() {
     return localCount;
   }
 
-  @JsonValue
+  @JsonGetter
   public long getRemoteCount() {
     return remoteCount;
   }


### PR DESCRIPTION
The txpool_pantheonStatistics json rpc was not enabled.

This PR adds it to the txpool group and ensures that it is active at appropriate times.