### PR TITLE
[MINOR] Rename rocksdDbConfiguration to rocksDbConfiguration

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
@@ -77,7 +77,7 @@ public class ThreadPantheonNodeRunner implements PantheonNodeRunner {
               .metricsSystem(noOpMetricsSystem)
               .maxPendingTransactions(PendingTransactions.MAX_PENDING_TRANSACTIONS)
               .pendingTransactionRetentionPeriod(PendingTransactions.DEFAULT_TX_RETENTION_HOURS)
-              .rocksdDbConfiguration(
+              .rocksDbConfiguration(
                   new RocksDbConfiguration.Builder().databaseDir(tempDir).build())
               .ethereumWireProtocolConfiguration(EthereumWireProtocolConfiguration.defaultConfig())
               .clock(Clock.systemUTC())

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
@@ -77,8 +77,7 @@ public class ThreadPantheonNodeRunner implements PantheonNodeRunner {
               .metricsSystem(noOpMetricsSystem)
               .maxPendingTransactions(PendingTransactions.MAX_PENDING_TRANSACTIONS)
               .pendingTransactionRetentionPeriod(PendingTransactions.DEFAULT_TX_RETENTION_HOURS)
-              .rocksDbConfiguration(
-                  new RocksDbConfiguration.Builder().databaseDir(tempDir).build())
+              .rocksDbConfiguration(new RocksDbConfiguration.Builder().databaseDir(tempDir).build())
               .ethereumWireProtocolConfiguration(EthereumWireProtocolConfiguration.defaultConfig())
               .clock(Clock.systemUTC())
               .build();

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -704,7 +704,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
           .fromEthNetworkConfig(updateNetworkConfig(getNetwork()))
           .synchronizerConfiguration(buildSyncConfig())
           .ethereumWireProtocolConfiguration(ethereumWireConfigurationBuilder.build())
-          .rocksdDbConfiguration(buildRocksDbConfiguration())
+          .rocksDbConfiguration(buildRocksDbConfiguration())
           .dataDirectory(dataDir())
           .miningParameters(
               new MiningParameters(coinbase, minTransactionGasPrice, extraData, isMiningEnabled))

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/PantheonControllerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/PantheonControllerBuilder.java
@@ -76,11 +76,11 @@ public abstract class PantheonControllerBuilder<C> {
   protected KeyPair nodeKeys;
   private StorageProvider storageProvider;
   private final List<Runnable> shutdownActions = new ArrayList<>();
-  private RocksDbConfiguration rocksdDbConfiguration;
+  private RocksDbConfiguration rocksDbConfiguration;
 
-  public PantheonControllerBuilder<C> rocksdDbConfiguration(
+  public PantheonControllerBuilder<C> rocksDbConfiguration(
       final RocksDbConfiguration rocksDbConfiguration) {
-    this.rocksdDbConfiguration = rocksDbConfiguration;
+    this.rocksDbConfiguration = rocksDbConfiguration;
     return this;
   }
 
@@ -171,15 +171,15 @@ public abstract class PantheonControllerBuilder<C> {
     checkNotNull(maxPendingTransactions, "Missing max pending transactions");
     checkNotNull(nodeKeys, "Missing node keys");
     checkArgument(
-        storageProvider != null || rocksdDbConfiguration != null,
+        storageProvider != null || rocksDbConfiguration != null,
         "Must supply either a storage provider or RocksDB configuration");
     checkArgument(
-        storageProvider == null || rocksdDbConfiguration == null,
+        storageProvider == null || rocksDbConfiguration == null,
         "Must supply either storage provider or RocksDB confguration, but not both");
     privacyParameters.setSigningKeyPair(nodeKeys);
 
-    if (storageProvider == null && rocksdDbConfiguration != null) {
-      storageProvider = RocksDbStorageProvider.create(rocksdDbConfiguration, metricsSystem);
+    if (storageProvider == null && rocksDbConfiguration != null) {
+      storageProvider = RocksDbStorageProvider.create(rocksDbConfiguration, metricsSystem);
     }
 
     prepForBuild();

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
@@ -112,7 +112,7 @@ public abstract class CommandTestAbstract {
     when(mockControllerBuilder.synchronizerConfiguration(any())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.ethereumWireProtocolConfiguration(any()))
         .thenReturn(mockControllerBuilder);
-    when(mockControllerBuilder.rocksdDbConfiguration(any())).thenReturn(mockControllerBuilder);
+    when(mockControllerBuilder.rocksDbConfiguration(any())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.dataDirectory(any())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.miningParameters(any())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.maxPendingTransactions(anyInt())).thenReturn(mockControllerBuilder);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description

Seems like a mistake, we named it as `rocksdDbConfiguration`, but shouldn't it be `rocksDbConfiguration`?

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
