### PR TITLE
[PAN-2652] RefactorPrivacyTests

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/PantheonNode.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/PantheonNode.java
@@ -118,8 +118,8 @@ public class PantheonNode implements NodeConfiguration, RunnableNode, AutoClosea
         path -> {
           try {
             copyResource(path, homeDirectory.resolve("key"));
-          } catch (IOException e) {
-            LOG.error("Could not find key file \"{}\" in resources", path);
+          } catch (Exception e) {
+            LOG.error(String.format("Could not find key file \"%s\" in resources", path), e);
           }
         });
     this.keyPair = KeyPairUtil.loadKeyPair(homeDirectory);

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/privacy/PrivateAcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/privacy/PrivateAcceptanceTestBase.java
@@ -42,12 +42,12 @@ public class PrivateAcceptanceTestBase extends AcceptanceTestBase {
     privateTransactionVerifier = new PrivateTransactionVerifier(eea, transactions);
   }
 
-  protected static OrionTestHarness createEnclave(
+  public static OrionTestHarness createEnclave(
       final String pubKey, final String privKey, final String... othernode) throws Exception {
     return OrionTestHarnessFactory.create(privacy.newFolder().toPath(), pubKey, privKey, othernode);
   }
 
-  protected static PrivacyParameters getPrivacyParameters(final OrionTestHarness testHarness)
+  public static PrivacyParameters getPrivacyParameters(final OrionTestHarness testHarness)
       throws IOException {
     return new PrivacyParameters.Builder()
         .setEnabled(true)

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/web3j/privacy/PrivacyNet.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/web3j/privacy/PrivacyNet.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.tests.web3j.privacy;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static tech.pegasys.pantheon.tests.acceptance.dsl.privacy.PrivateAcceptanceTestBase.getPrivacyParameters;
+
+import tech.pegasys.orion.testutil.OrionTestHarness;
+import tech.pegasys.orion.testutil.OrionTestHarnessFactory;
+import tech.pegasys.pantheon.controller.KeyPairUtil;
+import tech.pegasys.pantheon.crypto.SECP256K1;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.PantheonNode;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.cluster.Cluster;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.factory.PantheonNodeFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.io.Files;
+import net.consensys.cava.bytes.Bytes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.rules.TemporaryFolder;
+
+public class PrivacyNet {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private static final SECP256K1.KeyPair PANTHEON_KEYPAIR_NODE_1 =
+      KeyPairUtil.loadKeyPairFromResource("key");
+  private static final SECP256K1.KeyPair PANTHEON_KEYPAIR_NODE_2 =
+      KeyPairUtil.loadKeyPairFromResource("key1");
+  private static final SECP256K1.KeyPair PANTHEON_KEYPAIR_NODE_3 =
+      KeyPairUtil.loadKeyPairFromResource("key2");
+
+  private static final List<SECP256K1.KeyPair> KNOWN_PANTHEON_KEYPAIRS = new ArrayList<>();
+
+  private TemporaryFolder temporaryFolder;
+  private PantheonNodeFactory pantheonNodeFactory;
+  private Cluster cluster;
+  private List<PrivacyNode> nodes = null;
+
+  static {
+    KNOWN_PANTHEON_KEYPAIRS.add(PANTHEON_KEYPAIR_NODE_1);
+    KNOWN_PANTHEON_KEYPAIRS.add(PANTHEON_KEYPAIR_NODE_2);
+    KNOWN_PANTHEON_KEYPAIRS.add(PANTHEON_KEYPAIR_NODE_3);
+  }
+
+  public PrivacyNet(
+      final TemporaryFolder temporaryFolder,
+      final PantheonNodeFactory pantheonNodeFactory,
+      final Cluster cluster) {
+    this.temporaryFolder = temporaryFolder;
+    this.pantheonNodeFactory = pantheonNodeFactory;
+    this.cluster = cluster;
+  }
+
+  public List<PrivacyNode> getNodes() {
+    return nodes;
+  }
+
+  @SuppressWarnings("unused")
+  public PantheonNode getPantheon(final int i) {
+    // todo verify valid int and nodes()
+    return nodes.get(i).pantheon;
+  }
+
+  /**
+   * Initialize Test config with pre-known values, so that output at all stages remains consistent
+   * across runs.
+   */
+  public void initPreknownConfig1() throws IOException, NoSuchAlgorithmException {
+    nodes = new ArrayList<>();
+    nodes.add(makeNode(0, true, null, true));
+    String otherOrionNodes = nodes.get(0).orion.nodeUrl(); // All nodes use node 0 for discovery
+    nodes.add(makeNode(1, true, otherOrionNodes, true));
+    nodes.add(makeNode(2, false, otherOrionNodes, true));
+  }
+
+  /** Initialize Test config with generated keys and values, simulating a real deployed scenario */
+  @SuppressWarnings("unused")
+  public void initGeneratedConfig() throws IOException, NoSuchAlgorithmException {
+    nodes = new ArrayList<>();
+    nodes.add(makeNode(0, true, null, false));
+    String otherOrionNodes = nodes.get(0).orion.nodeUrl(); // All nodes use node 0 for discovery
+    nodes.add(makeNode(1, true, otherOrionNodes, false));
+    nodes.add(makeNode(2, false, otherOrionNodes, false));
+  }
+
+  protected static OrionTestHarness createEnclave(
+      final TemporaryFolder temporaryFolder,
+      final String pubKeyPath,
+      final String privKeyPath,
+      final boolean useKnownOrionKeys,
+      final String... othernode)
+      throws IOException, NoSuchAlgorithmException {
+    OrionTestHarness orion;
+    Path tmpPath = temporaryFolder.newFolder().toPath();
+    if (useKnownOrionKeys) {
+      orion = OrionTestHarnessFactory.create(tmpPath, pubKeyPath, privKeyPath, othernode);
+    } else {
+      KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+      PublicKey pubKey = keyPair.getPublic();
+      PrivateKey privKey = keyPair.getPrivate();
+
+      LOG.debug("pubkey      : " + pubKey);
+      LOG.debug("pubkey bytes: " + Bytes.wrap(pubKey.getEncoded()).toHexString());
+      LOG.debug("pubkey b64  : " + Base64.getEncoder().encodeToString(pubKey.getEncoded()));
+
+      LOG.debug("privkey      : " + privKey);
+      LOG.debug("privkey bytes: " + Bytes.wrap(privKey.getEncoded()).toHexString());
+      LOG.debug("privkey b64  : " + Base64.getEncoder().encodeToString(privKey.getEncoded()));
+
+      orion =
+          OrionTestHarnessFactory.create(
+              tmpPath,
+              keyPair.getPublic(),
+              pubKeyPath,
+              keyPair.getPrivate(),
+              privKeyPath,
+              othernode);
+    }
+    return orion;
+  }
+
+  public PrivacyNode makeNode(
+      final int i,
+      final boolean isMiningEnabled,
+      final String otherOrionNodes,
+      final boolean useKnownOrionKeys)
+      throws IOException, NoSuchAlgorithmException {
+    String nodeName = String.format("node%d", i);
+    String orionPrivateKeyFileName = String.format("orion_key_%d.key", i);
+    String orionPublicKeyFileName = String.format("orion_key_%d.pub", i);
+    OrionTestHarness orion;
+    if (otherOrionNodes == null) {
+      // Need conditional because createEnclave will choke if passing in null
+      orion =
+          createEnclave(
+              temporaryFolder, orionPublicKeyFileName, orionPrivateKeyFileName, useKnownOrionKeys);
+    } else {
+      orion =
+          createEnclave(
+              temporaryFolder,
+              orionPublicKeyFileName,
+              orionPrivateKeyFileName,
+              useKnownOrionKeys,
+              otherOrionNodes);
+    }
+
+    PantheonNode pantheon;
+    String keyFilePath;
+    // node 0's file is "key",  every other node includes node number, like "key0"
+    if (i == 0) {
+      keyFilePath = "key";
+    } else {
+      keyFilePath = String.format("key%d", i);
+    }
+    if (isMiningEnabled) {
+      pantheon =
+          pantheonNodeFactory.createPrivateTransactionEnabledMinerNode(
+              nodeName, getPrivacyParameters(orion), keyFilePath);
+    } else {
+      pantheon =
+          pantheonNodeFactory.createPrivateTransactionEnabledNode(
+              nodeName, getPrivacyParameters(orion), keyFilePath);
+    }
+    String orionPubKey =
+        Files.asCharSource(orion.getConfig().publicKeys().get(0).toFile(), UTF_8).read().trim();
+
+    return new PrivacyNode(pantheon, orion, KNOWN_PANTHEON_KEYPAIRS.get(i), orionPubKey);
+  }
+
+  public void startPantheonNodes() {
+    // Todo: Verify  init was called
+    if (nodes == null)
+      throw new IllegalStateException(
+          "Cannot start network nodes.  init method was never called to initialize the nodes");
+    List<PantheonNode> pantheonNodes =
+        nodes.stream().map(sc -> sc.pantheon).collect(Collectors.toList());
+    // cluster.start(pantheonNodes);
+    cluster.start(pantheonNodes.get(0), pantheonNodes.get(1), pantheonNodes.get(2));
+  }
+
+  public void stopOrionNodes() {
+    if (nodes == null) return; // Never started
+    for (PrivacyNode node : nodes) {
+      try {
+        node.orion.getOrion().stop();
+      } catch (RuntimeException e) {
+        LOG.error(
+            String.format(
+                "Error stopping Orion node %s.  Logging and continuing to shutdown other nodes.",
+                node.orion.nodeUrl()),
+            e);
+      }
+    }
+  }
+
+  public void stop() {
+    try {
+      cluster.stop();
+    } catch (RuntimeException e) {
+      LOG.error("Error stopping Pantheon nodes.  Logging and continuing.", e);
+    }
+    try {
+      stopOrionNodes();
+    } catch (RuntimeException e) {
+      LOG.error("Error stopping Orion nodes.  Logging and continuing.", e);
+    }
+  }
+
+  /** Verify that each Orion node has connected to every other Orion */
+  public void verifyAllOrionNetworkConnections() {
+    for (int i = 0; i < nodes.size(); i++) {
+      for (int j = i; j < nodes.size(); j++) {
+        nodes.get(i).testOrionConnection(nodes.get(j));
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(String.format("temporaryFolder      = %s\n", temporaryFolder.getRoot()));
+    for (PrivacyNode privacyNode : nodes) {
+      sb.append(String.format("Pantheon Node Name   = %s\n", privacyNode.pantheon.getName()));
+      sb.append(String.format("Pantheon Address     = %s\n", privacyNode.pantheon.getAddress()));
+      sb.append(
+          String.format(
+              "Pantheon Private Key = %s\n", privacyNode.pantheonNodeKeypair.getPrivateKey()));
+      sb.append(
+          String.format(
+              "Pantheon Public  Key = %s\n", privacyNode.pantheonNodeKeypair.getPublicKey()));
+      sb.append(String.format("Orion Pub Key        = %s\n", privacyNode.getOrionPubKeyBytes()));
+      sb.append(
+          String.format(
+              "Orion Pub Key Base64 = %s\n",
+              Base64.getEncoder()
+                  .encodeToString(privacyNode.getOrionPubKeyBytes().extractArray())));
+
+      sb.append(String.format("Pantheon             = %s\n", privacyNode.pantheon));
+      sb.append(String.format("Orion Config         = %s\n", privacyNode.orion.getConfig()));
+      sb.append(String.format("Orion Pub Key        = %s\n", privacyNode.getOrionPubKeyBytes()));
+    }
+    return sb.toString();
+  }
+}

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/web3j/privacy/PrivacyNode.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/web3j/privacy/PrivacyNode.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.tests.web3j.privacy;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static tech.pegasys.pantheon.tests.acceptance.dsl.WaitUtils.waitFor;
+
+import tech.pegasys.orion.testutil.OrionTestHarness;
+import tech.pegasys.pantheon.crypto.SECP256K1;
+import tech.pegasys.pantheon.enclave.Enclave;
+import tech.pegasys.pantheon.enclave.types.SendRequest;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.PantheonNode;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PrivacyNode {
+  private static final Logger LOG = LogManager.getLogger();
+
+  public PantheonNode pantheon;
+  public OrionTestHarness orion;
+  public SECP256K1.KeyPair pantheonNodeKeypair;
+  public String orionPubKey;
+  private Map<String, Long> noncesByPrivacyGroup = new HashMap<>();
+
+  public PrivacyNode(
+      final PantheonNode pantheon,
+      final OrionTestHarness orion,
+      final SECP256K1.KeyPair pantheonNodeKeypair,
+      final String orionPubKey) {
+    this.pantheon = pantheon;
+    this.orion = orion;
+    this.pantheonNodeKeypair = pantheonNodeKeypair;
+    this.orionPubKey = orionPubKey;
+  }
+
+  public BytesValue getOrionPubKeyBytes() {
+    return BytesValue.wrap(orionPubKey.getBytes(UTF_8));
+  }
+
+  public void testOrionConnection(final PrivacyNode otherNode) {
+    LOG.info(
+        String.format(
+            "Testing Orion connectivity between %s (%s) and %s (%s)",
+            pantheon.getName(),
+            orion.nodeUrl(),
+            otherNode.pantheon.getName(),
+            otherNode.orion.nodeUrl()));
+    Enclave orionEnclave = new Enclave(orion.clientUrl());
+    SendRequest sendRequest1 =
+        new SendRequest(
+            "SGVsbG8sIFdvcmxkIQ==", orion.getPublicKeys().get(0), otherNode.orion.getPublicKeys());
+    waitFor(() -> orionEnclave.send(sendRequest1));
+  }
+
+  /*
+    private long getNonce(final PantheonNode node, final String privacyGroupId) {
+      return node.execute(
+              privateTransactions.getTransactionCount(node.getAddress().toString(), privacyGroupId))
+          .longValue();
+    }
+  */
+
+  // TODO: Convert this to check the blockchain instead of tracking here.
+  public long getNonce(final int[] privacyGroupNodes) {
+    List<Integer> list = Arrays.stream(privacyGroupNodes).boxed().collect(Collectors.toList());
+    String key = list.stream().map(Object::toString).collect(Collectors.joining(","));
+    Long nonce = noncesByPrivacyGroup.getOrDefault(key, -1L);
+    noncesByPrivacyGroup.put(key, ++nonce);
+    return nonce;
+  }
+}

--- a/enclave/src/main/java/tech/pegasys/pantheon/enclave/Enclave.java
+++ b/enclave/src/main/java/tech/pegasys/pantheon/enclave/Enclave.java
@@ -76,7 +76,7 @@ public class Enclave {
     try (Response response = client.newCall(request).execute()) {
       return objectMapper.readValue(response.body().string(), responseType);
     } catch (IOException e) {
-      LOG.error("Enclave failed to execute ", request);
+      LOG.error("Enclave failed to execute {}", request);
       throw new IOException("Enclave failed to execute post", e);
     }
   }

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/KeyPairUtil.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/KeyPairUtil.java
@@ -14,16 +14,47 @@ package tech.pegasys.pantheon.controller;
 
 import tech.pegasys.pantheon.crypto.InvalidSEC256K1PrivateKeyStoreException;
 import tech.pegasys.pantheon.crypto.SECP256K1;
+import tech.pegasys.pantheon.util.bytes.Bytes32;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
+import com.google.common.io.Resources;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class KeyPairUtil {
   private static final Logger LOG = LogManager.getLogger();
+
+  public static String loadResourceFile(final String resourcePath) {
+    try {
+      URL path = KeyPairUtil.class.getClassLoader().getResource(resourcePath);
+      return Resources.toString(path, StandardCharsets.UTF_8).trim();
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to load resource: " + resourcePath, e);
+    }
+  }
+
+  public static SECP256K1.KeyPair loadKeyPairFromResource(final String resourcePath) {
+    final SECP256K1.KeyPair keyPair;
+    String keyData = loadResourceFile(resourcePath);
+    if (keyData == null || keyData.isEmpty()) {
+      throw new IllegalArgumentException("Unable to load resource: " + resourcePath);
+    }
+    try {
+      SECP256K1.PrivateKey privateKey =
+          SECP256K1.PrivateKey.create(Bytes32.fromHexString((keyData)));
+      keyPair = SECP256K1.KeyPair.create(privateKey);
+
+      LOG.info("Loaded keyPair {} from {}", keyPair.getPublicKey().toString(), resourcePath);
+      return keyPair;
+    } catch (InvalidSEC256K1PrivateKeyStoreException e) {
+      throw new IllegalArgumentException("Supplied file does not contain valid keyPair pair.");
+    }
+  }
 
   public static SECP256K1.KeyPair loadKeyPair(final File keyFile)
       throws IOException, IllegalArgumentException {

--- a/testutil/src/main/java/tech/pegasys/orion/testutil/OrionTestHarnessFactory.java
+++ b/testutil/src/main/java/tech/pegasys/orion/testutil/OrionTestHarnessFactory.java
@@ -12,30 +12,84 @@
  */
 package tech.pegasys.orion.testutil;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.consensys.cava.io.file.Files.copyResource;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Base64;
 
+import com.google.common.io.CharSink;
+import com.google.common.io.Files;
 import net.consensys.orion.cmd.Orion;
 import net.consensys.orion.config.Config;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 
 public class OrionTestHarnessFactory {
-
   private static final Logger LOG = LogManager.getLogger();
   protected static final String HOST = "127.0.0.1";
+
+  public static OrionTestHarness create(
+      final Path tempDir,
+      final Ed25519PublicKeyParameters pubKey,
+      final String pubKeyPath,
+      final Ed25519PrivateKeyParameters privKey,
+      final String privKeyPath,
+      final String... othernodes)
+      throws IOException {
+    Path pubKeyFile = tempDir.resolve(pubKeyPath);
+    CharSink pubKeySink = Files.asCharSink(pubKeyFile.toFile(), UTF_8);
+    pubKeySink.write(Base64.getEncoder().encodeToString(pubKey.getEncoded()));
+
+    Path privKeyFile = tempDir.resolve(privKeyPath);
+    CharSink privKeySink = Files.asCharSink(privKeyFile.toFile(), UTF_8);
+    privKeySink.write(Base64.getEncoder().encodeToString(privKey.getEncoded()));
+
+    return create(tempDir, pubKeyFile, privKeyFile, othernodes);
+  }
+
+  public static OrionTestHarness create(
+      final Path tempDir,
+      final PublicKey pubKey,
+      final String pubKeyPath,
+      final PrivateKey privKey,
+      final String privKeyPath,
+      final String... othernodes)
+      throws IOException {
+    Path pubKeyFile = tempDir.resolve(pubKeyPath);
+    CharSink pubKeySink = Files.asCharSink(pubKeyFile.toFile(), UTF_8);
+    pubKeySink.write(Base64.getEncoder().encodeToString(pubKey.getEncoded()));
+
+    Path privKeyFile = tempDir.resolve(privKeyPath);
+    CharSink privKeySink = Files.asCharSink(privKeyFile.toFile(), UTF_8);
+    privKeySink.write(Base64.getEncoder().encodeToString(privKey.getEncoded()));
+    return create(tempDir, pubKeyFile, privKeyFile, othernodes);
+  }
 
   public static OrionTestHarness create(
       final Path tempDir,
       final String pubKeyPath,
       final String privKeyPath,
       final String... othernodes)
-      throws Exception {
-
+      throws IOException {
     Path key1pub = copyResource(pubKeyPath, tempDir.resolve(pubKeyPath));
     Path key1key = copyResource(privKeyPath, tempDir.resolve(privKeyPath));
 
+    return create(tempDir, key1pub, key1key, othernodes);
+  }
+
+  private static OrionTestHarness create(
+      final Path tempDir, final Path key1pub, final Path key1key, final String... othernodes)
+      throws IOException {
+    /*
+        Path key1pub = copyResource(pubKeyPath, tempDir.resolve(pubKeyPath));
+        Path key1key = copyResource(privKeyPath, tempDir.resolve(privKeyPath));
+    */
     // @formatter:off
     String confString =
         "tls=\"off\"\n"
@@ -57,7 +111,7 @@ public class OrionTestHarnessFactory {
             + joinPathsAsTomlListEntry(key1key)
             + "]\n"
             + "workdir= \""
-            + tempDir.toString()
+            + escapePath(tempDir)
             + "\"\n";
 
     if (othernodes.length != 0) {
@@ -77,6 +131,16 @@ public class OrionTestHarnessFactory {
     return new OrionTestHarness(orion, config);
   }
 
+  /**
+   * Replace backslashes with double backslashes so that cava's parser will escape properly on
+   * Windows.
+   */
+  @SuppressWarnings("UnnecessaryLocalVariable")
+  private static String escapePath(final Path path) {
+    String strPath = path.toAbsolutePath().toString().replace("\\", "\\\\");
+    return strPath;
+  }
+
   private static String joinPathsAsTomlListEntry(final Path... paths) {
     StringBuilder builder = new StringBuilder();
     boolean first = true;
@@ -85,7 +149,7 @@ public class OrionTestHarnessFactory {
         builder.append(",");
       }
       first = false;
-      builder.append("\"").append(path.toAbsolutePath().toString()).append("\"");
+      builder.append("\"").append(escapePath(path)).append("\"");
     }
     return builder.toString();
   }


### PR DESCRIPTION
- Generate Account and Contract Hex instead of relying on literals
- Started conversion to a model that can generate keys & config, and support many nodes
