### PR TITLE
Add explanatory comment about default port

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/netty/DeFramer.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/netty/DeFramer.java
@@ -171,7 +171,10 @@ final class DeFramer extends ByteToMessageDecoder {
     final InetSocketAddress remoteAddress = ((InetSocketAddress) ctx.channel().remoteAddress());
     int port = peerInfo.getPort();
     if (port == 0) {
-      // Most peers advertise a port of "0", just set a default best guess in this case
+      // Most peers advertise a port of "0", just set a default best guess in this case.
+      // We can't simply use the remote address port because peers initiating inbound connections
+      // are free to choose any port they want for their side of the connection.  The remote port
+      // does not actually correspond to the peer's listening port.
       port = EnodeURL.DEFAULT_LISTENING_PORT;
     }
     return DefaultPeer.fromEnodeURL(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Add explanatory comment on the choice of the default port in `DeFramer`.  Original discussion here: https://github.com/PegaSysEng/pantheon/pull/1391#discussion_r280479459

