### PR TITLE
[Minor] Start BlockPropagationManager immediately - don't wait for full sync

### DIFF
--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
@@ -106,6 +106,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
   public void start() {
     if (running.compareAndSet(false, true)) {
       syncState.addSyncStatusListener(this::syncStatusCallback);
+      blockPropagationManager.start();
       if (fastSyncDownloader.isPresent()) {
         fastSyncDownloader.get().start().whenComplete(this::handleFastSyncResult);
       } else {
@@ -149,7 +150,6 @@ public class DefaultSynchronizer<C> implements Synchronizer {
 
   private void startFullSync() {
     LOG.info("Starting synchronizer.");
-    blockPropagationManager.start();
     fullSyncDownloader.start();
   }
 

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/sync/DefaultSynchronizer.java
@@ -105,6 +105,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
   @Override
   public void start() {
     if (running.compareAndSet(false, true)) {
+      LOG.info("Starting synchronizer.");
       syncState.addSyncStatusListener(this::syncStatusCallback);
       blockPropagationManager.start();
       if (fastSyncDownloader.isPresent()) {
@@ -119,8 +120,8 @@ public class DefaultSynchronizer<C> implements Synchronizer {
 
   @Override
   public void stop() {
-    LOG.info("Stopping synchronizer");
     if (running.compareAndSet(true, false)) {
+      LOG.info("Stopping synchronizer");
       fastSyncDownloader.ifPresent(FastSyncDownloader::stop);
       fullSyncDownloader.stop();
     }
@@ -149,7 +150,6 @@ public class DefaultSynchronizer<C> implements Synchronizer {
   }
 
   private void startFullSync() {
-    LOG.info("Starting synchronizer.");
     fullSyncDownloader.start();
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Start `BlockPropagationManager` immediately - don't wait for full sync.  `BlockPropagationManager` is responsible for listening for block announcements and updating the estimated height and total difficulty of our peers' chains.  We need this to be running during fast sync so we can keep an accurate picture of our peers' states. 