### PR TITLE
[PAN-2624] Start listening for p2p connections after start() is invoked

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -643,20 +643,23 @@ public class DefaultP2PNetwork implements P2PNetwork {
 
   @Override
   public void stop() {
-    if (this.started.get() && stopped.compareAndSet(false, true)) {
-      sendClientQuittingToPeers();
-      peerConnectionScheduler.shutdownNow();
-      peerDiscoveryAgent.stop().join();
-      peerBondedObserverId.ifPresent(peerDiscoveryAgent::removePeerBondedObserver);
-      peerBondedObserverId = OptionalLong.empty();
-      peerDroppedObserverId.ifPresent(peerDiscoveryAgent::removePeerDroppedObserver);
-      peerDroppedObserverId = OptionalLong.empty();
-      blockchain.ifPresent(b -> blockAddedObserverId.ifPresent(b::removeObserver));
-      blockAddedObserverId = OptionalLong.empty();
-      peerDiscoveryAgent.stop().join();
-      workers.shutdownGracefully();
-      boss.shutdownGracefully();
+    if (!this.started.get() || !stopped.compareAndSet(false, true)) {
+      // We haven't started, or we've started and stopped already
+      return;
     }
+
+    sendClientQuittingToPeers();
+    peerConnectionScheduler.shutdownNow();
+    peerDiscoveryAgent.stop().join();
+    peerBondedObserverId.ifPresent(peerDiscoveryAgent::removePeerBondedObserver);
+    peerBondedObserverId = OptionalLong.empty();
+    peerDroppedObserverId.ifPresent(peerDiscoveryAgent::removePeerDroppedObserver);
+    peerDroppedObserverId = OptionalLong.empty();
+    blockchain.ifPresent(b -> blockAddedObserverId.ifPresent(b::removeObserver));
+    blockAddedObserverId = OptionalLong.empty();
+    peerDiscoveryAgent.stop().join();
+    workers.shutdownGracefully();
+    boss.shutdownGracefully();
   }
 
   private void sendClientQuittingToPeers() {

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -304,7 +304,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
           latch.countDown();
         });
 
-    // Ensure ourPeerInfo has been set prior to returning from the constructor.
+    // Ensure ourPeerInfo has been set prior to returning
     try {
       if (!latch.await(1, TimeUnit.MINUTES)) {
         throw new RuntimeException("Timed out while waiting for network startup");

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -184,6 +184,7 @@ public final class DefaultP2PNetworkTest {
     final Peer peer = mockPeer();
     final PeerConnection peerConnection = mockPeerConnection();
 
+    network.start();
     network.connect(peer).complete(peerConnection);
     network.stop();
 


### PR DESCRIPTION
## PR description

Start listening for incoming p2p connections only after start() is invoked.  Additionally, since we're no longer setting up listening in the constructor, we can now gate the stop() method so that it only runs after the network has been started.