### PR TITLE
[PAN-2634] Make sure ThreadPantheonNodeRunner is exercised by automation

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/ClusterThreadNodeRunnerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/ClusterThreadNodeRunnerAcceptanceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.tests.acceptance;
+
+import tech.pegasys.pantheon.tests.acceptance.dsl.AcceptanceTestBase;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.Node;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.PantheonNode;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.PantheonNodeRunner;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.ThreadPantheonNodeRunner;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.cluster.Cluster;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.cluster.ClusterConfiguration;
+import tech.pegasys.pantheon.tests.acceptance.dsl.node.cluster.ClusterConfigurationBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClusterThreadNodeRunnerAcceptanceTest extends AcceptanceTestBase {
+
+  private Node fullNode;
+  private Cluster noDiscoveryCluster;
+
+  @Before
+  public void setUp() throws Exception {
+    final ClusterConfiguration clusterConfiguration =
+        new ClusterConfigurationBuilder().setAwaitPeerDiscovery(false).build();
+    final PantheonNodeRunner pantheonNodeRunner = new ThreadPantheonNodeRunner();
+    noDiscoveryCluster = new Cluster(clusterConfiguration, net, pantheonNodeRunner);
+    final PantheonNode noDiscoveryNode = pantheon.createNodeWithNoDiscovery("noDiscovery");
+    fullNode = pantheon.createArchiveNode("node2");
+    noDiscoveryCluster.start(noDiscoveryNode, fullNode);
+  }
+
+  @Test
+  public void shouldVerifySomething() {
+    // we don't care what verifies, just that it gets to the point something can verify
+    fullNode.verify(net.awaitPeerCount(0));
+  }
+
+  @Override
+  public void tearDownAcceptanceTestBase() {
+    noDiscoveryCluster.stop();
+    super.tearDownAcceptanceTestBase();
+  }
+}

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/cluster/Cluster.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/cluster/Cluster.java
@@ -53,7 +53,10 @@ public class Cluster implements AutoCloseable {
     this(clusterConfiguration, net, PantheonNodeRunner.instance());
   }
 
-  public Cluster(final ClusterConfiguration clusterConfiguration, final Net net, final PantheonNodeRunner pantheonNodeRunner) {
+  public Cluster(
+      final ClusterConfiguration clusterConfiguration,
+      final Net net,
+      final PantheonNodeRunner pantheonNodeRunner) {
     this.clusterConfiguration = clusterConfiguration;
     this.net = net;
     this.pantheonNodeRunner = pantheonNodeRunner;

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/cluster/Cluster.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/cluster/Cluster.java
@@ -39,19 +39,24 @@ public class Cluster implements AutoCloseable {
   private static final Logger LOG = LogManager.getLogger();
 
   private final Map<String, RunnableNode> nodes = new HashMap<>();
-  private final PantheonNodeRunner pantheonNodeRunner = PantheonNodeRunner.instance();
+  private final PantheonNodeRunner pantheonNodeRunner;
   private final Net net;
   private final ClusterConfiguration clusterConfiguration;
   private List<? extends RunnableNode> originalNodes = emptyList();
   private List<URI> bootnodes = emptyList();
 
   public Cluster(final Net net) {
-    this(new ClusterConfigurationBuilder().build(), net);
+    this(new ClusterConfigurationBuilder().build(), net, PantheonNodeRunner.instance());
   }
 
   public Cluster(final ClusterConfiguration clusterConfiguration, final Net net) {
+    this(clusterConfiguration, net, PantheonNodeRunner.instance());
+  }
+
+  public Cluster(final ClusterConfiguration clusterConfiguration, final Net net, final PantheonNodeRunner pantheonNodeRunner) {
     this.clusterConfiguration = clusterConfiguration;
     this.net = net;
+    this.pantheonNodeRunner = pantheonNodeRunner;
   }
 
   public void start(final Node... nodes) {


### PR DESCRIPTION

## PR description
To make sure it is automated I extended the cluster to accept a defined
PantheonNode instead of an automatic one (where automatic is the
default) and then cloned a simple test and forced it to use the
ThreadPantheonNodeRunner.

## Fixed Issue(s)
PAN-2634