### PR TITLE
Rename "Ether token" to "Ether"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Pantheon includes a [command line interface](Reference/Pantheon-CLI-Syntax.md) a
 for running, maintaining, debugging, and monitoring nodes in an Ethereum network. You can use the API via RPC
 over HTTP or via WebSockets, and Pub/Sub is supported. The API supports typical Ethereum functionalities such as:
 
-* Ether token mining
+* Ether mining
 * Smart contract development
 * Decentralized application (Dapp) development
 


### PR DESCRIPTION
"Ether" is the "token" for Ethereum, it seems odd to have "Ether token". If you google "ether token", the result is information about ERC20s rather than ETH.