### PR TITLE
Optimise TransactionPool.addRemoteTransaction

### DIFF
--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPool.java
@@ -106,11 +106,11 @@ public class TransactionPool implements BlockAddedObserver {
   }
 
   public void addRemoteTransactions(final Collection<Transaction> transactions) {
+    if (!syncState.isInSync(SYNC_TOLERANCE)) {
+      return;
+    }
     final Set<Transaction> addedTransactions = new HashSet<>();
     for (final Transaction transaction : sortByNonce(transactions)) {
-      if (!syncState.isInSync(SYNC_TOLERANCE)) {
-        return;
-      }
       final ValidationResult<TransactionInvalidReason> validationResult =
           validateTransaction(transaction);
       if (validationResult.isValid()) {

--- a/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/tech/pegasys/pantheon/ethereum/eth/transactions/TransactionPool.java
@@ -33,9 +33,7 @@ import tech.pegasys.pantheon.ethereum.mainnet.TransactionValidator;
 import tech.pegasys.pantheon.ethereum.mainnet.TransactionValidator.TransactionInvalidReason;
 import tech.pegasys.pantheon.ethereum.mainnet.ValidationResult;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -110,7 +108,7 @@ public class TransactionPool implements BlockAddedObserver {
       return;
     }
     final Set<Transaction> addedTransactions = new HashSet<>();
-    for (final Transaction transaction : sortByNonce(transactions)) {
+    for (final Transaction transaction : transactions) {
       final ValidationResult<TransactionInvalidReason> validationResult =
           validateTransaction(transaction);
       if (validationResult.isValid()) {
@@ -128,13 +126,6 @@ public class TransactionPool implements BlockAddedObserver {
     if (!addedTransactions.isEmpty()) {
       transactionBatchAddedListener.onTransactionsAdded(addedTransactions);
     }
-  }
-
-  // Sort transactions by nonce to ensure we import sequences of transactions correctly
-  private List<Transaction> sortByNonce(final Collection<Transaction> transactions) {
-    final List<Transaction> sortedTransactions = new ArrayList<>(transactions);
-    sortedTransactions.sort(Comparator.comparing(Transaction::getNonce));
-    return sortedTransactions;
   }
 
   public void addTransactionListener(final PendingTransactionListener listener) {


### PR DESCRIPTION
## PR description
The transaction pool doesn't add remote transactions until we're in sync. Previously this check was performed after sorting and beginning to iterate the transactions.  Move the check to the very start of the method so we bail out as soon as possible.

Additionally, since we no longer reject transactions where the nonce is too high, we don't need to sort the transactions by nonce.