### PR TITLE
[PAN-2730] Create MaintainedPeers class

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeers.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeers.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.peers;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import tech.pegasys.pantheon.util.Subscribers;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.vertx.core.impl.ConcurrentHashSet;
+
+/** Represents a set of peers for which connections should be actively maintained. */
+public class MaintainedPeers {
+  private final Set<Peer> maintainedPeers = new ConcurrentHashSet<>();
+  private final Subscribers<PeerAddedCallback> addedSubscribers = new Subscribers<>();
+  private final Subscribers<PeerRemovedCallback> removedCallbackSubscribers = new Subscribers<>();
+
+  public boolean add(final Peer peer) {
+    checkArgument(
+        peer.getEnodeURL().isListening(),
+        "Invalid enode url.  Enode url must contain a non-zero listening port.");
+    boolean wasAdded = maintainedPeers.add(peer);
+    addedSubscribers.forEach(s -> s.onPeerAdded(peer, wasAdded));
+    return wasAdded;
+  }
+
+  public boolean remove(final Peer peer) {
+    boolean wasRemoved = maintainedPeers.remove(peer);
+    removedCallbackSubscribers.forEach(s -> s.onPeerRemoved(peer, wasRemoved));
+    return wasRemoved;
+  }
+
+  public boolean contains(final Peer peer) {
+    return maintainedPeers.contains(peer);
+  }
+
+  public int size() {
+    return maintainedPeers.size();
+  }
+
+  public void subscribeAdd(final PeerAddedCallback callback) {
+    addedSubscribers.subscribe(callback);
+  }
+
+  public void subscribeRemove(final PeerRemovedCallback callback) {
+    removedCallbackSubscribers.subscribe(callback);
+  }
+
+  public Stream<Peer> streamPeers() {
+    return maintainedPeers.stream();
+  }
+
+  public interface PeerAddedCallback {
+    void onPeerAdded(Peer peer, boolean wasAdded);
+  }
+
+  public interface PeerRemovedCallback {
+    void onPeerRemoved(Peer peer, boolean wasRemoved);
+  }
+}

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeers.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeers.java
@@ -62,10 +62,12 @@ public class MaintainedPeers {
     return maintainedPeers.stream();
   }
 
+  @FunctionalInterface
   public interface PeerAddedCallback {
     void onPeerAdded(Peer peer, boolean wasAdded);
   }
 
+  @FunctionalInterface
   public interface PeerRemovedCallback {
     void onPeerRemoved(Peer peer, boolean wasRemoved);
   }

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeersTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeersTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.peers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import tech.pegasys.pantheon.util.enode.EnodeURL;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+public class MaintainedPeersTest {
+
+  private MaintainedPeers maintainedPeers = new MaintainedPeers();
+
+  @Test
+  public void add_newPeer() {
+    final Peer peer = createPeer();
+    final AtomicInteger callbackCount = new AtomicInteger(0);
+    maintainedPeers.subscribeAdd(
+        (addedPeer, wasAdded) -> {
+          callbackCount.incrementAndGet();
+          assertThat(addedPeer).isEqualTo(peer);
+          assertThat(wasAdded).isTrue();
+        });
+
+    assertThat(maintainedPeers.size()).isEqualTo(0);
+    assertThat(maintainedPeers.add(peer)).isTrue();
+    assertThat(callbackCount).hasValue(1);
+    assertThat(maintainedPeers.size()).isEqualTo(1);
+    assertThat(maintainedPeers.contains(peer)).isTrue();
+  }
+
+  @Test
+  public void add_invalidPeer() {
+    final Peer peer = nonListeningPeer();
+    assertThatThrownBy(() -> maintainedPeers.add(peer))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Invalid enode url.  Enode url must contain a non-zero listening port.");
+    assertThat(maintainedPeers.contains(peer)).isFalse();
+  }
+
+  @Test
+  public void add_newDuplicatePeer() {
+    // Initial add
+    assertThat(maintainedPeers.size()).isEqualTo(0);
+    final Peer peer = createPeer();
+    assertThat(maintainedPeers.add(peer)).isTrue();
+    assertThat(maintainedPeers.size()).isEqualTo(1);
+
+    // Test duplicate add
+    final AtomicInteger callbackCount = new AtomicInteger(0);
+    maintainedPeers.subscribeAdd(
+        (addedPeer, wasAdded) -> {
+          callbackCount.incrementAndGet();
+          assertThat(addedPeer).isEqualTo(peer);
+          assertThat(wasAdded).isFalse();
+        });
+    assertThat(maintainedPeers.add(peer)).isFalse();
+    assertThat(callbackCount).hasValue(1);
+    assertThat(maintainedPeers.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void remove_existingPeer() {
+    // Initial add
+    final Peer peer = createPeer();
+    assertThat(maintainedPeers.add(peer)).isTrue();
+    assertThat(maintainedPeers.size()).isEqualTo(1);
+    assertThat(maintainedPeers.contains(peer)).isTrue();
+
+    // Test remove
+    final AtomicInteger callbackCount = new AtomicInteger(0);
+    maintainedPeers.subscribeRemove(
+        (addedPeer, wasRemoved) -> {
+          callbackCount.incrementAndGet();
+          assertThat(addedPeer).isEqualTo(peer);
+          assertThat(wasRemoved).isTrue();
+        });
+    assertThat(maintainedPeers.remove(peer)).isTrue();
+    assertThat(callbackCount).hasValue(1);
+    assertThat(maintainedPeers.size()).isEqualTo(0);
+    assertThat(maintainedPeers.contains(peer)).isFalse();
+  }
+
+  @Test
+  public void remove_nonExistentPeer() {
+    final Peer peer = createPeer();
+    assertThat(maintainedPeers.size()).isEqualTo(0);
+
+    final AtomicInteger callbackCount = new AtomicInteger(0);
+    maintainedPeers.subscribeRemove(
+        (addedPeer, wasRemoved) -> {
+          callbackCount.incrementAndGet();
+          assertThat(addedPeer).isEqualTo(peer);
+          assertThat(wasRemoved).isFalse();
+        });
+    assertThat(maintainedPeers.remove(peer)).isFalse();
+    assertThat(callbackCount).hasValue(1);
+    assertThat(maintainedPeers.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void stream_withPeers() {
+    // Initial add
+    final Peer peerA = createPeer();
+    final Peer peerB = createPeer();
+    assertThat(maintainedPeers.add(peerA)).isTrue();
+    assertThat(maintainedPeers.add(peerB)).isTrue();
+
+    final List<Peer> peers = maintainedPeers.streamPeers().collect(Collectors.toList());
+    assertThat(peers).containsExactlyInAnyOrder(peerA, peerB);
+  }
+
+  @Test
+  public void stream_empty() {
+    final List<Peer> peers = maintainedPeers.streamPeers().collect(Collectors.toList());
+    assertThat(peers).isEmpty();
+  }
+
+  private Peer createPeer() {
+    return DefaultPeer.fromEnodeURL(enodeBuilder().build());
+  }
+
+  private Peer nonListeningPeer() {
+    return DefaultPeer.fromEnodeURL(enodeBuilder().disableListening().build());
+  }
+
+  private EnodeURL.Builder enodeBuilder() {
+    return EnodeURL.builder().ipAddress("127.0.0.1").useDefaultPorts().nodeId(Peer.randomId());
+  }
+}


### PR DESCRIPTION
## PR description
Move peer maintenance list management into a new `MaintainedPeers` class.  This change will help facilitate the break up of logic within `DefaultP2PNetwork` by decoupling the add / remove action from the handling of peers in this list.  

This change also makes tests more robust by exposing a public dependency that can be checked directly, rather than having to reach into the `DefaultP2PNetwork` to check a private field.  Some connection-related checks were moved into `DefaultP2PNetwork.connect` in order to reduce the amount of custom logic executed when a new peer is added to `MaintainedPeers`.
