### PR TITLE
expand ~ (tilde) to home directory in arguments

### DIFF
--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -635,6 +635,8 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
     commandLine.registerConverter(UInt256.class, (arg) -> UInt256.of(new BigInteger(arg)));
     commandLine.registerConverter(Wei.class, (arg) -> Wei.of(Long.parseUnsignedLong(arg)));
     commandLine.registerConverter(PositiveNumber.class, PositiveNumber::fromString);
+    commandLine.registerConverter(
+        Path.class, s -> Paths.get(s.replaceFirst("~", System.getProperty("user.home"))));
 
     // Add performance options
     UnstableOptionsSubCommand.createUnstableOptions(

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
@@ -328,7 +328,9 @@ public class PantheonCommandTest extends CommandTestAbstract {
             .setGenesisConfig(encodeJsonGenesis(GENESIS_VALID_JSON))
             .setBootNodes(nodes)
             .build();
-    verify(mockControllerBuilder).dataDirectory(eq(Paths.get("~/pantheondata").toAbsolutePath()));
+    verify(mockControllerBuilder)
+        .dataDirectory(
+            eq(Paths.get(System.getProperty("user.home"), "pantheondata").toAbsolutePath()));
     verify(mockControllerBuilderFactory).fromEthNetworkConfig(eq(networkConfig));
 
     verify(mockSyncConfBuilder).syncMode(eq(SyncMode.FAST));


### PR DESCRIPTION
## PR description
When arguments are crafted in the form --arg=~/some/dir, the shell does not
expand the tilde. Since picocli does not expand the tilde by default,
this leads to inconsistencies.
