### PR TITLE
[PAN-2811] Be more lenient with discovery message deserialization

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
@@ -52,7 +52,7 @@ public class FindNeighborsPacketData implements PacketData {
     in.enterList();
     final BytesValue target = in.readBytesValue();
     final long expiration = in.readLongScalar();
-    in.leaveList(true);
+    in.leaveListLenient();
     return new FindNeighborsPacketData(target, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
@@ -52,7 +52,7 @@ public class FindNeighborsPacketData implements PacketData {
     in.enterList();
     final BytesValue target = in.readBytesValue();
     final long expiration = in.readLongScalar();
-    in.leaveList();
+    in.leaveList(true);
     return new FindNeighborsPacketData(target, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/NeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/NeighborsPacketData.java
@@ -45,7 +45,7 @@ public class NeighborsPacketData implements PacketData {
     in.enterList();
     final List<DiscoveryPeer> peers = in.readList(DiscoveryPeer::readFrom);
     final long expiration = in.readLongScalar();
-    in.leaveList();
+    in.leaveList(true);
     return new NeighborsPacketData(peers, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/NeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/NeighborsPacketData.java
@@ -45,7 +45,7 @@ public class NeighborsPacketData implements PacketData {
     in.enterList();
     final List<DiscoveryPeer> peers = in.readList(DiscoveryPeer::readFrom);
     final long expiration = in.readLongScalar();
-    in.leaveList(true);
+    in.leaveListLenient();
     return new NeighborsPacketData(peers, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PingPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PingPacketData.java
@@ -54,7 +54,7 @@ public class PingPacketData implements PacketData {
     final Endpoint from = Endpoint.decodeStandalone(in);
     final Endpoint to = Endpoint.decodeStandalone(in);
     final long expiration = in.readLongScalar();
-    in.leaveList(true);
+    in.leaveListLenient();
     return new PingPacketData(from, to, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PingPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PingPacketData.java
@@ -13,14 +13,10 @@
 package tech.pegasys.pantheon.ethereum.p2p.discovery.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static tech.pegasys.pantheon.util.Preconditions.checkGuard;
 
 import tech.pegasys.pantheon.ethereum.p2p.discovery.Endpoint;
-import tech.pegasys.pantheon.ethereum.p2p.discovery.PeerDiscoveryPacketDecodingException;
 import tech.pegasys.pantheon.ethereum.rlp.RLPInput;
 import tech.pegasys.pantheon.ethereum.rlp.RLPOutput;
-
-import java.math.BigInteger;
 
 public class PingPacketData implements PacketData {
 
@@ -53,18 +49,12 @@ public class PingPacketData implements PacketData {
 
   public static PingPacketData readFrom(final RLPInput in) {
     in.enterList();
-    final BigInteger version = in.readBigIntegerScalar();
-    checkGuard(
-        version.intValue() == VERSION,
-        PeerDiscoveryPacketDecodingException::new,
-        "Version mismatch in ping packet. Expected: %s, got: %s.",
-        VERSION,
-        version);
-
+    // The first element signifies the "version", but this value is ignored as of EIP-8
+    in.readBigIntegerScalar();
     final Endpoint from = Endpoint.decodeStandalone(in);
     final Endpoint to = Endpoint.decodeStandalone(in);
     final long expiration = in.readLongScalar();
-    in.leaveList();
+    in.leaveList(true);
     return new PingPacketData(from, to, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PongPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PongPacketData.java
@@ -44,7 +44,7 @@ public class PongPacketData implements PacketData {
     final Endpoint to = Endpoint.decodeStandalone(in);
     final BytesValue hash = in.readBytesValue();
     final long expiration = in.readLongScalar();
-    in.leaveList();
+    in.leaveList(true);
     return new PongPacketData(to, hash, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PongPacketData.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PongPacketData.java
@@ -44,7 +44,7 @@ public class PongPacketData implements PacketData {
     final Endpoint to = Endpoint.decodeStandalone(in);
     final BytesValue hash = in.readBytesValue();
     final long expiration = in.readLongScalar();
-    in.leaveList(true);
+    in.leaveListLenient();
     return new PongPacketData(to, hash, expiration);
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/wire/PeerInfo.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/wire/PeerInfo.java
@@ -61,7 +61,7 @@ public class PeerInfo {
         in.nextIsNull() ? Collections.emptyList() : in.readList(Capability::readFrom);
     final int port = in.readIntScalar();
     final BytesValue nodeId = in.readBytesValue();
-    in.leaveList(true);
+    in.leaveListLenient();
     return new PeerInfo(version, clientId, caps, port, nodeId);
   }
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/FindNeighborsPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/FindNeighborsPacketDataTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.discovery.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.pantheon.ethereum.p2p.peers.Peer;
+import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
+import tech.pegasys.pantheon.ethereum.rlp.RLP;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import org.junit.Test;
+
+public class FindNeighborsPacketDataTest {
+  @Test
+  public void serializeDeserialize() {
+    final long time = System.currentTimeMillis();
+    final BytesValue target = Peer.randomId();
+
+    final FindNeighborsPacketData packet = FindNeighborsPacketData.create(target);
+    final BytesValue serialized = RLP.encode(packet::writeTo);
+    final FindNeighborsPacketData deserialized =
+        FindNeighborsPacketData.readFrom(RLP.input(serialized));
+
+    assertThat(deserialized.getTarget()).isEqualTo(target);
+    assertThat(deserialized.getExpiration()).isGreaterThan(time);
+  }
+
+  @Test
+  public void readFrom() {
+    final long time = System.currentTimeMillis();
+    final BytesValue target = Peer.randomId();
+
+    BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeBytesValue(target);
+    out.writeLongScalar(time);
+    out.endList();
+    final BytesValue encoded = out.encoded();
+
+    final FindNeighborsPacketData deserialized =
+        FindNeighborsPacketData.readFrom(RLP.input(encoded));
+    assertThat(deserialized.getTarget()).isEqualTo(target);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+
+  @Test
+  public void readFrom_withExtraFields() {
+    final long time = System.currentTimeMillis();
+    final BytesValue target = Peer.randomId();
+
+    BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeBytesValue(target);
+    out.writeLongScalar(time);
+    // Add extra list elements
+    out.writeLong(123L);
+    out.endList();
+    final BytesValue encoded = out.encoded();
+
+    final FindNeighborsPacketData deserialized =
+        FindNeighborsPacketData.readFrom(RLP.input(encoded));
+    assertThat(deserialized.getTarget()).isEqualTo(target);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+}

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/NeighborsPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/NeighborsPacketDataTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.discovery.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.pantheon.ethereum.p2p.peers.PeerTestHelper.enode;
+
+import tech.pegasys.pantheon.ethereum.p2p.discovery.DiscoveryPeer;
+import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
+import tech.pegasys.pantheon.ethereum.rlp.RLP;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class NeighborsPacketDataTest {
+
+  @Test
+  public void serializeDeserialize() {
+    final long time = System.currentTimeMillis();
+    final List<DiscoveryPeer> peers =
+        Arrays.asList(DiscoveryPeer.fromEnode(enode()), DiscoveryPeer.fromEnode(enode()));
+
+    final NeighborsPacketData packet = NeighborsPacketData.create(peers);
+    final BytesValue serialized = RLP.encode(packet::writeTo);
+    final NeighborsPacketData deserialized = NeighborsPacketData.readFrom(RLP.input(serialized));
+
+    assertThat(deserialized.getNodes()).isEqualTo(peers);
+    assertThat(deserialized.getExpiration()).isGreaterThan(time);
+  }
+
+  @Test
+  public void readFrom() {
+    final long time = System.currentTimeMillis();
+    final List<DiscoveryPeer> peers =
+        Arrays.asList(DiscoveryPeer.fromEnode(enode()), DiscoveryPeer.fromEnode(enode()));
+
+    BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeList(peers, DiscoveryPeer::writeTo);
+    out.writeLongScalar(time);
+    out.endList();
+    BytesValue encoded = out.encoded();
+
+    final NeighborsPacketData deserialized = NeighborsPacketData.readFrom(RLP.input(encoded));
+    assertThat(deserialized.getNodes()).isEqualTo(peers);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+
+  @Test
+  public void readFrom_extraFields() {
+    final long time = System.currentTimeMillis();
+    final List<DiscoveryPeer> peers =
+        Arrays.asList(DiscoveryPeer.fromEnode(enode()), DiscoveryPeer.fromEnode(enode()));
+
+    BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeList(peers, DiscoveryPeer::writeTo);
+    out.writeLongScalar(time);
+    out.endList();
+    BytesValue encoded = out.encoded();
+
+    final NeighborsPacketData deserialized = NeighborsPacketData.readFrom(RLP.input(encoded));
+    assertThat(deserialized.getNodes()).isEqualTo(peers);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+}

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PingPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PingPacketDataTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.discovery.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.pantheon.ethereum.p2p.discovery.Endpoint;
+import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
+import tech.pegasys.pantheon.ethereum.rlp.RLP;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import java.util.OptionalInt;
+
+import org.junit.Test;
+
+public class PingPacketDataTest {
+
+  @Test
+  public void serializeDeserialize() {
+    final long currentTime = System.currentTimeMillis();
+
+    final Endpoint from = new Endpoint("127.0.0.1", 30303, OptionalInt.of(30303));
+    final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
+    final PingPacketData packet = PingPacketData.create(from, to);
+    final BytesValue serialized = RLP.encode(packet::writeTo);
+    final PingPacketData deserialized = PingPacketData.readFrom(RLP.input(serialized));
+
+    assertThat(deserialized.getFrom()).isEqualTo(from);
+    assertThat(deserialized.getTo()).isEqualTo(to);
+    assertThat(deserialized.getExpiration()).isGreaterThan(currentTime);
+  }
+
+  @Test
+  public void readFrom() {
+    final int version = 4;
+    final Endpoint from = new Endpoint("127.0.0.1", 30303, OptionalInt.of(30303));
+    final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
+    final long time = System.currentTimeMillis();
+
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeIntScalar(version);
+    from.encodeStandalone(out);
+    to.encodeStandalone(out);
+    out.writeLongScalar(time);
+    out.endList();
+
+    final BytesValue serialized = out.encoded();
+    final PingPacketData deserialized = PingPacketData.readFrom(RLP.input(serialized));
+
+    assertThat(deserialized.getFrom()).isEqualTo(from);
+    assertThat(deserialized.getTo()).isEqualTo(to);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+
+  @Test
+  public void readFrom_withExtraFields() {
+    final int version = 4;
+    final Endpoint from = new Endpoint("127.0.0.1", 30303, OptionalInt.of(30303));
+    final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
+    final long time = System.currentTimeMillis();
+
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeIntScalar(version);
+    from.encodeStandalone(out);
+    to.encodeStandalone(out);
+    out.writeLongScalar(time);
+    // Add extra field
+    out.writeLongScalar(11);
+    out.endList();
+
+    final BytesValue serialized = out.encoded();
+    final PingPacketData deserialized = PingPacketData.readFrom(RLP.input(serialized));
+
+    assertThat(deserialized.getFrom()).isEqualTo(from);
+    assertThat(deserialized.getTo()).isEqualTo(to);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+
+  @Test
+  public void readFrom_unknownVersion() {
+    final int version = 99;
+    final Endpoint from = new Endpoint("127.0.0.1", 30303, OptionalInt.of(30303));
+    final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
+    final long time = System.currentTimeMillis();
+
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    out.writeIntScalar(version);
+    from.encodeStandalone(out);
+    to.encodeStandalone(out);
+    out.writeLongScalar(time);
+    out.endList();
+
+    final BytesValue serialized = out.encoded();
+    final PingPacketData deserialized = PingPacketData.readFrom(RLP.input(serialized));
+
+    assertThat(deserialized.getFrom()).isEqualTo(from);
+    assertThat(deserialized.getTo()).isEqualTo(to);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+}

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PongPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/discovery/internal/PongPacketDataTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.discovery.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.pantheon.ethereum.p2p.discovery.Endpoint;
+import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
+import tech.pegasys.pantheon.ethereum.rlp.RLP;
+import tech.pegasys.pantheon.util.bytes.Bytes32;
+import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import java.util.OptionalInt;
+
+import org.junit.Test;
+
+public class PongPacketDataTest {
+
+  @Test
+  public void serializeDeserialize() {
+    final long currentTime = System.currentTimeMillis();
+    final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
+    final Bytes32 hash = Bytes32.fromHexStringLenient("0x1234");
+
+    final PongPacketData packet = PongPacketData.create(to, hash);
+    final BytesValue serialized = RLP.encode(packet::writeTo);
+    final PongPacketData deserialized = PongPacketData.readFrom(RLP.input(serialized));
+
+    assertThat(deserialized.getTo()).isEqualTo(to);
+    assertThat(deserialized.getPingHash()).isEqualTo(hash);
+    assertThat(deserialized.getExpiration()).isGreaterThan(currentTime);
+  }
+
+  @Test
+  public void readFrom() {
+    final long time = System.currentTimeMillis();
+    final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
+    final Bytes32 hash = Bytes32.fromHexStringLenient("0x1234");
+
+    BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    to.encodeStandalone(out);
+    out.writeBytesValue(hash);
+    out.writeLongScalar(time);
+    out.endList();
+    final BytesValue encoded = out.encoded();
+
+    final PongPacketData deserialized = PongPacketData.readFrom(RLP.input(encoded));
+    assertThat(deserialized.getTo()).isEqualTo(to);
+    assertThat(deserialized.getPingHash()).isEqualTo(hash);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+
+  @Test
+  public void readFrom_withExtraFields() {
+    final long time = System.currentTimeMillis();
+    final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
+    final Bytes32 hash = Bytes32.fromHexStringLenient("0x1234");
+
+    BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.startList();
+    to.encodeStandalone(out);
+    out.writeBytesValue(hash);
+    out.writeLongScalar(time);
+    // Add random fields
+    out.writeLong(1234L);
+    out.endList();
+    final BytesValue encoded = out.encoded();
+
+    final PongPacketData deserialized = PongPacketData.readFrom(RLP.input(encoded));
+    assertThat(deserialized.getTo()).isEqualTo(to);
+    assertThat(deserialized.getPingHash()).isEqualTo(hash);
+    assertThat(deserialized.getExpiration()).isEqualTo(time);
+  }
+}

--- a/ethereum/rlp/src/main/java/tech/pegasys/pantheon/ethereum/rlp/AbstractRLPInput.java
+++ b/ethereum/rlp/src/main/java/tech/pegasys/pantheon/ethereum/rlp/AbstractRLPInput.java
@@ -494,7 +494,11 @@ abstract class AbstractRLPInput implements RLPInput {
   }
 
   @Override
-  public void leaveList(final boolean ignoreRest) {
+  public void leaveListLenient() {
+    leaveList(true);
+  }
+
+  private void leaveList(final boolean ignoreRest) {
     checkState(depth > 0, "Not within an RLP list");
 
     if (!ignoreRest) {

--- a/ethereum/rlp/src/main/java/tech/pegasys/pantheon/ethereum/rlp/RLPInput.java
+++ b/ethereum/rlp/src/main/java/tech/pegasys/pantheon/ethereum/rlp/RLPInput.java
@@ -110,9 +110,6 @@ public interface RLPInput {
   /**
    * Exits the current list after all its items have been consumed.
    *
-   * <p>This method is equivalent to calling {@link #leaveList(boolean)} with value <code>false
-   * </code>.
-   *
    * <p>Note that this method technically doesn't consume any input but must be called after having
    * read the last element of a list. This allow to ensure the structure of the input is indeed the
    * one expected.
@@ -122,18 +119,13 @@ public interface RLPInput {
   void leaveList();
 
   /**
-   * Exits the current list, allowing the caller to ignore any remaining unconsumed elements.
+   * Exits the current list, ignoring any remaining unconsumed elements.
    *
    * <p>Note that this method technically doesn't consume any input but must be called after having
    * read the last element of a list. This allow to ensure the structure of the input is indeed the
    * one expected.
-   *
-   * @param ignoreRest Whether to ignore any remaining elements in the list. If elements remain and
-   *     this parameter is <code>false</code>, an exception will be thrown.
-   * @throws RLPException if the current list is not finished (it has more items), if <code>
-   *     ignoreRest</code> is <code>false</code>.
    */
-  void leaveList(boolean ignoreRest);
+  void leaveListLenient();
 
   /**
    * Reads a scalar from the input and return is as a long value.

--- a/ethereum/rlp/src/test/java/tech/pegasys/pantheon/ethereum/rlp/BytesValueRLPInputTest.java
+++ b/ethereum/rlp/src/test/java/tech/pegasys/pantheon/ethereum/rlp/BytesValueRLPInputTest.java
@@ -452,7 +452,7 @@ public class BytesValueRLPInputTest {
     final RLPInput in = RLP.input(h("0xc80102c51112c22122"));
     assertThat(in.enterList()).isEqualTo(3);
     assertThat(in.readByte()).isEqualTo((byte) 0x01);
-    in.leaveList(true);
+    in.leaveListLenient();
   }
 
   @Test
@@ -460,7 +460,7 @@ public class BytesValueRLPInputTest {
     final RLPInput in = RLP.input(h("0xc80102c51112c22122"));
     assertThat(in.enterList()).isEqualTo(3);
     assertThat(in.readByte()).isEqualTo((byte) 0x01);
-    assertThatThrownBy(() -> in.leaveList(false))
+    assertThatThrownBy(() -> in.leaveList())
         .isInstanceOf(RLPException.class)
         .hasMessageStartingWith("Not at the end of the current list");
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
[EIP-8](https://eips.ethereum.org/EIPS/eip-8) specifies that devp2p discovery message deserialization should be lenient in order to make protocol upgrades easier.  This PR updates discovery packet deserialization to be more lenient by:
* ignoring extra fields
* ignoring the version in PING packets