### PR TITLE
Remove duplication between EeaTransactionCountRpc & PrivateTransactionHandler

### DIFF
--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/privacy/PrivateTransactionHandler.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/privacy/PrivateTransactionHandler.java
@@ -172,8 +172,7 @@ public class PrivateTransactionHandler {
                     .getMutable(lastRootHash)
                     .map(
                         worldState -> {
-                          final Account maybePrivateSender =
-                              worldState.get(sender);
+                          final Account maybePrivateSender = worldState.get(sender);
 
                           if (maybePrivateSender != null) {
                             return maybePrivateSender.getNonce();

--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/privacy/PrivateTransactionHandler.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/privacy/PrivateTransactionHandler.java
@@ -23,9 +23,9 @@ import tech.pegasys.pantheon.enclave.types.SendRequest;
 import tech.pegasys.pantheon.enclave.types.SendResponse;
 import tech.pegasys.pantheon.ethereum.core.Account;
 import tech.pegasys.pantheon.ethereum.core.Address;
-import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
 import tech.pegasys.pantheon.ethereum.core.Transaction;
+import tech.pegasys.pantheon.ethereum.core.Util;
 import tech.pegasys.pantheon.ethereum.mainnet.TransactionValidator.TransactionInvalidReason;
 import tech.pegasys.pantheon.ethereum.mainnet.ValidationResult;
 import tech.pegasys.pantheon.ethereum.rlp.BytesValueRLPOutput;
@@ -70,7 +70,7 @@ public class PrivateTransactionHandler {
     this.enclave = enclave;
     this.privacyPrecompileAddress = privacyPrecompileAddress;
     this.nodeKeyPair = nodeKeyPair;
-    this.signerAddress = Address.extract(Hash.hash(nodeKeyPair.getPublicKey().getEncodedBytes()));
+    this.signerAddress = Util.publicKeyToAddress(nodeKeyPair.getPublicKey());
     this.privateStateStorage = privateStateStorage;
     this.privateWorldStateArchive = privateWorldStateArchive;
   }
@@ -122,7 +122,7 @@ public class PrivateTransactionHandler {
   public ValidationResult<TransactionInvalidReason> validatePrivateTransaction(
       final PrivateTransaction privateTransaction, final String privacyGroupId) {
     final long actualNonce = privateTransaction.getNonce();
-    final long expectedNonce = getSenderNonce(privateTransaction, privacyGroupId);
+    final long expectedNonce = getSenderNonce(privateTransaction.getSender(), privacyGroupId);
     LOG.debug("Validating actual nonce {} with expected nonce {}", actualNonce, expectedNonce);
     if (expectedNonce > actualNonce) {
       return ValidationResult.invalid(
@@ -163,8 +163,7 @@ public class PrivateTransactionHandler {
         privateFor);
   }
 
-  private long getSenderNonce(
-      final PrivateTransaction privateTransaction, final String privacyGroupId) {
+  public long getSenderNonce(final Address sender, final String privacyGroupId) {
     return privateStateStorage
         .getPrivateAccountState(BytesValue.fromHexString(privacyGroupId))
         .map(
@@ -174,7 +173,7 @@ public class PrivateTransactionHandler {
                     .map(
                         worldState -> {
                           final Account maybePrivateSender =
-                              worldState.get(privateTransaction.getSender());
+                              worldState.get(sender);
 
                           if (maybePrivateSender != null) {
                             return maybePrivateSender.getNonce();

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
@@ -317,16 +317,18 @@ public class JsonRpcMethodsFactory {
           new AdminPeers(p2pNetwork));
     }
     if (rpcApis.contains(RpcApis.EEA)) {
+      final PrivateTransactionHandler privateTransactionHandler =
+          new PrivateTransactionHandler(privacyParameters);
       final Enclave enclave = new Enclave(privacyParameters.getEnclaveUri());
       addMethods(
           enabledMethods,
           new EeaGetTransactionReceipt(blockchainQueries, enclave, parameter, privacyParameters),
           new EeaSendRawTransaction(
               blockchainQueries,
-              new PrivateTransactionHandler(privacyParameters),
+              privateTransactionHandler,
               transactionPool,
               parameter),
-          new EeaGetTransactionCount(parameter, privacyParameters),
+          new EeaGetTransactionCount(parameter, privateTransactionHandler),
           new EeaGetPrivateTransaction(enclave, parameter, privacyParameters),
           new EeaCreatePrivacyGroup(new Enclave(privacyParameters.getEnclaveUri()), parameter),
           new EeaDeletePrivacyGroup(new Enclave(privacyParameters.getEnclaveUri()), parameter),

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/JsonRpcMethodsFactory.java
@@ -324,10 +324,7 @@ public class JsonRpcMethodsFactory {
           enabledMethods,
           new EeaGetTransactionReceipt(blockchainQueries, enclave, parameter, privacyParameters),
           new EeaSendRawTransaction(
-              blockchainQueries,
-              privateTransactionHandler,
-              transactionPool,
-              parameter),
+              blockchainQueries, privateTransactionHandler, transactionPool, parameter),
           new EeaGetTransactionCount(parameter, privateTransactionHandler),
           new EeaGetPrivateTransaction(enclave, parameter, privacyParameters),
           new EeaCreatePrivacyGroup(new Enclave(privacyParameters.getEnclaveUri()), parameter),

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/privacy/EeaGetTransactionCount.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/privacy/EeaGetTransactionCount.java
@@ -12,10 +12,7 @@
  */
 package tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.privacy;
 
-import tech.pegasys.pantheon.ethereum.core.Account;
 import tech.pegasys.pantheon.ethereum.core.Address;
-import tech.pegasys.pantheon.ethereum.core.MutableWorldState;
-import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
 import tech.pegasys.pantheon.ethereum.jsonrpc.RpcMethod;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods.JsonRpcMethod;
@@ -25,10 +22,7 @@ import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcErrorResp
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.results.Quantity;
-import tech.pegasys.pantheon.ethereum.privacy.PrivateStateStorage;
 import tech.pegasys.pantheon.ethereum.privacy.PrivateTransactionHandler;
-import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
-import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 public class EeaGetTransactionCount implements JsonRpcMethod {
 

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/privacy/EeaGetTransactionCountTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/privacy/EeaGetTransactionCountTest.java
@@ -17,20 +17,14 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
 import tech.pegasys.pantheon.ethereum.core.Address;
-import tech.pegasys.pantheon.ethereum.core.Hash;
-import tech.pegasys.pantheon.ethereum.core.MutableAccount;
-import tech.pegasys.pantheon.ethereum.core.MutableWorldState;
-import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
-import tech.pegasys.pantheon.ethereum.core.WorldUpdater;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.parameters.JsonRpcParameter;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import tech.pegasys.pantheon.ethereum.privacy.PrivateStateStorage;
 import tech.pegasys.pantheon.ethereum.privacy.PrivateTransactionHandler;
-import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
+
+import org.junit.Test;
 
 public class EeaGetTransactionCountTest {
 
@@ -51,7 +45,7 @@ public class EeaGetTransactionCountTest {
     final EeaGetTransactionCount eeaGetTransactionCount =
         new EeaGetTransactionCount(parameters, privateTransactionHandler);
 
-    final Object[] params = new Object[]{senderAddress, privacyGroupId.toString()};
+    final Object[] params = new Object[] {senderAddress, privacyGroupId.toString()};
     final JsonRpcRequest request = new JsonRpcRequest("1", "eea_getTransactionCount", params);
 
     final JsonRpcSuccessResponse response =

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/privacy/EeaGetTransactionCountTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/privacy/EeaGetTransactionCountTest.java
@@ -17,34 +17,24 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.junit.Test;
 import tech.pegasys.pantheon.ethereum.core.Address;
 import tech.pegasys.pantheon.ethereum.core.Hash;
 import tech.pegasys.pantheon.ethereum.core.MutableAccount;
 import tech.pegasys.pantheon.ethereum.core.MutableWorldState;
 import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
-import tech.pegasys.pantheon.ethereum.core.Wei;
 import tech.pegasys.pantheon.ethereum.core.WorldUpdater;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.parameters.JsonRpcParameter;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import tech.pegasys.pantheon.ethereum.privacy.PrivateStateStorage;
+import tech.pegasys.pantheon.ethereum.privacy.PrivateTransactionHandler;
 import tech.pegasys.pantheon.ethereum.worldstate.WorldStateArchive;
 import tech.pegasys.pantheon.util.bytes.BytesValue;
-
-import java.util.Optional;
-
-import org.junit.Test;
 
 public class EeaGetTransactionCountTest {
 
   private final JsonRpcParameter parameters = new JsonRpcParameter();
-  private final PrivateStateStorage privacyStateStorage = mock(PrivateStateStorage.class);
-  private final WorldStateArchive privateWorldStateArchive = mock(WorldStateArchive.class);
-  private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
-  private final MutableWorldState mutableWorldState = mock(MutableWorldState.class);
-  private final WorldUpdater worldUpdater = mock(WorldUpdater.class);
-  private final MutableAccount mutableAccount = mock(MutableAccount.class);
-  private final Hash lastRootHash = mock(Hash.class);
   private final BytesValue privacyGroupId = BytesValue.wrap("0x123".getBytes(UTF_8));
 
   private final Address senderAddress =
@@ -53,30 +43,20 @@ public class EeaGetTransactionCountTest {
 
   @Test
   public void verifyTransactionCount() {
-    when(mutableWorldState.updater()).thenReturn(worldUpdater);
-    when(mutableAccount.getNonce()).thenReturn(NONCE);
-    // Create account in storage with given nonce
-    when(worldUpdater.createAccount(senderAddress, NONCE, Wei.ZERO)).thenReturn(mutableAccount);
-    when(privateWorldStateArchive.getMutable()).thenReturn(mutableWorldState);
-
-    when(privacyParameters.getPrivateStateStorage()).thenReturn(privacyStateStorage);
-    when(privacyParameters.getPrivateWorldStateArchive()).thenReturn(privateWorldStateArchive);
-
-    when(privacyStateStorage.getPrivateAccountState(privacyGroupId))
-        .thenReturn(Optional.of(lastRootHash));
-    when(privateWorldStateArchive.getMutable(lastRootHash))
-        .thenReturn(Optional.of(mutableWorldState));
-    when(mutableWorldState.get(senderAddress)).thenReturn(mutableAccount);
+    final PrivateTransactionHandler privateTransactionHandler =
+        mock(PrivateTransactionHandler.class);
+    when(privateTransactionHandler.getSenderNonce(senderAddress, privacyGroupId.toString()))
+        .thenReturn(NONCE);
 
     final EeaGetTransactionCount eeaGetTransactionCount =
-        new EeaGetTransactionCount(parameters, privacyParameters);
+        new EeaGetTransactionCount(parameters, privateTransactionHandler);
 
-    final Object[] params = new Object[] {senderAddress, privacyGroupId.toString()};
+    final Object[] params = new Object[]{senderAddress, privacyGroupId.toString()};
     final JsonRpcRequest request = new JsonRpcRequest("1", "eea_getTransactionCount", params);
 
     final JsonRpcSuccessResponse response =
         (JsonRpcSuccessResponse) eeaGetTransactionCount.response(request);
 
-    assertEquals("0x5", response.getResult());
+    assertEquals(String.format("0x%X", NONCE), response.getResult());
   }
 }


### PR DESCRIPTION
Have the eeaTransactionCount json RPC reuse the nonce calculator stored in the PrivateTransactionHandler.

Potentially this function should be pushed down to the worldStateArchive ...