### PR TITLE
[PIE-1647] Update smoke tests docker images for zulu and openjdk to private ones

### DIFF
--- a/Jenkinsfile.smoke
+++ b/Jenkinsfile.smoke
@@ -40,6 +40,7 @@ def linuxImagesPrivate = [
     'pegasyseng/jdk:oracle-8-0.0.1',
     'pegasyseng/jdk:oracle-11-0.0.1',
     'pegasyseng/jdk:corretto-8-0.0.1',
+    'pegasyseng/jdk:openjdk-12',
     'pegasyseng/jdk:zulu-openjdk-8',
     'pegasyseng/jdk:zulu-openjdk-11',
     'pegasyseng/jdk:zulu-openjdk-12'

--- a/Jenkinsfile.smoke
+++ b/Jenkinsfile.smoke
@@ -13,10 +13,6 @@ def runDocker(image, cmd) {
 def linuxImages = [
     'openjdk:8-jdk',
     'openjdk:11-jdk',
-    'openjdk:12-jdk',
-    'azul/zulu-openjdk:8',
-    'azul/zulu-openjdk:11',
-    'azul/zulu-openjdk:12',
     'adoptopenjdk/openjdk8-openj9:latest',
     'adoptopenjdk/openjdk11-openj9:latest'
 ]
@@ -43,7 +39,10 @@ def createLinuxBuild(dockerImage) {
 def linuxImagesPrivate = [
     'pegasyseng/jdk:oracle-8-0.0.1',
     'pegasyseng/jdk:oracle-11-0.0.1',
-    'pegasyseng/jdk:corretto-8-0.0.1'
+    'pegasyseng/jdk:corretto-8-0.0.1',
+    'pegasyseng/jdk:zulu-openjdk-8',
+    'pegasyseng/jdk:zulu-openjdk-11',
+    'pegasyseng/jdk:zulu-openjdk-12'
 ]
 
 def createLinuxBuildPrivateImage(dockerImage) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Modified the Jenkins Smoke Test to use private docker images for Zulu OpenJDK (8, 11 & 12) and OpenJDK 12

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
