### PR TITLE
[PAN-2797] Check connections more frequently during acceptance tests

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/PantheonNode.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/PantheonNode.java
@@ -24,6 +24,7 @@ import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
 import tech.pegasys.pantheon.ethereum.core.Util;
 import tech.pegasys.pantheon.ethereum.jsonrpc.JsonRpcConfiguration;
 import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
+import tech.pegasys.pantheon.ethereum.p2p.config.NetworkingConfiguration;
 import tech.pegasys.pantheon.ethereum.permissioning.PermissioningConfiguration;
 import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 import tech.pegasys.pantheon.tests.acceptance.dsl.condition.Condition;
@@ -78,6 +79,7 @@ public class PantheonNode implements NodeConfiguration, RunnableNode, AutoClosea
   private final KeyPair keyPair;
   private final Properties portsProperties = new Properties();
   private final Boolean p2pEnabled;
+  private final NetworkingConfiguration networkingConfiguration;
 
   private final String name;
   private final MiningParameters miningParameters;
@@ -112,6 +114,7 @@ public class PantheonNode implements NodeConfiguration, RunnableNode, AutoClosea
       final boolean devMode,
       final GenesisConfigurationProvider genesisConfigProvider,
       final boolean p2pEnabled,
+      final NetworkingConfiguration networkingConfiguration,
       final boolean discoveryEnabled,
       final boolean bootnodeEligible,
       final List<String> plugins,
@@ -139,6 +142,7 @@ public class PantheonNode implements NodeConfiguration, RunnableNode, AutoClosea
     this.genesisConfigProvider = genesisConfigProvider;
     this.devMode = devMode;
     this.p2pEnabled = p2pEnabled;
+    this.networkingConfiguration = networkingConfiguration;
     this.discoveryEnabled = discoveryEnabled;
     plugins.forEach(
         pluginName -> {
@@ -470,6 +474,10 @@ public class PantheonNode implements NodeConfiguration, RunnableNode, AutoClosea
   @Override
   public boolean isP2pEnabled() {
     return p2pEnabled;
+  }
+
+  public NetworkingConfiguration getNetworkingConfiguration() {
+    return networkingConfiguration;
   }
 
   @Override

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ProcessPantheonNodeRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ProcessPantheonNodeRunner.java
@@ -14,6 +14,7 @@ package tech.pegasys.pantheon.tests.acceptance.dsl.node;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import tech.pegasys.pantheon.cli.options.NetworkingOptions;
 import tech.pegasys.pantheon.ethereum.jsonrpc.RpcApi;
 import tech.pegasys.pantheon.ethereum.jsonrpc.RpcApis;
 import tech.pegasys.pantheon.ethereum.permissioning.PermissioningConfiguration;
@@ -143,6 +144,10 @@ public class ProcessPantheonNodeRunner implements PantheonNodeRunner {
     if (!node.isP2pEnabled()) {
       params.add("--p2p-enabled");
       params.add("false");
+    } else {
+      final List<String> networkConfigParams =
+          NetworkingOptions.fromConfig(node.getNetworkingConfiguration()).getCLIOptions();
+      params.addAll(networkConfigParams);
     }
 
     node.getPermissioningConfiguration()

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
@@ -145,6 +145,7 @@ public class ThreadPantheonNodeRunner implements PantheonNodeRunner {
             .p2pAdvertisedHost(node.getHostName())
             .p2pListenPort(0)
             .maxPeers(25)
+            .networkingConfiguration(node.getNetworkingConfiguration())
             .jsonRpcConfiguration(node.jsonRpcConfiguration())
             .webSocketConfiguration(node.webSocketConfiguration())
             .dataDir(node.homeDirectory())

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonFactoryConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonFactoryConfiguration.java
@@ -16,6 +16,7 @@ import tech.pegasys.pantheon.ethereum.core.MiningParameters;
 import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
 import tech.pegasys.pantheon.ethereum.jsonrpc.JsonRpcConfiguration;
 import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
+import tech.pegasys.pantheon.ethereum.p2p.config.NetworkingConfiguration;
 import tech.pegasys.pantheon.ethereum.permissioning.PermissioningConfiguration;
 import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 import tech.pegasys.pantheon.tests.acceptance.dsl.node.configuration.genesis.GenesisConfigurationProvider;
@@ -36,6 +37,7 @@ public class PantheonFactoryConfiguration {
   private final boolean devMode;
   private final GenesisConfigurationProvider genesisConfigProvider;
   private final boolean p2pEnabled;
+  private final NetworkingConfiguration networkingConfiguration;
   private final boolean discoveryEnabled;
   private final boolean bootnodeEligible;
   private final List<String> plugins;
@@ -53,6 +55,7 @@ public class PantheonFactoryConfiguration {
       final boolean devMode,
       final GenesisConfigurationProvider genesisConfigProvider,
       final boolean p2pEnabled,
+      final NetworkingConfiguration networkingConfiguration,
       final boolean discoveryEnabled,
       final boolean bootnodeEligible,
       final List<String> plugins,
@@ -68,6 +71,7 @@ public class PantheonFactoryConfiguration {
     this.devMode = devMode;
     this.genesisConfigProvider = genesisConfigProvider;
     this.p2pEnabled = p2pEnabled;
+    this.networkingConfiguration = networkingConfiguration;
     this.discoveryEnabled = discoveryEnabled;
     this.bootnodeEligible = bootnodeEligible;
     this.plugins = plugins;
@@ -120,6 +124,10 @@ public class PantheonFactoryConfiguration {
 
   public boolean isP2pEnabled() {
     return p2pEnabled;
+  }
+
+  public NetworkingConfiguration getNetworkingConfiguration() {
+    return networkingConfiguration;
   }
 
   public boolean isBootnodeEligible() {

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonFactoryConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonFactoryConfigurationBuilder.java
@@ -20,6 +20,7 @@ import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
 import tech.pegasys.pantheon.ethereum.jsonrpc.JsonRpcConfiguration;
 import tech.pegasys.pantheon.ethereum.jsonrpc.RpcApis;
 import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
+import tech.pegasys.pantheon.ethereum.p2p.config.NetworkingConfiguration;
 import tech.pegasys.pantheon.ethereum.permissioning.PermissioningConfiguration;
 import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 import tech.pegasys.pantheon.tests.acceptance.dsl.node.configuration.genesis.GenesisConfigurationProvider;
@@ -45,10 +46,17 @@ public class PantheonFactoryConfigurationBuilder {
   private boolean devMode = true;
   private GenesisConfigurationProvider genesisConfigProvider = ignore -> Optional.empty();
   private Boolean p2pEnabled = true;
+  private NetworkingConfiguration networkingConfiguration = NetworkingConfiguration.create();
   private boolean discoveryEnabled = true;
   private boolean bootnodeEligible = true;
   private List<String> plugins = new ArrayList<>();
   private List<String> extraCLIOptions = new ArrayList<>();
+
+  public PantheonFactoryConfigurationBuilder() {
+    // Check connections more frequently during acceptance tests to cut down on
+    // intermittent failures due to the fact that we're running over a real network
+    networkingConfiguration.setInitiateConnectionsFrequency(5);
+  }
 
   public PantheonFactoryConfigurationBuilder name(final String name) {
     this.name = name;
@@ -192,6 +200,7 @@ public class PantheonFactoryConfigurationBuilder {
         devMode,
         genesisConfigProvider,
         p2pEnabled,
+        networkingConfiguration,
         discoveryEnabled,
         bootnodeEligible,
         plugins,

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonNodeFactory.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonNodeFactory.java
@@ -44,6 +44,7 @@ public class PantheonNodeFactory {
         config.isDevMode(),
         config.getGenesisConfigProvider(),
         config.isP2pEnabled(),
+        config.getNetworkingConfiguration(),
         config.isDiscoveryEnabled(),
         config.isBootnodeEligible(),
         config.getPlugins(),

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/privacy/PrivacyPantheonFactoryConfiguration.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/privacy/PrivacyPantheonFactoryConfiguration.java
@@ -17,6 +17,7 @@ import tech.pegasys.pantheon.ethereum.core.MiningParameters;
 import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
 import tech.pegasys.pantheon.ethereum.jsonrpc.JsonRpcConfiguration;
 import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
+import tech.pegasys.pantheon.ethereum.p2p.config.NetworkingConfiguration;
 import tech.pegasys.pantheon.ethereum.permissioning.PermissioningConfiguration;
 import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 import tech.pegasys.pantheon.tests.acceptance.dsl.node.configuration.PantheonFactoryConfiguration;
@@ -41,6 +42,7 @@ public class PrivacyPantheonFactoryConfiguration extends PantheonFactoryConfigur
       final boolean devMode,
       final GenesisConfigurationProvider genesisConfigProvider,
       final boolean p2pEnabled,
+      final NetworkingConfiguration networkingConfiguration,
       final boolean discoveryEnabled,
       final boolean bootnodeEligible,
       final List<String> plugins,
@@ -58,6 +60,7 @@ public class PrivacyPantheonFactoryConfiguration extends PantheonFactoryConfigur
         devMode,
         genesisConfigProvider,
         p2pEnabled,
+        networkingConfiguration,
         discoveryEnabled,
         bootnodeEligible,
         plugins,

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/privacy/PrivacyPantheonFactoryConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/privacy/PrivacyPantheonFactoryConfigurationBuilder.java
@@ -44,6 +44,7 @@ public class PrivacyPantheonFactoryConfigurationBuilder {
         config.isDevMode(),
         config.getGenesisConfigProvider(),
         config.isP2pEnabled(),
+        config.getNetworkingConfiguration(),
         config.isDiscoveryEnabled(),
         config.isBootnodeEligible(),
         config.getPlugins(),

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/privacy/PrivacyPantheonNodeFactory.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/privacy/PrivacyPantheonNodeFactory.java
@@ -40,6 +40,7 @@ public class PrivacyPantheonNodeFactory {
         config.isDevMode(),
         config.getGenesisConfigProvider(),
         config.isP2pEnabled(),
+        config.getNetworkingConfiguration(),
         config.isDiscoveryEnabled(),
         config.isBootnodeEligible(),
         config.getPlugins(),

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -22,6 +22,7 @@ import tech.pegasys.pantheon.ethereum.core.MiningParameters;
 import tech.pegasys.pantheon.ethereum.core.PrivacyParameters;
 import tech.pegasys.pantheon.ethereum.jsonrpc.JsonRpcConfiguration;
 import tech.pegasys.pantheon.ethereum.jsonrpc.websocket.WebSocketConfiguration;
+import tech.pegasys.pantheon.ethereum.p2p.config.NetworkingConfiguration;
 import tech.pegasys.pantheon.ethereum.permissioning.PermissioningConfiguration;
 import tech.pegasys.pantheon.metrics.prometheus.MetricsConfiguration;
 import tech.pegasys.pantheon.tests.acceptance.dsl.node.PantheonNode;
@@ -55,6 +56,7 @@ public class PrivacyNode extends PantheonNode {
       final boolean devMode,
       final GenesisConfigurationProvider genesisConfigProvider,
       final boolean p2pEnabled,
+      final NetworkingConfiguration networkingConfiguration,
       final boolean discoveryEnabled,
       final boolean bootnodeEligible,
       final List<String> plugins,
@@ -73,6 +75,7 @@ public class PrivacyNode extends PantheonNode {
         devMode,
         genesisConfigProvider,
         p2pEnabled,
+        networkingConfiguration,
         discoveryEnabled,
         bootnodeEligible,
         plugins,

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/config/NetworkingConfiguration.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/config/NetworkingConfiguration.java
@@ -12,13 +12,19 @@
  */
 package tech.pegasys.pantheon.ethereum.p2p.config;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.Objects;
 
 public class NetworkingConfiguration {
+  public static final int DEFAULT_INITIATE_CONNECTIONS_FREQUENCY_SEC = 30;
+  public static final int DEFAULT_CHECK_MAINTAINED_CONNECTSION_FREQUENCY_SEC = 60;
+
   private DiscoveryConfiguration discovery = new DiscoveryConfiguration();
   private RlpxConfiguration rlpx = new RlpxConfiguration();
-
-  private NetworkingConfiguration() {}
+  private int initiateConnectionsFrequencySec = DEFAULT_INITIATE_CONNECTIONS_FREQUENCY_SEC;
+  private int checkMaintainedConnectionsFrequencySec =
+      DEFAULT_CHECK_MAINTAINED_CONNECTSION_FREQUENCY_SEC;
 
   public static NetworkingConfiguration create() {
     return new NetworkingConfiguration();
@@ -39,6 +45,28 @@ public class NetworkingConfiguration {
 
   public NetworkingConfiguration setRlpx(final RlpxConfiguration rlpx) {
     this.rlpx = rlpx;
+    return this;
+  }
+
+  public int getInitiateConnectionsFrequencySec() {
+    return initiateConnectionsFrequencySec;
+  }
+
+  public NetworkingConfiguration setInitiateConnectionsFrequency(
+      final int initiateConnectionsFrequency) {
+    checkArgument(initiateConnectionsFrequency > 0);
+    this.initiateConnectionsFrequencySec = initiateConnectionsFrequency;
+    return this;
+  }
+
+  public int getCheckMaintainedConnectionsFrequencySec() {
+    return checkMaintainedConnectionsFrequencySec;
+  }
+
+  public NetworkingConfiguration setCheckMaintainedConnectionsFrequency(
+      final int checkMaintainedConnectionsFrequency) {
+    checkArgument(checkMaintainedConnectionsFrequency > 0);
+    this.checkMaintainedConnectionsFrequencySec = checkMaintainedConnectionsFrequency;
     return this;
   }
 

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -181,10 +181,14 @@ public class DefaultP2PNetwork implements P2PNetwork {
     peerBondedObserverId =
         OptionalLong.of(peerDiscoveryAgent.observePeerBondedEvents(this::handlePeerBondedEvent));
 
+    // Periodically check maintained connections
+    final int checkMaintainedConnectionsSec = config.getCheckMaintainedConnectionsFrequencySec();
     peerConnectionScheduler.scheduleWithFixedDelay(
-        this::checkMaintainedConnectionPeers, 2, 60, TimeUnit.SECONDS);
+        this::checkMaintainedConnectionPeers, 2, checkMaintainedConnectionsSec, TimeUnit.SECONDS);
+    // Periodically initiate outgoing connections to discovered peers
+    final int checkConnectionsSec = config.getInitiateConnectionsFrequencySec();
     peerConnectionScheduler.scheduleWithFixedDelay(
-        this::attemptPeerConnections, 30, 30, TimeUnit.SECONDS);
+        this::attemptPeerConnections, checkConnectionsSec, checkConnectionsSec, TimeUnit.SECONDS);
   }
 
   @Override

--- a/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
@@ -105,6 +105,7 @@ public class RunnerBuilder {
   private Vertx vertx;
   private PantheonController<?> pantheonController;
 
+  private NetworkingConfiguration networkingConfiguration = NetworkingConfiguration.create();
   private Collection<BytesValue> bannedNodeIds = new ArrayList<>();
   private boolean p2pEnabled = true;
   private boolean discovery;
@@ -144,6 +145,12 @@ public class RunnerBuilder {
 
   public RunnerBuilder ethNetworkConfig(final EthNetworkConfig ethNetworkConfig) {
     this.ethNetworkConfig = ethNetworkConfig;
+    return this;
+  }
+
+  public RunnerBuilder networkingConfiguration(
+      final NetworkingConfiguration networkingConfiguration) {
+    this.networkingConfiguration = networkingConfiguration;
     return this;
   }
 
@@ -250,10 +257,7 @@ public class RunnerBuilder {
             .setMaxPeers(maxPeers)
             .setSupportedProtocols(subProtocols)
             .setClientId(PantheonInfo.version());
-    final NetworkingConfiguration networkConfig =
-        NetworkingConfiguration.create()
-            .setRlpx(rlpxConfiguration)
-            .setDiscovery(discoveryConfiguration);
+    networkingConfiguration.setRlpx(rlpxConfiguration).setDiscovery(discoveryConfiguration);
 
     final PeerPermissionsBlacklist bannedNodes = PeerPermissionsBlacklist.create();
     bannedNodeIds.forEach(bannedNodes::add);
@@ -283,7 +287,7 @@ public class RunnerBuilder {
             DefaultP2PNetwork.builder()
                 .vertx(vertx)
                 .keyPair(keyPair)
-                .config(networkConfig)
+                .config(networkingConfiguration)
                 .peerPermissions(peerPermissions)
                 .metricsSystem(metricsSystem)
                 .supportedCapabilities(caps)

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -40,6 +40,7 @@ import tech.pegasys.pantheon.cli.custom.JsonRPCWhitelistHostsProperty;
 import tech.pegasys.pantheon.cli.custom.RpcAuthFileValidator;
 import tech.pegasys.pantheon.cli.error.PantheonExceptionHandler;
 import tech.pegasys.pantheon.cli.options.EthProtocolOptions;
+import tech.pegasys.pantheon.cli.options.NetworkingOptions;
 import tech.pegasys.pantheon.cli.options.RocksDBOptions;
 import tech.pegasys.pantheon.cli.options.SynchronizerOptions;
 import tech.pegasys.pantheon.cli.options.TransactionPoolOptions;
@@ -150,6 +151,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
 
   private final BlockImporter blockImporter;
 
+  final NetworkingOptions networkingOptions = NetworkingOptions.create();
   final SynchronizerOptions synchronizerOptions = SynchronizerOptions.create();
   final EthProtocolOptions ethProtocolOptions = EthProtocolOptions.create();
   final RocksDBOptions rocksDBOptions = RocksDBOptions.create();
@@ -676,6 +678,8 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
     UnstableOptionsSubCommand.createUnstableOptions(
         commandLine,
         ImmutableMap.of(
+            "P2P Network",
+            networkingOptions,
             "Synchronizer",
             synchronizerOptions,
             "RocksDB",
@@ -1143,6 +1147,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
             .p2pAdvertisedHost(p2pAdvertisedHost)
             .p2pListenPort(p2pListenPort)
             .maxPeers(maxPeers)
+            .networkingConfiguration(networkingOptions.toDomainObject())
             .graphQLConfiguration(graphQLConfiguration)
             .jsonRpcConfiguration(jsonRpcConfiguration)
             .webSocketConfiguration(webSocketConfiguration)

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/options/NetworkingOptions.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/options/NetworkingOptions.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.cli.options;
+
+import tech.pegasys.pantheon.ethereum.p2p.config.NetworkingConfiguration;
+
+import java.util.Arrays;
+import java.util.List;
+
+import picocli.CommandLine;
+
+public class NetworkingOptions implements CLIOptions<NetworkingConfiguration> {
+  private final String INITIATE_CONNECTIONS_FREQUENCY_FLAG =
+      "--Xp2p-initiate-connections-frequency";
+  private final String CHECK_MAINTAINED_CONNECTIONS_FREQUENCY_FLAG =
+      "--Xp2p-check-maintained-connections-frequency";
+
+  @CommandLine.Option(
+      names = INITIATE_CONNECTIONS_FREQUENCY_FLAG,
+      hidden = true,
+      defaultValue = "30",
+      paramLabel = "<INTEGER>",
+      description =
+          "The frequency (in seconds) at which to initiate new outgoing connections (default: ${DEFAULT-VALUE})")
+  private int initiateConnectionsFrequencySec =
+      NetworkingConfiguration.DEFAULT_INITIATE_CONNECTIONS_FREQUENCY_SEC;
+
+  @CommandLine.Option(
+      names = CHECK_MAINTAINED_CONNECTIONS_FREQUENCY_FLAG,
+      hidden = true,
+      defaultValue = "60",
+      paramLabel = "<INTEGER>",
+      description =
+          "The frequency (in seconds) at which to check maintained connections (default: ${DEFAULT-VALUE})")
+  private int checkMaintainedConnectionsFrequencySec =
+      NetworkingConfiguration.DEFAULT_CHECK_MAINTAINED_CONNECTSION_FREQUENCY_SEC;
+
+  private NetworkingOptions() {}
+
+  public static NetworkingOptions create() {
+    return new NetworkingOptions();
+  }
+
+  public static NetworkingOptions fromConfig(final NetworkingConfiguration networkingConfig) {
+    final NetworkingOptions cliOptions = new NetworkingOptions();
+    cliOptions.checkMaintainedConnectionsFrequencySec =
+        networkingConfig.getCheckMaintainedConnectionsFrequencySec();
+    cliOptions.initiateConnectionsFrequencySec =
+        networkingConfig.getInitiateConnectionsFrequencySec();
+    return cliOptions;
+  }
+
+  @Override
+  public NetworkingConfiguration toDomainObject() {
+    NetworkingConfiguration config = NetworkingConfiguration.create();
+    config.setCheckMaintainedConnectionsFrequency(checkMaintainedConnectionsFrequencySec);
+    config.setInitiateConnectionsFrequency(initiateConnectionsFrequencySec);
+    return config;
+  }
+
+  @Override
+  public List<String> getCLIOptions() {
+    return Arrays.asList(
+        CHECK_MAINTAINED_CONNECTIONS_FREQUENCY_FLAG,
+        OptionParser.format(checkMaintainedConnectionsFrequencySec),
+        INITIATE_CONNECTIONS_FREQUENCY_FLAG,
+        OptionParser.format(initiateConnectionsFrequencySec));
+  }
+}

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
@@ -24,6 +24,7 @@ import tech.pegasys.pantheon.Runner;
 import tech.pegasys.pantheon.RunnerBuilder;
 import tech.pegasys.pantheon.cli.config.EthNetworkConfig;
 import tech.pegasys.pantheon.cli.options.EthProtocolOptions;
+import tech.pegasys.pantheon.cli.options.NetworkingOptions;
 import tech.pegasys.pantheon.cli.options.RocksDBOptions;
 import tech.pegasys.pantheon.cli.options.SynchronizerOptions;
 import tech.pegasys.pantheon.cli.options.TransactionPoolOptions;
@@ -153,6 +154,7 @@ public abstract class CommandTestAbstract {
     when(mockRunnerBuilder.pantheonController(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.discovery(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.ethNetworkConfig(any())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.networkingConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.p2pAdvertisedHost(anyString())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.p2pListenPort(anyInt())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.maxPeers(anyInt())).thenReturn(mockRunnerBuilder);
@@ -255,6 +257,10 @@ public abstract class CommandTestAbstract {
 
     public RocksDBOptions getRocksDBOptions() {
       return rocksDBOptions;
+    }
+
+    public NetworkingOptions getNetworkingOptions() {
+      return networkingOptions;
     }
 
     public SynchronizerOptions getSynchronizerOptions() {

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/options/NetworkingOptionsTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/options/NetworkingOptionsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.cli.options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.pantheon.ethereum.p2p.config.NetworkingConfiguration;
+
+import org.junit.Test;
+
+public class NetworkingOptionsTest
+    extends AbstractCLIOptionsTest<NetworkingConfiguration, NetworkingOptions> {
+
+  @Test
+  public void checkMaintainedConnectionsFrequencyFlag_isSet() {
+    final TestPantheonCommand cmd =
+        parseCommand("--Xp2p-check-maintained-connections-frequency", "2");
+
+    final NetworkingOptions options = cmd.getNetworkingOptions();
+    final NetworkingConfiguration networkingConfig = options.toDomainObject();
+    assertThat(networkingConfig.getCheckMaintainedConnectionsFrequencySec()).isEqualTo(2);
+
+    assertThat(commandErrorOutput.toString()).isEmpty();
+    assertThat(commandOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void checkMaintainedFrequencyConnectionsFlag_isNotSet() {
+    final TestPantheonCommand cmd = parseCommand();
+
+    final NetworkingOptions options = cmd.getNetworkingOptions();
+    final NetworkingConfiguration networkingConfig = options.toDomainObject();
+    assertThat(networkingConfig.getCheckMaintainedConnectionsFrequencySec()).isEqualTo(60);
+
+    assertThat(commandErrorOutput.toString()).isEmpty();
+    assertThat(commandOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void initiateConnectionsFrequencyFlag_isSet() {
+    final TestPantheonCommand cmd = parseCommand("--Xp2p-initiate-connections-frequency", "2");
+
+    final NetworkingOptions options = cmd.getNetworkingOptions();
+    final NetworkingConfiguration networkingConfig = options.toDomainObject();
+    assertThat(networkingConfig.getInitiateConnectionsFrequencySec()).isEqualTo(2);
+
+    assertThat(commandErrorOutput.toString()).isEmpty();
+    assertThat(commandOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void initiateConnectionsFrequencyFlag_isNotSet() {
+    final TestPantheonCommand cmd = parseCommand();
+
+    final NetworkingOptions options = cmd.getNetworkingOptions();
+    final NetworkingConfiguration networkingConfig = options.toDomainObject();
+    assertThat(networkingConfig.getInitiateConnectionsFrequencySec()).isEqualTo(30);
+
+    assertThat(commandErrorOutput.toString()).isEmpty();
+    assertThat(commandOutput.toString()).isEmpty();
+  }
+
+  @Override
+  NetworkingConfiguration createDefaultDomainObject() {
+    return NetworkingConfiguration.create();
+  }
+
+  @Override
+  NetworkingConfiguration createCustomizedDomainObject() {
+    final NetworkingConfiguration config = NetworkingConfiguration.create();
+    config.setInitiateConnectionsFrequency(
+        NetworkingConfiguration.DEFAULT_INITIATE_CONNECTIONS_FREQUENCY_SEC + 10);
+    config.setCheckMaintainedConnectionsFrequency(
+        NetworkingConfiguration.DEFAULT_CHECK_MAINTAINED_CONNECTSION_FREQUENCY_SEC + 10);
+    return config;
+  }
+
+  @Override
+  NetworkingOptions optionsFromDomainObject(final NetworkingConfiguration domainObject) {
+    return NetworkingOptions.fromConfig(domainObject);
+  }
+
+  @Override
+  NetworkingOptions getOptionsFromPantheonCommand(final TestPantheonCommand pantheonCommand) {
+    return pantheonCommand.getNetworkingOptions();
+  }
+}


### PR DESCRIPTION
## PR description
Try to cut down on intermittent acceptance tests failures by retrying connections more frequently during acceptance tests:
* Add experimental option for setting the frequency of network checks
* Use these experimental options to modify acceptance test configuration