### PR TITLE
[PAN-1683] Exempt static nodes from all connection limits

### DIFF
--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfiguration.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfiguration.java
@@ -85,18 +85,10 @@ public class RlpxConfiguration {
     return this;
   }
 
-  public boolean isLimitRemoteWireConnectionsEnabled() {
-    return limitRemoteWireConnectionsEnabled;
-  }
-
   public RlpxConfiguration setLimitRemoteWireConnectionsEnabled(
       final boolean limitRemoteWireConnectionsEnabled) {
     this.limitRemoteWireConnectionsEnabled = limitRemoteWireConnectionsEnabled;
     return this;
-  }
-
-  public double getFractionRemoteWireConnectionsAllowed() {
-    return fractionRemoteWireConnectionsAllowed;
   }
 
   public RlpxConfiguration setFractionRemoteWireConnectionsAllowed(
@@ -106,6 +98,14 @@ public class RlpxConfiguration {
         "Fraction of remote connections allowed must be between 0.0 and 1.0 (inclusive).");
     this.fractionRemoteWireConnectionsAllowed = fractionRemoteWireConnectionsAllowed;
     return this;
+  }
+
+  public int getMaxRemotelyInitiatedConnections() {
+    if (!limitRemoteWireConnectionsEnabled) {
+      return maxPeers;
+    }
+
+    return (int) Math.floor(maxPeers * fractionRemoteWireConnectionsAllowed);
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -23,13 +23,13 @@ import tech.pegasys.pantheon.ethereum.p2p.discovery.PeerDiscoveryAgent;
 import tech.pegasys.pantheon.ethereum.p2p.discovery.PeerDiscoveryEvent.PeerBondedEvent;
 import tech.pegasys.pantheon.ethereum.p2p.discovery.PeerDiscoveryStatus;
 import tech.pegasys.pantheon.ethereum.p2p.discovery.VertxPeerDiscoveryAgent;
-import tech.pegasys.pantheon.ethereum.p2p.peers.DefaultPeerProperties;
+import tech.pegasys.pantheon.ethereum.p2p.peers.DefaultPeerPrivileges;
 import tech.pegasys.pantheon.ethereum.p2p.peers.EnodeURL;
 import tech.pegasys.pantheon.ethereum.p2p.peers.LocalNode;
 import tech.pegasys.pantheon.ethereum.p2p.peers.MaintainedPeers;
 import tech.pegasys.pantheon.ethereum.p2p.peers.MutableLocalNode;
 import tech.pegasys.pantheon.ethereum.p2p.peers.Peer;
-import tech.pegasys.pantheon.ethereum.p2p.peers.PeerProperties;
+import tech.pegasys.pantheon.ethereum.p2p.peers.PeerPrivileges;
 import tech.pegasys.pantheon.ethereum.p2p.permissions.PeerPermissions;
 import tech.pegasys.pantheon.ethereum.p2p.permissions.PeerPermissionsBlacklist;
 import tech.pegasys.pantheon.ethereum.p2p.rlpx.ConnectCallback;
@@ -424,9 +424,9 @@ public class DefaultP2PNetwork implements P2PNetwork {
 
       final MutableLocalNode localNode =
           MutableLocalNode.create(config.getRlpx().getClientId(), 5, supportedCapabilities);
-      final PeerProperties peerProperties = new DefaultPeerProperties(maintainedPeers);
+      final PeerPrivileges peerPrivileges = new DefaultPeerPrivileges(maintainedPeers);
       peerDiscoveryAgent = peerDiscoveryAgent == null ? createDiscoveryAgent() : peerDiscoveryAgent;
-      rlpxAgent = rlpxAgent == null ? createRlpxAgent(localNode, peerProperties) : rlpxAgent;
+      rlpxAgent = rlpxAgent == null ? createRlpxAgent(localNode, peerPrivileges) : rlpxAgent;
 
       return new DefaultP2PNetwork(
           localNode,
@@ -457,12 +457,12 @@ public class DefaultP2PNetwork implements P2PNetwork {
     }
 
     private RlpxAgent createRlpxAgent(
-        final LocalNode localNode, final PeerProperties peerProperties) {
+        final LocalNode localNode, final PeerPrivileges peerPrivileges) {
       return RlpxAgent.builder()
           .keyPair(keyPair)
           .config(config.getRlpx())
           .peerPermissions(peerPermissions)
-          .peerProperties(peerProperties)
+          .peerPrivileges(peerPrivileges)
           .localNode(localNode)
           .metricsSystem(metricsSystem)
           .build();

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/DefaultPeerPrivileges.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/DefaultPeerPrivileges.java
@@ -12,15 +12,20 @@
  */
 package tech.pegasys.pantheon.ethereum.p2p.peers;
 
-public class DefaultPeerProperties implements PeerProperties {
-  final MaintainedPeers maintainedPeers;
+public class DefaultPeerPrivileges implements PeerPrivileges {
+  private final MaintainedPeers maintainedPeers;
 
-  public DefaultPeerProperties(final MaintainedPeers maintainedPeers) {
+  public DefaultPeerPrivileges(final MaintainedPeers maintainedPeers) {
     this.maintainedPeers = maintainedPeers;
   }
 
   @Override
-  public boolean ignoreMaxPeerLimits(final Peer peer) {
+  public boolean canExceedMaxPeerLimits(final Peer peer) {
+    return maintainedPeers.contains(peer);
+  }
+
+  @Override
+  public boolean canExceedRemoteConnectionLimits(final Peer peer) {
     return maintainedPeers.contains(peer);
   }
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/DefaultPeerPrivileges.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/DefaultPeerPrivileges.java
@@ -20,12 +20,7 @@ public class DefaultPeerPrivileges implements PeerPrivileges {
   }
 
   @Override
-  public boolean canExceedMaxPeerLimits(final Peer peer) {
-    return maintainedPeers.contains(peer);
-  }
-
-  @Override
-  public boolean canExceedRemoteConnectionLimits(final Peer peer) {
+  public boolean canExceedConnectionLimits(final Peer peer) {
     return maintainedPeers.contains(peer);
   }
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerPrivileges.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerPrivileges.java
@@ -15,21 +15,11 @@ package tech.pegasys.pantheon.ethereum.p2p.peers;
 public interface PeerPrivileges {
 
   /**
-   * If true, the given peer can connect or remain connected even if the max connection limit has
-   * been reached or exceeded.
+   * If true, the given peer can connect or remain connected even if the max connection limit or the
+   * maximum remote connection limit has been reached or exceeded.
    *
    * @param peer The peer to be checked.
-   * @return {@code true} if the peer should be allowed to connect regardless of max peer limits.
+   * @return {@code true} if the peer should be allowed to connect regardless of connection limits.
    */
-  boolean canExceedMaxPeerLimits(final Peer peer);
-
-  /**
-   * If true, the given peer can initiate an incoming connection even if the remote connection limit
-   * has been reached.
-   *
-   * @param peer The peer to be checked.
-   * @return {@code true} if the peer should be allowed to connect regardless of remote connection
-   *     limits.
-   */
-  boolean canExceedRemoteConnectionLimits(final Peer peer);
+  boolean canExceedConnectionLimits(final Peer peer);
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerPrivileges.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/peers/PeerPrivileges.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.pantheon.ethereum.p2p.peers;
 
-public interface PeerProperties {
+public interface PeerPrivileges {
 
   /**
    * If true, the given peer can connect or remain connected even if the max connection limit has
@@ -21,5 +21,15 @@ public interface PeerProperties {
    * @param peer The peer to be checked.
    * @return {@code true} if the peer should be allowed to connect regardless of max peer limits.
    */
-  boolean ignoreMaxPeerLimits(final Peer peer);
+  boolean canExceedMaxPeerLimits(final Peer peer);
+
+  /**
+   * If true, the given peer can initiate an incoming connection even if the remote connection limit
+   * has been reached.
+   *
+   * @param peer The peer to be checked.
+   * @return {@code true} if the peer should be allowed to connect regardless of remote connection
+   *     limits.
+   */
+  boolean canExceedRemoteConnectionLimits(final Peer peer);
 }

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgent.java
@@ -384,12 +384,12 @@ public class RlpxAgent {
     enforceConnectionLimits();
   }
 
-  private boolean limitRemoteWireConnectionsEnabled() {
+  private boolean shouldLimitRemoteConnections() {
     return maxRemotelyInitiatedConnections < maxConnections;
   }
 
   private boolean remoteConnectionLimitReached() {
-    return limitRemoteWireConnectionsEnabled()
+    return shouldLimitRemoteConnections()
         && countUntrustedRemotelyInitiatedConnections() >= maxRemotelyInitiatedConnections;
   }
 
@@ -402,7 +402,7 @@ public class RlpxAgent {
   }
 
   private void enforceRemoteConnectionLimits() {
-    if (!limitRemoteWireConnectionsEnabled()
+    if (!shouldLimitRemoteConnections()
         || connectionsById.size() < maxRemotelyInitiatedConnections) {
       // Nothing to do
       return;

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfigurationTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfigurationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.pantheon.ethereum.p2p.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class RlpxConfigurationTest {
+
+  @Test
+  public void getMaxRemotelyInitiatedConnections_remoteLimitsDisabled() {
+    final RlpxConfiguration config =
+        RlpxConfiguration.create()
+            .setFractionRemoteWireConnectionsAllowed(.5)
+            .setLimitRemoteWireConnectionsEnabled(false)
+            .setMaxPeers(20);
+
+    assertThat(config.getMaxRemotelyInitiatedConnections()).isEqualTo(20);
+  }
+
+  @Test
+  public void getMaxRemotelyInitiatedConnections_remoteLimitsEnabled() {
+    final RlpxConfiguration config =
+        RlpxConfiguration.create()
+            .setFractionRemoteWireConnectionsAllowed(.5)
+            .setLimitRemoteWireConnectionsEnabled(true)
+            .setMaxPeers(20);
+
+    assertThat(config.getMaxRemotelyInitiatedConnections()).isEqualTo(10);
+  }
+
+  @Test
+  public void getMaxRemotelyInitiatedConnections_remoteLimitsEnabledWithNonIntegerRatio() {
+    final RlpxConfiguration config =
+        RlpxConfiguration.create()
+            .setFractionRemoteWireConnectionsAllowed(.50)
+            .setLimitRemoteWireConnectionsEnabled(true)
+            .setMaxPeers(25);
+
+    assertThat(config.getMaxRemotelyInitiatedConnections()).isEqualTo(12);
+  }
+
+  @Test
+  public void getMaxRemotelyInitiatedConnections_remoteLimitsEnabledRoundsToZero() {
+    final RlpxConfiguration config =
+        RlpxConfiguration.create()
+            .setFractionRemoteWireConnectionsAllowed(.5)
+            .setLimitRemoteWireConnectionsEnabled(true)
+            .setMaxPeers(1);
+
+    assertThat(config.getMaxRemotelyInitiatedConnections()).isEqualTo(0);
+  }
+}

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeersTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/peers/MaintainedPeersTest.java
@@ -14,6 +14,7 @@ package tech.pegasys.pantheon.ethereum.p2p.peers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static tech.pegasys.pantheon.ethereum.p2p.peers.PeerTestHelper.enodeBuilder;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -126,6 +127,18 @@ public class MaintainedPeersTest {
   }
 
   @Test
+  public void contains() {
+    final Peer peerA = createPeer();
+    final Peer peerAClone = DefaultPeer.fromEnodeURL(peerA.getEnodeURL());
+    final Peer peerB = createPeer();
+
+    maintainedPeers.add(peerA);
+    assertThat(maintainedPeers.contains(peerA)).isTrue();
+    assertThat(maintainedPeers.contains(peerAClone)).isTrue();
+    assertThat(maintainedPeers.contains(peerB)).isFalse();
+  }
+
+  @Test
   public void stream_empty() {
     final List<Peer> peers = maintainedPeers.streamPeers().collect(Collectors.toList());
     assertThat(peers).isEmpty();
@@ -137,9 +150,5 @@ public class MaintainedPeersTest {
 
   private Peer nonListeningPeer() {
     return DefaultPeer.fromEnodeURL(enodeBuilder().disableListening().build());
-  }
-
-  private EnodeURL.Builder enodeBuilder() {
-    return EnodeURL.builder().ipAddress("127.0.0.1").useDefaultPorts().nodeId(Peer.randomId());
   }
 }

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -78,8 +78,7 @@ public class RlpxAgentTest {
   @Before
   public void setup() {
     // Set basic defaults
-    when(peerPrivileges.canExceedMaxPeerLimits(any())).thenReturn(false);
-    when(peerPrivileges.canExceedRemoteConnectionLimits(any())).thenReturn(false);
+    when(peerPrivileges.canExceedConnectionLimits(any())).thenReturn(false);
     config.setMaxPeers(5);
   }
 
@@ -459,8 +458,7 @@ public class RlpxAgentTest {
     assertThat(agent.getConnectionCount()).isEqualTo(maxRemotePeers);
 
     final Peer privilegedPeer = createPeer();
-    when(peerPrivileges.canExceedRemoteConnectionLimits(privilegedPeer)).thenReturn(true);
-    when(peerPrivileges.canExceedMaxPeerLimits(privilegedPeer)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(privilegedPeer)).thenReturn(true);
     final MockPeerConnection privilegedConnection = connection(privilegedPeer);
     connectionInitializer.simulateIncomingConnection(privilegedConnection);
     assertThat(privilegedConnection.isDisconnected()).isFalse();
@@ -491,7 +489,7 @@ public class RlpxAgentTest {
         (MockPeerConnection) existingConnectionFuture.get();
 
     final Peer peer = createPeer();
-    when(peerPrivileges.canExceedMaxPeerLimits(peer)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(peer)).thenReturn(true);
     final CompletableFuture<PeerConnection> connection = agent.connect(peer);
     connectionInitializer.completePendingFutures();
 
@@ -514,8 +512,8 @@ public class RlpxAgentTest {
     startAgentWithMaxPeers(1);
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerPrivileges.canExceedMaxPeerLimits(peerA)).thenReturn(true);
-    when(peerPrivileges.canExceedMaxPeerLimits(peerB)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(peerA)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(peerB)).thenReturn(true);
 
     // Saturate connections
     final CompletableFuture<PeerConnection> existingConnection = agent.connect(peerA);
@@ -539,8 +537,7 @@ public class RlpxAgentTest {
       throws ExecutionException, InterruptedException {
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerPrivileges.canExceedMaxPeerLimits(peerB)).thenReturn(true);
-    when(peerPrivileges.canExceedRemoteConnectionLimits(peerB)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(peerB)).thenReturn(true);
 
     // Saturate connections
     startAgentWithMaxPeers(1);
@@ -567,7 +564,7 @@ public class RlpxAgentTest {
       throws ExecutionException, InterruptedException {
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerPrivileges.canExceedMaxPeerLimits(peerA)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(peerA)).thenReturn(true);
 
     // Saturate connections
     startAgentWithMaxPeers(1);
@@ -594,9 +591,8 @@ public class RlpxAgentTest {
       throws ExecutionException, InterruptedException {
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerPrivileges.canExceedMaxPeerLimits(peerA)).thenReturn(true);
-    when(peerPrivileges.canExceedMaxPeerLimits(peerB)).thenReturn(true);
-    when(peerPrivileges.canExceedRemoteConnectionLimits(peerB)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(peerA)).thenReturn(true);
+    when(peerPrivileges.canExceedConnectionLimits(peerB)).thenReturn(true);
 
     // Saturate connections
     startAgentWithMaxPeers(1);

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -34,7 +34,7 @@ import tech.pegasys.pantheon.ethereum.p2p.peers.DefaultPeer;
 import tech.pegasys.pantheon.ethereum.p2p.peers.EnodeURL;
 import tech.pegasys.pantheon.ethereum.p2p.peers.MutableLocalNode;
 import tech.pegasys.pantheon.ethereum.p2p.peers.Peer;
-import tech.pegasys.pantheon.ethereum.p2p.peers.PeerProperties;
+import tech.pegasys.pantheon.ethereum.p2p.peers.PeerPrivileges;
 import tech.pegasys.pantheon.ethereum.p2p.peers.PeerTestHelper;
 import tech.pegasys.pantheon.ethereum.p2p.permissions.PeerPermissions;
 import tech.pegasys.pantheon.ethereum.p2p.permissions.PeerPermissions.Action;
@@ -68,7 +68,7 @@ public class RlpxAgentTest {
   private static final KeyPair KEY_PAIR = KeyPair.generate();
   private final RlpxConfiguration config = RlpxConfiguration.create();
   private final TestPeerPermissions peerPermissions = spy(new TestPeerPermissions());
-  private final PeerProperties peerProperties = mock(PeerProperties.class);
+  private final PeerPrivileges peerPrivileges = mock(PeerPrivileges.class);
   private final MutableLocalNode localNode = createMutableLocalNode();
   private final MetricsSystem metrics = new NoOpMetricsSystem();
   private final PeerConnectionEvents peerConnectionEvents = new PeerConnectionEvents(metrics);
@@ -79,7 +79,8 @@ public class RlpxAgentTest {
   @Before
   public void setup() {
     // Set basic defaults
-    when(peerProperties.ignoreMaxPeerLimits(any())).thenReturn(false);
+    when(peerPrivileges.canExceedMaxPeerLimits(any())).thenReturn(false);
+    when(peerPrivileges.canExceedRemoteConnectionLimits(any())).thenReturn(false);
     config.setMaxPeers(5);
   }
 
@@ -454,7 +455,7 @@ public class RlpxAgentTest {
         (MockPeerConnection) existingConnectionFuture.get();
 
     final Peer peer = createPeer();
-    when(peerProperties.ignoreMaxPeerLimits(peer)).thenReturn(true);
+    when(peerPrivileges.canExceedMaxPeerLimits(peer)).thenReturn(true);
     final CompletableFuture<PeerConnection> connection = agent.connect(peer);
     connectionInitializer.completePendingFutures();
 
@@ -477,8 +478,8 @@ public class RlpxAgentTest {
     startAgentWithMaxPeers(1);
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerProperties.ignoreMaxPeerLimits(peerA)).thenReturn(true);
-    when(peerProperties.ignoreMaxPeerLimits(peerB)).thenReturn(true);
+    when(peerPrivileges.canExceedMaxPeerLimits(peerA)).thenReturn(true);
+    when(peerPrivileges.canExceedMaxPeerLimits(peerB)).thenReturn(true);
 
     // Saturate connections
     final CompletableFuture<PeerConnection> existingConnection = agent.connect(peerA);
@@ -503,7 +504,7 @@ public class RlpxAgentTest {
       throws ExecutionException, InterruptedException {
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerProperties.ignoreMaxPeerLimits(peerB)).thenReturn(true);
+    when(peerPrivileges.canExceedMaxPeerLimits(peerB)).thenReturn(true);
 
     // Saturate connections
     startAgentWithMaxPeers(1);
@@ -530,7 +531,7 @@ public class RlpxAgentTest {
       throws ExecutionException, InterruptedException {
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerProperties.ignoreMaxPeerLimits(peerA)).thenReturn(true);
+    when(peerPrivileges.canExceedMaxPeerLimits(peerA)).thenReturn(true);
 
     // Saturate connections
     startAgentWithMaxPeers(1);
@@ -558,8 +559,8 @@ public class RlpxAgentTest {
       throws ExecutionException, InterruptedException {
     final Peer peerA = createPeer();
     final Peer peerB = createPeer();
-    when(peerProperties.ignoreMaxPeerLimits(peerA)).thenReturn(true);
-    when(peerProperties.ignoreMaxPeerLimits(peerB)).thenReturn(true);
+    when(peerPrivileges.canExceedMaxPeerLimits(peerA)).thenReturn(true);
+    when(peerPrivileges.canExceedMaxPeerLimits(peerB)).thenReturn(true);
 
     // Saturate connections
     startAgentWithMaxPeers(1);
@@ -935,7 +936,7 @@ public class RlpxAgentTest {
         .keyPair(KEY_PAIR)
         .config(config)
         .peerPermissions(peerPermissions)
-        .peerProperties(peerProperties)
+        .peerPrivileges(peerPrivileges)
         .localNode(localNode)
         .metricsSystem(metrics)
         .connectionInitializer(connectionInitializer)


### PR DESCRIPTION
## PR description

This PR makes static nodes exempt from the max remote connections limit.  

Some other small changes include:
* Renaming `PeerProperties` to `PeerPrivileges`
* Reordering some of the fields in `RlpxAgent`
* Additional tests