### PR TITLE
[PAN-1683] Rework remote connection limit flag defaults

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/PantheonNode.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/PantheonNode.java
@@ -146,7 +146,6 @@ public class PantheonNode implements NodeConfiguration, RunnableNode, AutoClosea
     this.devMode = devMode;
     this.p2pEnabled = p2pEnabled;
     this.networkingConfiguration = networkingConfiguration;
-    this.getNetworkingConfiguration().getRlpx().setFractionRemoteWireConnectionsAllowed(1.0);
     this.discoveryEnabled = discoveryEnabled;
     plugins.forEach(
         pluginName -> {

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
@@ -146,7 +146,6 @@ public class ThreadPantheonNodeRunner implements PantheonNodeRunner {
             .p2pAdvertisedHost(node.getHostName())
             .p2pListenPort(0)
             .maxPeers(25)
-            .fractionRemoteConnectionsAllowed(1.0)
             .networkingConfiguration(node.getNetworkingConfiguration())
             .jsonRpcConfiguration(node.jsonRpcConfiguration())
             .webSocketConfiguration(node.webSocketConfiguration())

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonFactoryConfigurationBuilder.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/configuration/PantheonFactoryConfigurationBuilder.java
@@ -194,7 +194,6 @@ public class PantheonFactoryConfigurationBuilder {
   }
 
   public PantheonFactoryConfiguration build() {
-    networkingConfiguration.getRlpx().setFractionRemoteWireConnectionsAllowed(1.0);
     return new PantheonFactoryConfiguration(
         name,
         miningParameters,

--- a/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/tech/pegasys/pantheon/ethereum/eth/transactions/TestNode.java
@@ -90,8 +90,7 @@ public class TestNode implements Closeable {
             .setRlpx(
                 RlpxConfiguration.create()
                     .setBindPort(listenPort)
-                    .setSupportedProtocols(EthProtocol.get())
-                    .setFractionRemoteWireConnectionsAllowed(1.0));
+                    .setSupportedProtocols(EthProtocol.get()));
 
     final GenesisConfigFile genesisConfigFile = GenesisConfigFile.development();
     final ProtocolSchedule<Void> protocolSchedule =

--- a/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfiguration.java
+++ b/ethereum/p2p/src/main/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfiguration.java
@@ -22,13 +22,13 @@ import java.util.List;
 import java.util.Objects;
 
 public class RlpxConfiguration {
-  public static final float DEFAULT_FRACTION_REMOTE_CONNECTIONS_ALLOWED = 0.5f;
+  public static final float DEFAULT_FRACTION_REMOTE_CONNECTIONS_ALLOWED = 0.6f;
   private String clientId = "TestClient/1.0.0";
   private String bindHost = "0.0.0.0";
   private int bindPort = 30303;
   private int maxPeers = 25;
   private boolean limitRemoteWireConnectionsEnabled = false;
-  private double fractionRemoteWireConnectionsAllowed = DEFAULT_FRACTION_REMOTE_CONNECTIONS_ALLOWED;
+  private float fractionRemoteWireConnectionsAllowed = DEFAULT_FRACTION_REMOTE_CONNECTIONS_ALLOWED;
   private List<SubProtocol> supportedProtocols = Collections.emptyList();
 
   public static RlpxConfiguration create() {
@@ -92,7 +92,7 @@ public class RlpxConfiguration {
   }
 
   public RlpxConfiguration setFractionRemoteWireConnectionsAllowed(
-      final double fractionRemoteWireConnectionsAllowed) {
+      final float fractionRemoteWireConnectionsAllowed) {
     checkState(
         fractionRemoteWireConnectionsAllowed >= 0.0 && fractionRemoteWireConnectionsAllowed <= 1.0,
         "Fraction of remote connections allowed must be between 0.0 and 1.0 (inclusive).");

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfigurationTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/config/RlpxConfigurationTest.java
@@ -22,7 +22,7 @@ public class RlpxConfigurationTest {
   public void getMaxRemotelyInitiatedConnections_remoteLimitsDisabled() {
     final RlpxConfiguration config =
         RlpxConfiguration.create()
-            .setFractionRemoteWireConnectionsAllowed(.5)
+            .setFractionRemoteWireConnectionsAllowed(.5f)
             .setLimitRemoteWireConnectionsEnabled(false)
             .setMaxPeers(20);
 
@@ -33,7 +33,7 @@ public class RlpxConfigurationTest {
   public void getMaxRemotelyInitiatedConnections_remoteLimitsEnabled() {
     final RlpxConfiguration config =
         RlpxConfiguration.create()
-            .setFractionRemoteWireConnectionsAllowed(.5)
+            .setFractionRemoteWireConnectionsAllowed(.5f)
             .setLimitRemoteWireConnectionsEnabled(true)
             .setMaxPeers(20);
 
@@ -44,7 +44,7 @@ public class RlpxConfigurationTest {
   public void getMaxRemotelyInitiatedConnections_remoteLimitsEnabledWithNonIntegerRatio() {
     final RlpxConfiguration config =
         RlpxConfiguration.create()
-            .setFractionRemoteWireConnectionsAllowed(.50)
+            .setFractionRemoteWireConnectionsAllowed(.5f)
             .setLimitRemoteWireConnectionsEnabled(true)
             .setMaxPeers(25);
 
@@ -55,7 +55,7 @@ public class RlpxConfigurationTest {
   public void getMaxRemotelyInitiatedConnections_remoteLimitsEnabledRoundsToZero() {
     final RlpxConfiguration config =
         RlpxConfiguration.create()
-            .setFractionRemoteWireConnectionsAllowed(.5)
+            .setFractionRemoteWireConnectionsAllowed(.5f)
             .setLimitRemoteWireConnectionsEnabled(true)
             .setMaxPeers(1);
 

--- a/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/tech/pegasys/pantheon/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -323,7 +323,7 @@ public class RlpxAgentTest {
   public void incomingConnection_afterMaxRemotelyInitiatedConnectionsHaveBeenEstablished() {
     final int maxPeers = 10;
     final int maxRemotePeers = 8;
-    final double maxRemotePeersFraction = (double) maxRemotePeers / (double) maxPeers;
+    final float maxRemotePeersFraction = (float) maxRemotePeers / (float) maxPeers;
     config.setLimitRemoteWireConnectionsEnabled(true);
     config.setFractionRemoteWireConnectionsAllowed(maxRemotePeersFraction);
     startAgentWithMaxPeers(maxPeers);
@@ -347,7 +347,7 @@ public class RlpxAgentTest {
   public void connect_afterMaxRemotelyInitiatedConnectionsHaveBeenEstablished() {
     final int maxPeers = 10;
     final int maxRemotePeers = 8;
-    final double maxRemotePeersFraction = (double) maxRemotePeers / (double) maxPeers;
+    final float maxRemotePeersFraction = (float) maxRemotePeers / (float) maxPeers;
     config.setLimitRemoteWireConnectionsEnabled(true);
     config.setFractionRemoteWireConnectionsAllowed(maxRemotePeersFraction);
     startAgentWithMaxPeers(maxPeers);
@@ -373,7 +373,7 @@ public class RlpxAgentTest {
   @Test
   public void incomingConnection_withMaxRemotelyInitiatedConnectionsAt100Percent() {
     final int maxPeers = 10;
-    final double maxRemotePeersFraction = 1.0;
+    final float maxRemotePeersFraction = 1.0f;
     config.setLimitRemoteWireConnectionsEnabled(true);
     config.setFractionRemoteWireConnectionsAllowed(maxRemotePeersFraction);
     startAgentWithMaxPeers(maxPeers);
@@ -390,7 +390,7 @@ public class RlpxAgentTest {
   @Test
   public void connect_withMaxRemotelyInitiatedConnectionsAt100Percent() {
     final int maxPeers = 10;
-    final double maxRemotePeersFraction = 1.0;
+    final float maxRemotePeersFraction = 1.0f;
     config.setLimitRemoteWireConnectionsEnabled(true);
     config.setFractionRemoteWireConnectionsAllowed(maxRemotePeersFraction);
     startAgentWithMaxPeers(maxPeers);
@@ -408,7 +408,7 @@ public class RlpxAgentTest {
   @Test
   public void incomingConnection_withMaxRemotelyInitiatedConnectionsAtZeroPercent() {
     final int maxPeers = 10;
-    final double maxRemotePeersFraction = 0.0;
+    final float maxRemotePeersFraction = 0.0f;
     config.setLimitRemoteWireConnectionsEnabled(true);
     config.setFractionRemoteWireConnectionsAllowed(maxRemotePeersFraction);
     startAgentWithMaxPeers(maxPeers);
@@ -423,7 +423,7 @@ public class RlpxAgentTest {
   @Test
   public void connect_withMaxRemotelyInitiatedConnectionsAtZeroPercent() {
     final int maxPeers = 10;
-    final double maxRemotePeersFraction = 0.0;
+    final float maxRemotePeersFraction = 0.0f;
     config.setLimitRemoteWireConnectionsEnabled(true);
     config.setFractionRemoteWireConnectionsAllowed(maxRemotePeersFraction);
     startAgentWithMaxPeers(maxPeers);
@@ -442,7 +442,7 @@ public class RlpxAgentTest {
   public void incomingConnection_succeedsForPrivilegedPeerWhenMaxRemoteConnectionsExceeded() {
     final int maxPeers = 5;
     final int maxRemotePeers = 3;
-    final double maxRemotePeersFraction = (double) maxRemotePeers / (double) maxPeers;
+    final float maxRemotePeersFraction = (float) maxRemotePeers / (float) maxPeers;
     config.setLimitRemoteWireConnectionsEnabled(true);
     config.setFractionRemoteWireConnectionsAllowed(maxRemotePeersFraction);
     startAgentWithMaxPeers(maxPeers);

--- a/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/RunnerBuilder.java
@@ -113,7 +113,7 @@ public class RunnerBuilder {
   private NatMethod natMethod = NatMethod.NONE;
   private int maxPeers;
   private boolean limitRemoteWireConnectionsEnabled = false;
-  private double fractionRemoteConnectionsAllowed;
+  private float fractionRemoteConnectionsAllowed;
   private EthNetworkConfig ethNetworkConfig;
 
   private JsonRpcConfiguration jsonRpcConfiguration;
@@ -183,7 +183,7 @@ public class RunnerBuilder {
   }
 
   public RunnerBuilder fractionRemoteConnectionsAllowed(
-      final double fractionRemoteConnectionsAllowed) {
+      final float fractionRemoteConnectionsAllowed) {
     this.fractionRemoteConnectionsAllowed = fractionRemoteConnectionsAllowed;
     return this;
   }

--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -241,17 +241,17 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
   @Option(
       names = {"--remote-connections-limit-enabled"},
       description =
-          "Set to limit the fraction of wire connections initiated by peers. (default: ${DEFAULT-VALUE})")
-  private final Boolean isLimitRemoteWireConnectionsEnabled = false;
+          "Whether to limit the number of P2P connections initiated remotely. (default: ${DEFAULT-VALUE})")
+  private final Boolean isLimitRemoteWireConnectionsEnabled = true;
 
   @Option(
-      names = {"--remote-connections-percentage"},
+      names = {"--max-remote-connections-percentage"},
       paramLabel = MANDATORY_DOUBLE_FORMAT_HELP,
       description =
-          "Percentage of remote wire connections that can be established. Must be between 0 and 100 inclusive. (default: ${DEFAULT-VALUE})",
+          "The maximum percentage of P2P connections that can be initiated remotely. Must be between 0 and 100 inclusive. (default: ${DEFAULT-VALUE})",
       arity = "1",
       converter = PercentageConverter.class)
-  private final Integer remoteConnectionsPercentage =
+  private final Integer maxRemoteConnectionsPercentage =
       Fraction.fromFloat(DEFAULT_FRACTION_REMOTE_WIRE_CONNECTIONS_ALLOWED)
           .toPercentage()
           .getValue();
@@ -796,7 +796,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
             "--max-peers",
             "--banned-node-id",
             "--banned-node-ids",
-            "--remote-connections-percentage"));
+            "--max-remote-connections-percentage"));
     // Check that mining options are able to work or send an error
     checkOptionDependencies(
         logger,
@@ -1189,7 +1189,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
             .maxPeers(maxPeers)
             .limitRemoteWireConnectionsEnabled(isLimitRemoteWireConnectionsEnabled)
             .fractionRemoteConnectionsAllowed(
-                Fraction.fromPercentage(remoteConnectionsPercentage).getValue())
+                Fraction.fromPercentage(maxRemoteConnectionsPercentage).getValue())
             .networkingConfiguration(networkingOptions.toDomainObject())
             .graphQLConfiguration(graphQLConfiguration)
             .jsonRpcConfiguration(jsonRpcConfiguration)

--- a/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
@@ -179,7 +179,6 @@ public final class RunnerTest {
             .webSocketConfiguration(aheadWebSocketConfiguration)
             .metricsConfiguration(aheadMetricsConfiguration)
             .dataDir(dbAhead)
-            .fractionRemoteConnectionsAllowed(1.0)
             .build();
     try {
 

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
@@ -14,7 +14,7 @@ package tech.pegasys.pantheon.cli;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -109,7 +109,7 @@ public abstract class CommandTestAbstract {
   @Captor protected ArgumentCaptor<File> fileArgumentCaptor;
   @Captor protected ArgumentCaptor<String> stringArgumentCaptor;
   @Captor protected ArgumentCaptor<Integer> intArgumentCaptor;
-  @Captor protected ArgumentCaptor<Double> doubleArgumentCaptor;
+  @Captor protected ArgumentCaptor<Float> floatCaptor;
   @Captor protected ArgumentCaptor<EthNetworkConfig> ethNetworkConfigArgumentCaptor;
   @Captor protected ArgumentCaptor<SynchronizerConfiguration> syncConfigurationCaptor;
   @Captor protected ArgumentCaptor<JsonRpcConfiguration> jsonRpcConfigArgumentCaptor;
@@ -166,7 +166,7 @@ public abstract class CommandTestAbstract {
     when(mockRunnerBuilder.maxPeers(anyInt())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.limitRemoteWireConnectionsEnabled(anyBoolean()))
         .thenReturn(mockRunnerBuilder);
-    when(mockRunnerBuilder.fractionRemoteConnectionsAllowed(anyDouble()))
+    when(mockRunnerBuilder.fractionRemoteConnectionsAllowed(anyFloat()))
         .thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.p2pEnabled(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natMethod(any())).thenReturn(mockRunnerBuilder);

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
@@ -158,7 +158,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
     verify(mockRunnerBuilder).p2pAdvertisedHost(eq("127.0.0.1"));
     verify(mockRunnerBuilder).p2pListenPort(eq(30303));
     verify(mockRunnerBuilder).maxPeers(eq(25));
-    verify(mockRunnerBuilder).fractionRemoteConnectionsAllowed(eq(0.5));
+    verify(mockRunnerBuilder).fractionRemoteConnectionsAllowed(eq(0.6f));
     verify(mockRunnerBuilder).jsonRpcConfiguration(eq(defaultJsonRpcConfiguration));
     verify(mockRunnerBuilder).graphQLConfiguration(eq(DEFAULT_GRAPH_QL_CONFIGURATION));
     verify(mockRunnerBuilder).webSocketConfiguration(eq(defaultWebSocketConfiguration));
@@ -722,8 +722,8 @@ public class PantheonCommandTest extends CommandTestAbstract {
     verify(mockRunnerBuilder).p2pAdvertisedHost(eq("127.0.0.1"));
     verify(mockRunnerBuilder).p2pListenPort(eq(30303));
     verify(mockRunnerBuilder).maxPeers(eq(25));
-    verify(mockRunnerBuilder).limitRemoteWireConnectionsEnabled(eq(false));
-    verify(mockRunnerBuilder).fractionRemoteConnectionsAllowed(eq(0.5));
+    verify(mockRunnerBuilder).limitRemoteWireConnectionsEnabled(eq(true));
+    verify(mockRunnerBuilder).fractionRemoteConnectionsAllowed(eq(0.6f));
     verify(mockRunnerBuilder).jsonRpcConfiguration(eq(jsonRpcConfiguration));
     verify(mockRunnerBuilder).graphQLConfiguration(eq(graphQLConfiguration));
     verify(mockRunnerBuilder).webSocketConfiguration(eq(webSocketConfiguration));
@@ -1023,7 +1023,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
         "false",
         "--max-peers",
         "42",
-        "--remote-connections-percentage",
+        "--max-remote-connections-percentage",
         "50",
         "--banned-node-id",
         String.join(",", nodes),
@@ -1036,7 +1036,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
         "--bootnodes",
         "--max-peers",
         "--banned-node-ids",
-        "--remote-connections-percentage");
+        "--max-remote-connections-percentage");
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();
@@ -1247,13 +1247,13 @@ public class PantheonCommandTest extends CommandTestAbstract {
     final int remoteConnectionsPercentage = 12;
     parseCommand(
         "--remote-connections-limit-enabled",
-        "--remote-connections-percentage",
+        "--max-remote-connections-percentage",
         String.valueOf(remoteConnectionsPercentage));
 
-    verify(mockRunnerBuilder).fractionRemoteConnectionsAllowed(doubleArgumentCaptor.capture());
+    verify(mockRunnerBuilder).fractionRemoteConnectionsAllowed(floatCaptor.capture());
     verify(mockRunnerBuilder).build();
 
-    assertThat(doubleArgumentCaptor.getValue())
+    assertThat(floatCaptor.getValue())
         .isEqualTo(
             Fraction.fromPercentage(Percentage.fromInt(remoteConnectionsPercentage)).getValue());
 
@@ -1265,24 +1265,25 @@ public class PantheonCommandTest extends CommandTestAbstract {
   public void remoteConnectionsPercentageWithInvalidFormatMustFail() {
 
     parseCommand(
-        "--remote-connections-limit-enabled", "--remote-connections-percentage", "invalid");
+        "--remote-connections-limit-enabled", "--max-remote-connections-percentage", "invalid");
     verifyZeroInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .contains(
-            "Invalid value for option '--remote-connections-percentage'",
+            "Invalid value for option '--max-remote-connections-percentage'",
             "should be a number between 0 and 100 inclusive");
   }
 
   @Test
   public void remoteConnectionsPercentageWithOutOfRangeMustFail() {
 
-    parseCommand("--remote-connections-limit-enabled", "--remote-connections-percentage", "150");
+    parseCommand(
+        "--remote-connections-limit-enabled", "--max-remote-connections-percentage", "150");
     verifyZeroInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .contains(
-            "Invalid value for option '--remote-connections-percentage'",
+            "Invalid value for option '--max-remote-connections-percentage'",
             "should be a number between 0 and 100 inclusive");
   }
 

--- a/pantheon/src/test/resources/everything_config.toml
+++ b/pantheon/src/test/resources/everything_config.toml
@@ -27,8 +27,8 @@ banned-node-id=["0x6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec
 p2p-host="1.2.3.4"
 p2p-port=1234
 max-peers=42
-remote-connections-limit-enabled=false
-remote-connections-percentage=50
+remote-connections-limit-enabled=true
+max-remote-connections-percentage=60
 host-whitelist=["all"]
 
 # chain


### PR DESCRIPTION
## PR description
Rework remote connection limit defaults:
* Enable remote connection limits by default
* Bump up the default percentage of remote connection to 60 in order to make the limit a little more forgiving for private networks where all nodes may use the same configuration

Other changes include:
- Change flag from `--remote-connections-percentage` to `--max-remote-connections-percentage` for clarity
- Reword help text for clarity / consistency
- Use `float` to represent max percentage of remote connection consistently
- Remove extraneous configuration of these options in tests


