### PR TITLE
[PAN-1683] Rename CLI flag for better ordering of options

### DIFF
--- a/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/cli/PantheonCommand.java
@@ -245,7 +245,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
   private final Boolean isLimitRemoteWireConnectionsEnabled = true;
 
   @Option(
-      names = {"--max-remote-connections-percentage"},
+      names = {"--remote-connections-max-percentage"},
       paramLabel = MANDATORY_DOUBLE_FORMAT_HELP,
       description =
           "The maximum percentage of P2P connections that can be initiated remotely. Must be between 0 and 100 inclusive. (default: ${DEFAULT-VALUE})",
@@ -796,7 +796,7 @@ public class PantheonCommand implements DefaultCommandValues, Runnable {
             "--max-peers",
             "--banned-node-id",
             "--banned-node-ids",
-            "--max-remote-connections-percentage"));
+            "--remote-connections-max-percentage"));
     // Check that mining options are able to work or send an error
     checkOptionDependencies(
         logger,

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/PantheonCommandTest.java
@@ -1023,7 +1023,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
         "false",
         "--max-peers",
         "42",
-        "--max-remote-connections-percentage",
+        "--remote-connections-max-percentage",
         "50",
         "--banned-node-id",
         String.join(",", nodes),
@@ -1036,7 +1036,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
         "--bootnodes",
         "--max-peers",
         "--banned-node-ids",
-        "--max-remote-connections-percentage");
+        "--remote-connections-max-percentage");
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();
@@ -1247,7 +1247,7 @@ public class PantheonCommandTest extends CommandTestAbstract {
     final int remoteConnectionsPercentage = 12;
     parseCommand(
         "--remote-connections-limit-enabled",
-        "--max-remote-connections-percentage",
+        "--remote-connections-max-percentage",
         String.valueOf(remoteConnectionsPercentage));
 
     verify(mockRunnerBuilder).fractionRemoteConnectionsAllowed(floatCaptor.capture());
@@ -1265,12 +1265,12 @@ public class PantheonCommandTest extends CommandTestAbstract {
   public void remoteConnectionsPercentageWithInvalidFormatMustFail() {
 
     parseCommand(
-        "--remote-connections-limit-enabled", "--max-remote-connections-percentage", "invalid");
+        "--remote-connections-limit-enabled", "--remote-connections-max-percentage", "invalid");
     verifyZeroInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .contains(
-            "Invalid value for option '--max-remote-connections-percentage'",
+            "Invalid value for option '--remote-connections-max-percentage'",
             "should be a number between 0 and 100 inclusive");
   }
 
@@ -1278,12 +1278,12 @@ public class PantheonCommandTest extends CommandTestAbstract {
   public void remoteConnectionsPercentageWithOutOfRangeMustFail() {
 
     parseCommand(
-        "--remote-connections-limit-enabled", "--max-remote-connections-percentage", "150");
+        "--remote-connections-limit-enabled", "--remote-connections-max-percentage", "150");
     verifyZeroInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .contains(
-            "Invalid value for option '--max-remote-connections-percentage'",
+            "Invalid value for option '--remote-connections-max-percentage'",
             "should be a number between 0 and 100 inclusive");
   }
 

--- a/pantheon/src/test/resources/everything_config.toml
+++ b/pantheon/src/test/resources/everything_config.toml
@@ -28,7 +28,7 @@ p2p-host="1.2.3.4"
 p2p-port=1234
 max-peers=42
 remote-connections-limit-enabled=true
-max-remote-connections-percentage=60
+remote-connections-max-percentage=60
 host-whitelist=["all"]
 
 # chain


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Rename CLI flag from `--max-remote-connections-percentage` to `--remote-connections-max-percentage`, so that this flag will show up next to the related flag `--remote-connections-limit-enabled` when help is displayed.
