### PR TITLE
fix get signerMetrics when there are fewer blocks in the network than…

### DIFF
--- a/consensus/clique/src/test/java/tech/pegasys/pantheon/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
+++ b/consensus/clique/src/test/java/tech/pegasys/pantheon/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
@@ -13,7 +13,10 @@
 package tech.pegasys.pantheon.consensus.clique.jsonrpc.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalMatchers.lt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import tech.pegasys.pantheon.consensus.common.BlockInterface;
@@ -136,6 +139,30 @@ public class CliqueGetSignerMetricsTest {
     final JsonRpcRequest request = requestWithParams();
 
     final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+
+    assertThat((Collection<SignerMetricResult>) response.getResult())
+        .containsExactlyInAnyOrderElementsOf(signerMetricResultList);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void getSignerMetricsWhenThereAreFewerBlocksThanTheDefaultRange() {
+    final long startBlock = 0L;
+    final long headBlock = 2L;
+
+    final List<SignerMetricResult> signerMetricResultList = new ArrayList<>();
+
+    when(blockchainQueries.headBlockNumber()).thenReturn(headBlock);
+
+    LongStream.range(startBlock, headBlock)
+        .forEach(value -> signerMetricResultList.add(generateBlock(value)));
+
+    final JsonRpcRequest request = requestWithParams();
+
+    final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
+
+    // verify getBlockHeaderByNumber is not called with negative values
+    verify(blockchainQueries, never()).getBlockHeaderByNumber(lt(0L));
 
     assertThat((Collection<SignerMetricResult>) response.getResult())
         .containsExactlyInAnyOrderElementsOf(signerMetricResultList);

--- a/consensus/common/src/main/java/tech/pegasys/pantheon/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
+++ b/consensus/common/src/main/java/tech/pegasys/pantheon/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
@@ -101,7 +101,7 @@ public abstract class AbstractGetSignerMetricsMethod {
   private long getFromBlockNumber(final Optional<BlockParameter> startBlockParameter) {
     return startBlockParameter
         .map(this::resolveBlockNumber)
-        .orElseGet(() -> blockchainQueries.headBlockNumber() - DEFAULT_RANGE_BLOCK);
+        .orElseGet(() -> Math.max(0, blockchainQueries.headBlockNumber() - DEFAULT_RANGE_BLOCK));
   }
 
   private long getEndBlockNumber(final Optional<BlockParameter> endBlockParameter) {


### PR DESCRIPTION
## PR description

When no parameter is specified the method will go through the last 100 blocks. If there are less than 100 blocks available in the network the method will process all the blocks present.