### PR TITLE
Report 0 hashrate when the mining coordinator doesn't support mining

### DIFF
--- a/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/MiningCoordinator.java
+++ b/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/MiningCoordinator.java
@@ -43,8 +43,7 @@ public interface MiningCoordinator {
   }
 
   default Optional<Long> hashesPerSecond() {
-    throw new UnsupportedOperationException(
-        "Current consensus mechanism prevents querying of hashrate.");
+    return Optional.empty();
   }
 
   default Optional<EthHashSolverInputs> getWorkDefinition() {

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrate.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrate.java
@@ -15,8 +15,6 @@ package tech.pegasys.pantheon.ethereum.jsonrpc.internal.methods;
 import tech.pegasys.pantheon.ethereum.blockcreation.MiningCoordinator;
 import tech.pegasys.pantheon.ethereum.jsonrpc.RpcMethod;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
-import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcError;
-import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcErrorResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.results.Quantity;
@@ -42,7 +40,7 @@ public class EthHashrate implements JsonRpcMethod {
       final Optional<Long> hashesPerSecond = miningCoordinator.hashesPerSecond();
       return new JsonRpcSuccessResponse(req.getId(), Quantity.create(hashesPerSecond.orElse(0L)));
     } catch (final UnsupportedOperationException ex) {
-      return new JsonRpcErrorResponse(req.getId(), JsonRpcError.INVALID_REQUEST);
+      return new JsonRpcSuccessResponse(req.getId(), Quantity.create(0L));
     }
   }
 }

--- a/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrate.java
+++ b/ethereum/jsonrpc/src/main/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrate.java
@@ -36,11 +36,7 @@ public class EthHashrate implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest req) {
-    try {
-      final Optional<Long> hashesPerSecond = miningCoordinator.hashesPerSecond();
-      return new JsonRpcSuccessResponse(req.getId(), Quantity.create(hashesPerSecond.orElse(0L)));
-    } catch (final UnsupportedOperationException ex) {
-      return new JsonRpcSuccessResponse(req.getId(), Quantity.create(0L));
-    }
+    final Optional<Long> hashesPerSecond = miningCoordinator.hashesPerSecond();
+    return new JsonRpcSuccessResponse(req.getId(), Quantity.create(hashesPerSecond.orElse(0L)));
   }
 }

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrateTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrateTest.java
@@ -17,8 +17,6 @@ import static org.mockito.Mockito.when;
 
 import tech.pegasys.pantheon.ethereum.blockcreation.EthHashMiningCoordinator;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.JsonRpcRequest;
-import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcError;
-import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcErrorResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcResponse;
 import tech.pegasys.pantheon.ethereum.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
@@ -69,10 +67,9 @@ public class EthHashrateTest {
   }
 
   @Test
-  public void shouldReturnErrorWhenMiningCoordinatorDoesNotSupportHashing() {
+  public void shouldReturnZeroWhenMiningCoordinatorDoesNotSupportHashing() {
     final JsonRpcRequest request = requestWithParams();
-    final JsonRpcResponse expectedResponse =
-        new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_REQUEST);
+    final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(request.getId(), "0x0");
     when(miningCoordinator.hashesPerSecond()).thenThrow(UnsupportedOperationException.class);
 
     final JsonRpcResponse actualResponse = method.response(request);

--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrateTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/EthHashrateTest.java
@@ -66,16 +66,6 @@ public class EthHashrateTest {
     assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
   }
 
-  @Test
-  public void shouldReturnZeroWhenMiningCoordinatorDoesNotSupportHashing() {
-    final JsonRpcRequest request = requestWithParams();
-    final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(request.getId(), "0x0");
-    when(miningCoordinator.hashesPerSecond()).thenThrow(UnsupportedOperationException.class);
-
-    final JsonRpcResponse actualResponse = method.response(request);
-    assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
-  }
-
   private JsonRpcRequest requestWithParams() {
     return new JsonRpcRequest(JSON_RPC_VERSION, ETH_METHOD, new Object[] {});
   }


### PR DESCRIPTION
## PR description
Ethstats reporting was still failing on Clique based networks because our `eth_hashrate` call returned an error when the `MiningCoordinator` doesn't support hash rates.  The standard behaviour is to return 0 in this case, so adjust Pantheon to match.