### PR TITLE
[PAN-2954] - Allow fixedDifficulty=1 to mean "all solutions"

### DIFF
--- a/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/EthHashBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/EthHashBlockCreator.java
@@ -85,7 +85,10 @@ public class EthHashBlockCreator extends AbstractBlockCreator<Void> {
       final SealableBlockHeader sealableBlockHeader) {
     final BigInteger difficulty =
         BytesValues.asUnsignedBigInteger(sealableBlockHeader.getDifficulty().getBytes());
-    final UInt256 target = UInt256.of(EthHash.TARGET_UPPER_BOUND.divide(difficulty));
+    final UInt256 target =
+        difficulty.equals(BigInteger.ONE)
+            ? UInt256.MAX_VALUE
+            : UInt256.of(EthHash.TARGET_UPPER_BOUND.divide(difficulty));
 
     return new EthHashSolverInputs(
         target, EthHash.hashHeader(sealableBlockHeader), sealableBlockHeader.getNumber());

--- a/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
+++ b/ethereum/core/src/main/java/tech/pegasys/pantheon/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
@@ -31,9 +31,9 @@ public final class ProofOfWorkValidationRule implements DetachedBlockHeaderValid
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final BigInteger ETHHASH_TARGET_UPPER_BOUND = BigInteger.valueOf(2).pow(256);
+  private static final BigInteger ETHASH_TARGET_UPPER_BOUND = BigInteger.valueOf(2).pow(256);
 
-  private static final EthHasher HASHER = new EthHasher.Light();
+  static final EthHasher HASHER = new EthHasher.Light();
 
   @Override
   public boolean validate(final BlockHeader header, final BlockHeader parent) {
@@ -47,8 +47,10 @@ public final class ProofOfWorkValidationRule implements DetachedBlockHeaderValid
     }
     final BigInteger difficulty =
         BytesValues.asUnsignedBigInteger(header.getDifficulty().getBytes());
-    final UInt256 target = UInt256.of(ETHHASH_TARGET_UPPER_BOUND.divide(difficulty));
-
+    final UInt256 target =
+        difficulty.equals(BigInteger.ONE)
+            ? UInt256.MAX_VALUE
+            : UInt256.of(ETHASH_TARGET_UPPER_BOUND.divide(difficulty));
     final UInt256 result = UInt256.wrap(Bytes32.wrap(hashBuffer, 32));
     if (result.compareTo(target) > 0) {
       LOG.warn(
@@ -75,7 +77,7 @@ public final class ProofOfWorkValidationRule implements DetachedBlockHeaderValid
     return true;
   }
 
-  private Hash hashHeader(final BlockHeader header) {
+  Hash hashHeader(final BlockHeader header) {
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
 
     // Encode header without nonce and mixhash

--- a/util/src/main/java/tech/pegasys/pantheon/util/uint/UInt256.java
+++ b/util/src/main/java/tech/pegasys/pantheon/util/uint/UInt256.java
@@ -29,6 +29,9 @@ public interface UInt256 extends UInt256Value<UInt256> {
   UInt256 ONE = of(1);
   /** The value 32. */
   UInt256 U_32 = of(32);
+  /** The value of 2^256-1 */
+  UInt256 MAX_VALUE =
+      fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
   static UInt256 of(final long value) {
     return new DefaultUInt256(UInt256Bytes.of(value));


### PR DESCRIPTION
## PR description

If you try and do a difficulty of 1 the UInt256 class used for comparison throws
an error because 2^256 is 33 bytes.  Instead use 2^256-1 which is 32 bytes.
