### PR TITLE
[PAN-2331] Finer grained logging configuration

### DIFF
--- a/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/AdminChangeLogLevelTest.java
+++ b/ethereum/jsonrpc/src/test/java/tech/pegasys/pantheon/ethereum/jsonrpc/internal/methods/AdminChangeLogLevelTest.java
@@ -49,7 +49,7 @@ public class AdminChangeLogLevelTest {
   }
 
   @Test
-  public void shouldReturnCorrectResponse() {
+  public void shouldReturnCorrectResponseWhenRequestHasLogLevel() {
     final JsonRpcRequest request =
         new JsonRpcRequest("2.0", "admin_changeLogLevel", new Object[] {Level.DEBUG});
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(request.getId());
@@ -62,6 +62,29 @@ public class AdminChangeLogLevelTest {
     assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
     assertEquals(Level.INFO, levelBeforeJsonRpcRequest);
     assertEquals(Level.DEBUG, levelAfterJsonRpcRequest);
+  }
+
+  @Test
+  public void shouldReturnCorrectResponseWhenRequestHasLogLevelAndFilters() {
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            "2.0", "admin_changeLogLevel", new Object[] {Level.DEBUG, new String[] {"com"}});
+    final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(request.getId());
+
+    final Level levelOfAllProjectBeforeJsonRpcRequest = LogManager.getLogger().getLevel();
+    final Level levelWithSpecificPackageBeforeJsonRpcRequest =
+        LogManager.getLogger("com").getLevel();
+    final JsonRpcSuccessResponse actualResponse =
+        (JsonRpcSuccessResponse) adminChangeLogLevel.response(request);
+    final Level levelOfAllProjectAfterJsonRpcRequest = LogManager.getLogger().getLevel();
+    final Level levelWithSpecificPackageAfterJsonRpcRequest =
+        LogManager.getLogger("com").getLevel();
+
+    assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
+    assertEquals(Level.INFO, levelOfAllProjectBeforeJsonRpcRequest);
+    assertEquals(Level.INFO, levelOfAllProjectAfterJsonRpcRequest);
+    assertEquals(Level.INFO, levelWithSpecificPackageBeforeJsonRpcRequest);
+    assertEquals(Level.DEBUG, levelWithSpecificPackageAfterJsonRpcRequest);
   }
 
   @Test
@@ -95,6 +118,17 @@ public class AdminChangeLogLevelTest {
   public void requestHasInvalidStringLogLevelParameter() {
     final JsonRpcRequest request =
         new JsonRpcRequest("2.0", "admin_changeLogLevel", new String[] {"INVALID"});
+    final JsonRpcResponse expectedResponse =
+        new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS);
+
+    final JsonRpcResponse actualResponse = adminChangeLogLevel.response(request);
+    assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
+  }
+
+  @Test
+  public void requestHasInvalidLogFilterParameter() {
+    final JsonRpcRequest request =
+        new JsonRpcRequest("2.0", "admin_changeLogLevel", new Object[] {"DEBUG", "INVALID"});
     final JsonRpcResponse expectedResponse =
         new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS);
 


### PR DESCRIPTION
## PR description

Provide a way to enable logging for specific packages or classes. e.g. if my node isn't discovering peers I may want to see peer discovery at TRACE level but keep the Synchronizer at INFO level.

### Request

```json
{  
   "jsonrpc":"2.0",
   "method":"admin_changeLogLevel",
   "params":[  
      "DEBUG",
      [  
         "tech.pegasys.pantheon.ethereum.eth.manager",
         "tech.pegasys.pantheon.ethereum.p2p.rlpx.connections.netty.ApiHandler"
      ]
   ],
   "id":1
}
```

### Response

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": "Success"
}
```