### PR TITLE
[PAN-3023] Add command line option for target gas limit

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/node/ThreadPantheonNodeRunner.java
@@ -119,6 +119,7 @@ public class ThreadPantheonNodeRunner implements PantheonNodeRunner {
               .ethProtocolConfiguration(EthProtocolConfiguration.defaultConfig())
               .clock(Clock.systemUTC())
               .isRevertReasonEnabled(node.isRevertReasonEnabled())
+              .gasLimitCalculator((gasLimit) -> gasLimit)
               .build();
     } catch (final IOException e) {
       throw new RuntimeException("Error building PantheonController", e);

--- a/consensus/clique/src/main/java/tech/pegasys/pantheon/consensus/clique/blockcreation/CliqueMinerExecutor.java
+++ b/consensus/clique/src/main/java/tech/pegasys/pantheon/consensus/clique/blockcreation/CliqueMinerExecutor.java
@@ -53,14 +53,16 @@ public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, Cl
       final KeyPair nodeKeys,
       final MiningParameters miningParams,
       final AbstractBlockScheduler blockScheduler,
-      final EpochManager epochManager) {
+      final EpochManager epochManager,
+      final Function<Long, Long> gasLimitCalculator) {
     super(
         protocolContext,
         executorService,
         protocolSchedule,
         pendingTransactions,
         miningParams,
-        blockScheduler);
+        blockScheduler,
+        gasLimitCalculator);
     this.nodeKeys = nodeKeys;
     this.localAddress = Util.publicKeyToAddress(nodeKeys.getPublicKey());
     this.epochManager = epochManager;
@@ -89,7 +91,7 @@ public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, Cl
                 pendingTransactions,
                 protocolContext,
                 protocolSchedule,
-                (gasLimit) -> gasLimit,
+                gasLimitCalculator,
                 nodeKeys,
                 minTransactionGasPrice,
                 header,

--- a/consensus/clique/src/test/java/tech/pegasys/pantheon/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
+++ b/consensus/clique/src/test/java/tech/pegasys/pantheon/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
@@ -98,7 +98,8 @@ public class CliqueMinerExecutorTest {
             proposerKeyPair,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, vanityData, false),
             mock(CliqueBlockScheduler.class),
-            new EpochManager(EPOCH_LENGTH));
+            new EpochManager(EPOCH_LENGTH),
+            (gasLimit) -> gasLimit);
 
     // NOTE: Passing in the *parent* block, so must be 1 less than EPOCH
     final BlockHeader header = blockHeaderBuilder.number(EPOCH_LENGTH - 1).buildHeader();
@@ -135,7 +136,8 @@ public class CliqueMinerExecutorTest {
             proposerKeyPair,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, vanityData, false),
             mock(CliqueBlockScheduler.class),
-            new EpochManager(EPOCH_LENGTH));
+            new EpochManager(EPOCH_LENGTH),
+            (gasLimit) -> gasLimit);
 
     // Parent block was epoch, so the next block should contain no validators.
     final BlockHeader header = blockHeaderBuilder.number(EPOCH_LENGTH).buildHeader();
@@ -172,7 +174,8 @@ public class CliqueMinerExecutorTest {
             proposerKeyPair,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, initialVanityData, false),
             mock(CliqueBlockScheduler.class),
-            new EpochManager(EPOCH_LENGTH));
+            new EpochManager(EPOCH_LENGTH),
+            (gasLimit) -> gasLimit);
 
     executor.setExtraData(modifiedVanityData);
     final BytesValue extraDataBytes = executor.calculateExtraData(blockHeaderBuilder.buildHeader());

--- a/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/AbstractMinerExecutor.java
+++ b/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/AbstractMinerExecutor.java
@@ -25,6 +25,7 @@ import tech.pegasys.pantheon.util.bytes.BytesValue;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 
 public abstract class AbstractMinerExecutor<
     C, M extends BlockMiner<C, ? extends AbstractBlockCreator<C>>> {
@@ -34,6 +35,7 @@ public abstract class AbstractMinerExecutor<
   protected final ProtocolSchedule<C> protocolSchedule;
   protected final PendingTransactions pendingTransactions;
   protected final AbstractBlockScheduler blockScheduler;
+  protected final Function<Long, Long> gasLimitCalculator;
 
   protected volatile BytesValue extraData;
   protected volatile Wei minTransactionGasPrice;
@@ -44,7 +46,8 @@ public abstract class AbstractMinerExecutor<
       final ProtocolSchedule<C> protocolSchedule,
       final PendingTransactions pendingTransactions,
       final MiningParameters miningParams,
-      final AbstractBlockScheduler blockScheduler) {
+      final AbstractBlockScheduler blockScheduler,
+      final Function<Long, Long> gasLimitCalculator) {
     this.protocolContext = protocolContext;
     this.executorService = executorService;
     this.protocolSchedule = protocolSchedule;
@@ -52,6 +55,7 @@ public abstract class AbstractMinerExecutor<
     this.extraData = miningParams.getExtraData();
     this.minTransactionGasPrice = miningParams.getMinTransactionGasPrice();
     this.blockScheduler = blockScheduler;
+    this.gasLimitCalculator = gasLimitCalculator;
   }
 
   public abstract M startAsyncMining(

--- a/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/EthHashMinerExecutor.java
+++ b/ethereum/blockcreation/src/main/java/tech/pegasys/pantheon/ethereum/blockcreation/EthHashMinerExecutor.java
@@ -37,14 +37,16 @@ public class EthHashMinerExecutor extends AbstractMinerExecutor<Void, EthHashBlo
       final ProtocolSchedule<Void> protocolSchedule,
       final PendingTransactions pendingTransactions,
       final MiningParameters miningParams,
-      final AbstractBlockScheduler blockScheduler) {
+      final AbstractBlockScheduler blockScheduler,
+      final Function<Long, Long> gasLimitCalculator) {
     super(
         protocolContext,
         executorService,
         protocolSchedule,
         pendingTransactions,
         miningParams,
-        blockScheduler);
+        blockScheduler,
+        gasLimitCalculator);
     this.coinbase = miningParams.getCoinbase();
   }
 
@@ -77,7 +79,7 @@ public class EthHashMinerExecutor extends AbstractMinerExecutor<Void, EthHashBlo
                 pendingTransactions,
                 protocolContext,
                 protocolSchedule,
-                (gasLimit) -> gasLimit,
+                gasLimitCalculator,
                 solver,
                 minTransactionGasPrice,
                 parentHeader);

--- a/ethereum/blockcreation/src/test/java/tech/pegasys/pantheon/ethereum/blockcreation/EthHashMinerExecutorTest.java
+++ b/ethereum/blockcreation/src/test/java/tech/pegasys/pantheon/ethereum/blockcreation/EthHashMinerExecutorTest.java
@@ -49,7 +49,8 @@ public class EthHashMinerExecutorTest {
             null,
             pendingTransactions,
             miningParameters,
-            new DefaultBlockScheduler(1, 10, TestClock.fixed()));
+            new DefaultBlockScheduler(1, 10, TestClock.fixed()),
+            (gasLimit) -> gasLimit);
 
     assertThatExceptionOfType(CoinbaseNotSetException.class)
         .isThrownBy(() -> executor.startAsyncMining(Subscribers.create(), null))
@@ -74,7 +75,8 @@ public class EthHashMinerExecutorTest {
             null,
             pendingTransactions,
             miningParameters,
-            new DefaultBlockScheduler(1, 10, TestClock.fixed()));
+            new DefaultBlockScheduler(1, 10, TestClock.fixed()),
+            (gasLimit) -> gasLimit);
 
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> executor.setCoinbase(null))

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/CliquePantheonControllerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/CliquePantheonControllerBuilder.java
@@ -94,7 +94,8 @@ public class CliquePantheonControllerBuilder extends PantheonControllerBuilder<C
                 protocolContext.getConsensusState().getVoteTallyCache(),
                 localAddress,
                 secondsBetweenBlocks),
-            epochManager);
+            epochManager,
+            gasLimitCalculator);
     final CliqueMiningCoordinator miningCoordinator =
         new CliqueMiningCoordinator(
             protocolContext.getBlockchain(),

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonControllerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/IbftPantheonControllerBuilder.java
@@ -111,7 +111,7 @@ public class IbftPantheonControllerBuilder extends PantheonControllerBuilder<Ibf
 
     final IbftBlockCreatorFactory blockCreatorFactory =
         new IbftBlockCreatorFactory(
-            (gasLimit) -> gasLimit,
+            gasLimitCalculator,
             transactionPool.getPendingTransactions(),
             protocolContext,
             protocolSchedule,

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/MainnetPantheonControllerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/MainnetPantheonControllerBuilder.java
@@ -56,7 +56,8 @@ public class MainnetPantheonControllerBuilder extends PantheonControllerBuilder<
             new DefaultBlockScheduler(
                 MainnetBlockHeaderValidator.MINIMUM_SECONDS_SINCE_PARENT,
                 MainnetBlockHeaderValidator.TIMESTAMP_TOLERANCE_S,
-                clock));
+                clock),
+            gasLimitCalculator);
 
     final EthHashMiningCoordinator miningCoordinator =
         new EthHashMiningCoordinator(protocolContext.getBlockchain(), executor, syncState);

--- a/pantheon/src/main/java/tech/pegasys/pantheon/controller/PantheonControllerBuilder.java
+++ b/pantheon/src/main/java/tech/pegasys/pantheon/controller/PantheonControllerBuilder.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -84,6 +85,7 @@ public abstract class PantheonControllerBuilder<C> {
   protected Clock clock;
   protected KeyPair nodeKeys;
   protected boolean isRevertReasonEnabled;
+  protected Function<Long, Long> gasLimitCalculator;
   private StorageProvider storageProvider;
   private final List<Runnable> shutdownActions = new ArrayList<>();
   private RocksDbConfiguration rocksDbConfiguration;
@@ -181,6 +183,12 @@ public abstract class PantheonControllerBuilder<C> {
     return this;
   }
 
+  public PantheonControllerBuilder<C> gasLimitCalculator(
+      final Function<Long, Long> gasLimitCalculator) {
+    this.gasLimitCalculator = gasLimitCalculator;
+    return this;
+  }
+
   public PantheonController<C> build() throws IOException {
     checkNotNull(genesisConfig, "Missing genesis config");
     checkNotNull(syncConfig, "Missing sync config");
@@ -193,6 +201,7 @@ public abstract class PantheonControllerBuilder<C> {
     checkNotNull(clock, "Mising clock");
     checkNotNull(transactionPoolConfiguration, "Missing transaction pool configuration");
     checkNotNull(nodeKeys, "Missing node keys");
+    checkNotNull(gasLimitCalculator, "Missing gas limit calculator");
     checkArgument(
         storageProvider != null || rocksDbConfiguration != null,
         "Must supply either a storage provider or RocksDB configuration");

--- a/pantheon/src/test/java/tech/pegasys/pantheon/PrivacyTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/PrivacyTest.java
@@ -66,6 +66,7 @@ public class PrivacyTest {
             .clock(TestClock.fixed())
             .privacyParameters(privacyParameters)
             .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
+            .gasLimitCalculator(gasLimit -> gasLimit)
             .build();
 
     final Address privacyContractAddress = Address.privacyPrecompiled(ADDRESS);

--- a/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/RunnerTest.java
@@ -135,6 +135,7 @@ public final class RunnerTest {
             .clock(TestClock.fixed())
             .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
             .storageProvider(createKeyValueStorageProvider(dbAhead))
+            .gasLimitCalculator(gasLimit -> gasLimit)
             .build()) {
       setupState(blockCount, controller.getProtocolSchedule(), controller.getProtocolContext());
     }
@@ -154,6 +155,7 @@ public final class RunnerTest {
             .clock(TestClock.fixed())
             .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
             .storageProvider(createKeyValueStorageProvider(dbAhead))
+            .gasLimitCalculator(gasLimit -> gasLimit)
             .build();
     final String listenHost = InetAddress.getLoopbackAddress().getHostAddress();
     final JsonRpcConfiguration aheadJsonRpcConfiguration = jsonRpcConfiguration();
@@ -212,6 +214,7 @@ public final class RunnerTest {
               .privacyParameters(PrivacyParameters.DEFAULT)
               .clock(TestClock.fixed())
               .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
+              .gasLimitCalculator(gasLimit -> gasLimit)
               .build();
       final EnodeURL enode = runnerAhead.getLocalEnode().get();
       final EthNetworkConfig behindEthNetworkConfiguration =

--- a/pantheon/src/test/java/tech/pegasys/pantheon/chainexport/RlpBlockExporterTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/chainexport/RlpBlockExporterTest.java
@@ -88,6 +88,7 @@ public final class RlpBlockExporterTest {
         .dataDirectory(dataDir)
         .clock(TestClock.fixed())
         .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
+        .gasLimitCalculator(gasLimit -> gasLimit)
         .build();
   }
 

--- a/pantheon/src/test/java/tech/pegasys/pantheon/chainimport/JsonBlockImporterTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/chainimport/JsonBlockImporterTest.java
@@ -425,6 +425,7 @@ public abstract class JsonBlockImporterTest {
         .dataDirectory(dataDir)
         .clock(TestClock.fixed())
         .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
+        .gasLimitCalculator(gasLimit -> gasLimit)
         .build();
   }
 }

--- a/pantheon/src/test/java/tech/pegasys/pantheon/chainimport/RlpBlockImporterTest.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/chainimport/RlpBlockImporterTest.java
@@ -66,6 +66,7 @@ public final class RlpBlockImporterTest {
             .dataDirectory(dataDir)
             .clock(TestClock.fixed())
             .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
+            .gasLimitCalculator(gasLimit -> gasLimit)
             .build();
     final RlpBlockImporter.ImportResult result =
         rlpBlockImporter.importBlockchain(source, targetController);
@@ -105,6 +106,7 @@ public final class RlpBlockImporterTest {
             .dataDirectory(dataDir)
             .clock(TestClock.fixed())
             .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
+            .gasLimitCalculator(gasLimit -> gasLimit)
             .build();
     final RlpBlockImporter.ImportResult result =
         rlpBlockImporter.importBlockchain(source, controller);

--- a/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
+++ b/pantheon/src/test/java/tech/pegasys/pantheon/cli/CommandTestAbstract.java
@@ -154,6 +154,7 @@ public abstract class CommandTestAbstract {
     when(mockControllerBuilder.isRevertReasonEnabled(false)).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.isPruningEnabled(anyBoolean())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.pruningConfiguration(any())).thenReturn(mockControllerBuilder);
+    when(mockControllerBuilder.gasLimitCalculator(any())).thenReturn(mockControllerBuilder);
 
     // doReturn used because of generic PantheonController
     doReturn(mockController).when(mockControllerBuilder).build();

--- a/pantheon/src/test/resources/everything_config.toml
+++ b/pantheon/src/test/resources/everything_config.toml
@@ -105,3 +105,6 @@ Xincoming-tx-messages-keep-alive-seconds=60
 
 # Revert Reason
 revert-reason-enabled=false
+
+# Gas limit
+target-gas-limit=8000000


### PR DESCRIPTION
# PR description

Adds the --target-gas-limit command line option.

Gradually changes the block gas limit towards this target when option enabled.

## Fixed Issue(s)

https://pegasys1.atlassian.net/browse/PAN-3023