### PR TITLE
fix flaky ethsigner acceptance tests

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/privacy/condition/EeaGetTransactionReceiptTransaction.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/acceptance/dsl/privacy/condition/EeaGetTransactionReceiptTransaction.java
@@ -36,7 +36,7 @@ public class EeaGetTransactionReceiptTransaction implements Transaction<PrivateT
   public PrivateTransactionReceipt execute(final NodeRequests node) {
     final Pantheon pantheon = node.privacy().getPantheonClient();
     final PollingPrivateTransactionReceiptProcessor receiptProcessor =
-        new PollingPrivateTransactionReceiptProcessor(pantheon, 3000, 3);
+        new PollingPrivateTransactionReceiptProcessor(pantheon, 15000, 3);
     try {
       final PrivateTransactionReceipt result =
           receiptProcessor.waitForTransactionReceipt(transactionHash);

--- a/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/web3j/privacy/EthSignerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/pantheon/tests/web3j/privacy/EthSignerAcceptanceTest.java
@@ -95,11 +95,7 @@ public class EthSignerAcceptanceTest extends PrivacyAcceptanceTestBase {
         privateTransactionVerifier.validPrivateTransactionReceipt(transactionHash, receipt));
   }
 
-  // TODO: investigate and fix flaky test
-  // re-enable when fixed
-  // https://jenkins.pegasys.tech/job/Pantheon/job/master/1629/testReport/junit/tech.pegasys.pantheon.tests.web3j.privacy/EthSignerAcceptanceTest/AcceptanceTests___privateSmartContractMustDeployNoNonce/
   @Test
-  @Ignore
   public void privateSmartContractMustDeployWithPrivacyGroup() throws IOException {
     final String privacyGroupId =
         minerNode.execute(privacyTransactions.createPrivacyGroup(null, null, minerNode));


### PR DESCRIPTION
# PR description

Increases the timeout for fetching a private transaction receipt

## Fixed Issue(s)

https://github.com/PegaSysEng/pantheon/pull/1930

[PAN-3137]

[PAN-3137]: https://pegasys1.atlassian.net/browse/PAN-3137